### PR TITLE
【Rails】目標~講座(単元)新規API作成

### DIFF
--- a/rails/app/controllers/api/v1/student/goals_controller.rb
+++ b/rails/app/controllers/api/v1/student/goals_controller.rb
@@ -5,7 +5,7 @@ module Api
     module Student
       class GoalsController < Api::V1::Student::BaseController
         def create
-          form = ::Student::CreateGoalForm.new(current_user: current_user ,**create_goal_params.to_h.symbolize_keys)
+          form = ::Student::CreateGoalForm.new(current_user: current_user, **create_goal_params.to_h.symbolize_keys)
 
           if form.save
             render json: form.goal.id, status: :created

--- a/rails/app/controllers/api/v1/student/goals_controller.rb
+++ b/rails/app/controllers/api/v1/student/goals_controller.rb
@@ -5,10 +5,10 @@ module Api
     module Student
       class GoalsController < Api::V1::Student::BaseController
         def create
-          form = Student::CreateGoalForm.new(create_goal_params)
+          form = ::Student::CreateGoalForm.new(create_goal_params)
 
           if form.save
-            render json: { message: '目標が作成できました' }, status: :created
+            render json: form.goal.id, status: :created
           else
             render json: { errors: form.errors }, status: :unprocessable_entity
           end

--- a/rails/app/controllers/api/v1/student/goals_controller.rb
+++ b/rails/app/controllers/api/v1/student/goals_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Student
+      class GoalsController < Api::V1::Student::BaseController
+        def create
+          form = Student::CreateGoalForm.new(create_goal_params)
+
+          if form.save
+            render json: { message: '目標が作成できました' }, status: :created
+          else
+            render json: { errors: form.errors }, status: :unprocessable_entity
+          end
+        end
+
+        private
+
+        def create_goal_params
+          params.require(:goal).permit(:title, :description, :due_date).merge(user: current_user)
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/student/goals_controller.rb
+++ b/rails/app/controllers/api/v1/student/goals_controller.rb
@@ -5,19 +5,19 @@ module Api
     module Student
       class GoalsController < Api::V1::Student::BaseController
         def create
-          form = ::Student::CreateGoalForm.new(create_goal_params)
+          form = ::Student::CreateGoalForm.new(create_goal_params.merge(current_user: current_user))
 
           if form.save
             render json: form.goal.id, status: :created
           else
-            render json: { errors: form.errors }, status: :unprocessable_entity
+            render json: { errors: form.errors }, status: :unprocessable_content
           end
         end
 
         private
 
         def create_goal_params
-          params.require(:goal).permit(:title, :description, :due_date).merge(user: current_user)
+          params.require(:goal).permit(:title, :description, :due_date)
         end
       end
     end

--- a/rails/app/controllers/api/v1/student/goals_controller.rb
+++ b/rails/app/controllers/api/v1/student/goals_controller.rb
@@ -5,7 +5,7 @@ module Api
     module Student
       class GoalsController < Api::V1::Student::BaseController
         def create
-          form = ::Student::CreateGoalForm.new(create_goal_params.merge(current_user: current_user))
+          form = ::Student::CreateGoalForm.new(current_user: current_user ,**create_goal_params.to_h.symbolize_keys)
 
           if form.save
             render json: form.goal.id, status: :created

--- a/rails/app/controllers/api/v1/student/tasks_controller.rb
+++ b/rails/app/controllers/api/v1/student/tasks_controller.rb
@@ -5,10 +5,9 @@ module Api
     module Student
       class TasksController < Api::V1::Student::BaseController
         def create
-          form = ::Student::CreateTaskForm.new(create_task_params.merge(current_user: current_user))
+          form = ::Student::CreateTaskForm.new(current_user: current_user, **create_task_params.to_h.symbolize_keys)
 
-          if form.valid?
-            ::Student::CreateTaskService.new(form).call
+          if form.save
             render json: { message: 'タスクが作成されました。' }, status: :created
           else
             render json: { errors: form.errors }, status: :unprocessable_content

--- a/rails/app/controllers/api/v1/student/tasks_controller.rb
+++ b/rails/app/controllers/api/v1/student/tasks_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Student
+      class TasksController < Api::V1::Student::BaseController
+        def create
+          form = ::Student::CreateTaskForm.new(create_task_params.merge(current_user: current_user))
+
+          if form.valid?
+            ::Student::CreateTaskService.new(form).call
+            render json: { message: 'タスクが作成されました。' }, status: :created
+          else
+            render json: { errors: form.errors }, status: :unprocessable_content
+          end
+        end
+
+        private
+
+        def create_task_params
+          params.require(:task).permit(:goal_id, :title, :content, :priority, :due_date, :memo, unit_ids: [])
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -12,6 +12,6 @@ class ApplicationController < ActionController::API
   private
 
   def user_not_authorized(_exception)
-    render json: { errors: 'この操作を行う権限がありません'}, status: :forbidden
+    render json: { errors: 'この操作を行う権限がありません' }, status: :forbidden
   end
 end

--- a/rails/app/forms/student/create_goal_form.rb
+++ b/rails/app/forms/student/create_goal_form.rb
@@ -6,6 +6,8 @@ module Student
     include ActiveModel::Attributes
     include ActiveModel::Validations
 
+    attr_reader :goal
+
     attribute :user
     attribute :title, :string
     attribute :description, :string
@@ -18,12 +20,13 @@ module Student
     def save
       return unless valid?
 
-      Goal.create!(
+      @goal = Goal.create!(
         user: user,
         title: title,
         description: description,
         due_date: parsed_due_date
       )
+      true
     end
 
     private

--- a/rails/app/forms/student/create_goal_form.rb
+++ b/rails/app/forms/student/create_goal_form.rb
@@ -8,7 +8,6 @@ module Student
 
     attr_reader :goal
 
-    attribute :current_user
     attribute :title, :string
     attribute :description, :string
     attribute :due_date, :string
@@ -17,11 +16,16 @@ module Student
     validates :due_date, presence: true
     validate :due_date_must_be_valid
 
+    def initialize(current_user:, **attributes)
+      super(attributes)
+      @current_user = current_user
+    end
+
     def save
       return unless valid?
 
       @goal = Goal.create!(
-        user: current_user,
+        user: @current_user,
         title: title,
         description: description,
         due_date: parsed_due_date

--- a/rails/app/forms/student/create_goal_form.rb
+++ b/rails/app/forms/student/create_goal_form.rb
@@ -8,7 +8,7 @@ module Student
 
     attr_reader :goal
 
-    attribute :user
+    attribute :current_user
     attribute :title, :string
     attribute :description, :string
     attribute :due_date, :string
@@ -21,7 +21,7 @@ module Student
       return unless valid?
 
       @goal = Goal.create!(
-        user: user,
+        user: current_user,
         title: title,
         description: description,
         due_date: parsed_due_date

--- a/rails/app/forms/student/create_goal_form.rb
+++ b/rails/app/forms/student/create_goal_form.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Student
+  class CreateGoalForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations
+
+    attribute :user
+    attribute :title, :string
+    attribute :description, :string
+    attribute :due_date, :string
+
+    validates :title, presence: true
+    validates :due_date, presence: true
+    validate :due_date_must_be_valid
+
+    def save
+      return unless valid?
+
+      Goal.create!(
+        user: user,
+        title: title,
+        description: description,
+        due_date: parsed_due_date
+      )
+    end
+
+    private
+
+    def due_date_must_be_valid
+      return if due_date.blank?
+
+      parsed_due_date
+    rescue ArgumentError, TypeError
+      errors.add(:due_date, 'は正しい日付を入力してください')
+    end
+
+    def parsed_due_date
+      @parsed_due_date ||= Date.parse(due_date)
+    end
+  end
+end

--- a/rails/app/forms/student/create_task_form.rb
+++ b/rails/app/forms/student/create_task_form.rb
@@ -32,6 +32,7 @@ module Student
 
     def save
       return false unless valid?
+
       ::Student::CreateTaskService.new(self).call
       true
     end

--- a/rails/app/forms/student/create_task_form.rb
+++ b/rails/app/forms/student/create_task_form.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Student
+  class CreateTaskForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations
+
+    attribute :current_user
+    attribute :goal_id, :integer
+    attribute :title, :string
+    attribute :content, :string
+    attribute :priority, :integer
+    attribute :due_date, :string
+    attribute :memo, :string
+    attribute :unit_ids, default: []
+
+    validates :goal_id, presence: true
+    validates :title, presence: true
+    validates :content, presence: true
+    validates :priority, presence: true
+    validates :due_date, presence: true
+    validate :goal_must_exist
+    validate :due_date_must_be_valid
+    validate :unit_ids_must_exist
+
+    def parsed_due_date
+      @parsed_due_date ||= Date.parse(due_date)
+    end
+
+    def goal
+      return @goal if defined?(@goal)
+
+      @goal = current_user.goals.find_by(id: goal_id)
+    end
+
+    # フォーム入力を正規化（空文字除去 + integer化）
+    def unit_ids
+      Array(super).compact_blank.map(&:to_i)
+    end
+
+    private
+
+    def due_date_must_be_valid
+      return if due_date.blank?
+
+      parsed_due_date
+    rescue ArgumentError, TypeError
+      errors.add(:due_date, 'は正しい日付を入力してください')
+    end
+
+    def unit_ids_must_exist
+      return if unit_ids.blank?
+
+      return unless Unit.where(id: unit_ids).count != unit_ids.size
+
+      errors.add(:unit_ids, 'に不正な値が含まれています')
+    end
+
+    def goal_must_exist
+      errors.add(:goal_id, 'が不正です') if goal.nil?
+    end
+  end
+end

--- a/rails/app/forms/student/create_task_form.rb
+++ b/rails/app/forms/student/create_task_form.rb
@@ -6,7 +6,8 @@ module Student
     include ActiveModel::Attributes
     include ActiveModel::Validations
 
-    attribute :current_user
+    attr_reader :current_user
+
     attribute :goal_id, :integer
     attribute :title, :string
     attribute :content, :string
@@ -23,6 +24,17 @@ module Student
     validate :goal_must_exist
     validate :due_date_must_be_valid
     validate :unit_ids_must_exist
+
+    def initialize(current_user:, **attributes)
+      super(attributes)
+      @current_user = current_user
+    end
+
+    def save
+      return false unless valid?
+      ::Student::CreateTaskService.new(self).call
+      true
+    end
 
     def parsed_due_date
       @parsed_due_date ||= Date.parse(due_date)

--- a/rails/app/models/goal.rb
+++ b/rails/app/models/goal.rb
@@ -9,7 +9,7 @@
 #  title       :string(255)      not null
 #  description :text(65535)
 #  due_date    :date
-#  status      :integer          default(0), not null
+#  status      :integer          default("not_started"), not null
 #  deleted_at  :datetime
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null

--- a/rails/app/models/task.rb
+++ b/rails/app/models/task.rb
@@ -26,4 +26,14 @@ class Task < ApplicationRecord
   has_many :courses, through: :task_courses
   has_many :task_units, dependent: :destroy
   has_many :units, through: :task_units
+
+  enum priority: {
+    very_low: 1,
+    low: 2,
+    normal: 3,
+    high: 4,
+    very_high: 5
+  }
+
+  enum status: { not_started: 0, in_progress: 1, completed: 2 }
 end

--- a/rails/app/models/task.rb
+++ b/rails/app/models/task.rb
@@ -9,10 +9,10 @@
 #  goal_id        :bigint
 #  title          :string(100)      not null
 #  content        :text(65535)      not null
-#  priority       :integer          default(3), not null
+#  priority       :integer          default("normal"), not null
 #  due_date       :date
 #  estimated_time :integer
-#  status         :integer          default(0), not null
+#  status         :integer          default("not_started"), not null
 #  memo           :text(65535)
 #  completed_at   :datetime
 #  deleted_at     :datetime

--- a/rails/app/serializers/goal_serializer.rb
+++ b/rails/app/serializers/goal_serializer.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: goals
+#
+#  id          :bigint           not null, primary key
+#  user_id     :bigint           not null
+#  title       :string(255)      not null
+#  description :text(65535)
+#  due_date    :date
+#  status      :integer          default("not_started"), not null
+#  deleted_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class GoalSerializer < ActiveModel::Serializer
   attributes :id, :title, :description, :formatted_status, :formatted_due_date
 

--- a/rails/app/services/student/create_task_service.rb
+++ b/rails/app/services/student/create_task_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Student
+  class CreateTaskService
+    def initialize(form)
+      @form = form
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        task = Task.create!(
+          user: @form.current_user,
+          goal: @form.goal,
+          title: @form.title,
+          content: @form.content,
+          priority: @form.priority,
+          due_date: @form.parsed_due_date,
+          estimated_time: 0,
+          memo: @form.memo
+        )
+
+        units = Unit.where(id: @form.unit_ids)
+        task.units << units
+      end
+    end
+  end
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
 
       namespace :student do
         resource :dashboard, only: :show
+        resources :goals
       end
       namespace :teacher do
       end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
       namespace :student do
         resource :dashboard, only: :show
         resources :goals
+        resources :tasks
       end
       namespace :teacher do
       end

--- a/rails/spec/factories/courses.rb
+++ b/rails/spec/factories/courses.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: courses
+#
+#  id           :bigint           not null, primary key
+#  subject_id   :bigint
+#  level_number :integer          default(1), not null
+#  level_name   :string(255)      not null
+#  description  :text(65535)
+#  deleted_at   :datetime
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+FactoryBot.define do
+  factory :course do
+    association :subject
+    level_number { 1 }
+    level_name { '基礎' }
+    description { '基礎レベルのコース' }
+  end
+end

--- a/rails/spec/factories/goals.rb
+++ b/rails/spec/factories/goals.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: goals
+#
+#  id          :bigint           not null, primary key
+#  user_id     :bigint           not null
+#  title       :string(255)      not null
+#  description :text(65535)
+#  due_date    :date
+#  status      :integer          default("not_started"), not null
+#  deleted_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 FactoryBot.define do
   factory :goal do
     association :user

--- a/rails/spec/factories/subjects.rb
+++ b/rails/spec/factories/subjects.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: subjects
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+FactoryBot.define do
+  factory :subject do
+    name { '英語' }
+  end
+end

--- a/rails/spec/factories/units.rb
+++ b/rails/spec/factories/units.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: units
+#
+#  id         :bigint           not null, primary key
+#  course_id  :bigint           not null
+#  unit_name  :string(255)      not null
+#  deleted_at :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+FactoryBot.define do
+  factory :unit do
+    association :course
+    sequence(:unit_name) { |n| "単元#{n}" }
+  end
+end

--- a/rails/spec/forms/student/create_goal_form_spec.rb
+++ b/rails/spec/forms/student/create_goal_form_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Student::CreateGoalForm, type: :model do
-  subject { described_class.new(params) }
+  subject { described_class.new(**params) }
 
   let(:user) { create(:user) }
 
@@ -41,7 +41,7 @@ RSpec.describe Student::CreateGoalForm, type: :model do
     context 'titleがない時' do
       it '保存されない' do
         params[:title] = nil
-        form = described_class.new(params)
+        form = described_class.new(**params)
 
         expect(form.save).to be_nil
         expect(form.errors[:title]).to be_present
@@ -51,7 +51,7 @@ RSpec.describe Student::CreateGoalForm, type: :model do
     context 'due_dateが不正な値の時' do
       it 'エラーになる' do
         params[:due_date] = 'invalid-date'
-        form = described_class.new(params)
+        form = described_class.new(**params)
 
         expect(form.save).to be_nil
         expect(form.errors[:due_date]).to include('は正しい日付を入力してください')
@@ -61,7 +61,7 @@ RSpec.describe Student::CreateGoalForm, type: :model do
     context 'バリデーションエラーがあるとき' do
       it 'Goalは作成されない' do
         params[:title] = nil
-        form = described_class.new(params)
+        form = described_class.new(**params)
 
         expect { form.save }.not_to change(Goal, :count)
       end

--- a/rails/spec/forms/student/create_goal_form_spec.rb
+++ b/rails/spec/forms/student/create_goal_form_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Student::CreateGoalForm, type: :model do
         subject.save
         expect(subject.goal.due_date).to eq(Date.new(2026, 4, 11))
       end
+
+      it "trueを返す" do
+        expect(subject.save).to be true
+      end
     end
 
     context 'titleがない時' do

--- a/rails/spec/forms/student/create_goal_form_spec.rb
+++ b/rails/spec/forms/student/create_goal_form_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe Student::CreateGoalForm, type: :model do
       end
     end
 
+    context "descriptionが空でも保存できる" do
+      let(:params) { super().merge(description: nil) }
+      it "保存できる" do
+        expect(subject.save).to be true
+        expect(subject.goal).to be_persisted
+        expect(subject.goal.description).to be_nil
+      end
+    end
+
     context 'titleがない時' do
       let(:params) { super().merge(title: nil) }
       it '保存されない' do

--- a/rails/spec/forms/student/create_goal_form_spec.rb
+++ b/rails/spec/forms/student/create_goal_form_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe Student::CreateGoalForm, type: :model do
     end
 
     context 'titleがない時' do
+      let(:params) { super().merge(title: nil) }
       it '保存されない' do
-        params[:title] = nil
         form = described_class.new(**params)
 
         expect(form.save).to be_nil

--- a/rails/spec/forms/student/create_goal_form_spec.rb
+++ b/rails/spec/forms/student/create_goal_form_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Student::CreateGoalForm, type: :model do
+  subject { described_class.new(params) }
+
+  let(:user) { create(:user) }
+
+  let(:params) do
+    {
+      current_user: user,
+      title: '英語を頑張る',
+      description: '毎日30分',
+      due_date: '2026-04-11'
+    }
+  end
+
+  describe '#save' do
+    context '入力が正しい時' do
+      it 'Goalが作成される' do
+        expect { subject.save }.to change(Goal, :count).by(1)
+      end
+
+      it 'current_userに紐づいたGoalが作成される' do
+        subject.save
+        expect(subject.goal.user).to eq(user)
+      end
+
+      it 'goalをattr_readerで取得できる' do
+        subject.save
+        expect(subject.goal).to be_a(Goal)
+      end
+
+      it 'due_dateがDate型で保存される' do
+        subject.save
+        expect(subject.goal.due_date).to eq(Date.new(2026, 4, 11))
+      end
+    end
+
+    context 'titleがない時' do
+      it '保存されない' do
+        params[:title] = nil
+        form = described_class.new(params)
+
+        expect(form.save).to be_nil
+        expect(form.errors[:title]).to be_present
+      end
+    end
+
+    context 'due_dateが不正な値の時' do
+      it 'エラーになる' do
+        params[:due_date] = 'invalid-date'
+        form = described_class.new(params)
+
+        expect(form.save).to be_nil
+        expect(form.errors[:due_date]).to include('は正しい日付を入力してください')
+      end
+    end
+
+    context 'バリデーションエラーがあるとき' do
+      it 'Goalは作成されない' do
+        params[:title] = nil
+        form = described_class.new(params)
+
+        expect { form.save }.not_to change(Goal, :count)
+      end
+    end
+  end
+end

--- a/rails/spec/forms/student/create_task_form_spec.rb
+++ b/rails/spec/forms/student/create_task_form_spec.rb
@@ -20,6 +20,27 @@ RSpec.describe Student::CreateTaskForm, type: :model do
     }
   end
 
+  describe "#save" do
+    context "入力が正しい時" do
+      it "Taskが作成される" do
+        expect { subject.save }.to change(Task, :count).by(1)
+      end
+
+      it "作成されたtaskのデータが与えられたパラメーターの値になっていること" do
+        subject.save
+        task = Task.last
+
+        expect(task.user).to eq(user)
+        expect(task.goal).to eq(goal)
+        expect(task.title).to eq('タスク')
+        expect(task.content).to eq('内容')
+        expect(task.priority).to eq('very_low')
+        expect(task.memo).to eq('メモ')
+        expect(task.due_date).to eq(Date.new(2026, 2, 10))
+      end
+    end
+  end
+
   it '有効であること' do
     expect(subject).to be_valid
   end

--- a/rails/spec/forms/student/create_task_form_spec.rb
+++ b/rails/spec/forms/student/create_task_form_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Student::CreateTaskForm, type: :model do
-  subject { described_class.new(params) }
+  subject { described_class.new(**params) }
 
   let(:user) { create(:user) }
   let(:goal) { create(:goal, user:) }

--- a/rails/spec/forms/student/create_task_form_spec.rb
+++ b/rails/spec/forms/student/create_task_form_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Student::CreateTaskForm, type: :model do
+  subject { described_class.new(params) }
+
+  let(:user) { create(:user) }
+  let(:goal) { create(:goal, user:) }
+
+  let(:params) do
+    {
+      current_user: user,
+      goal_id: goal.id,
+      title: 'タスク',
+      content: '内容',
+      priority: 1,
+      due_date: '2026-02-10',
+      memo: 'メモ'
+    }
+  end
+
+  it '有効であること' do
+    expect(subject).to be_valid
+  end
+
+  context '他人のgoalを指定した場合' do
+    let(:other_goal) { create(:goal) }
+
+    before do
+      subject.goal_id = other_goal.id
+    end
+
+    it '無効になる' do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:goal_id]).to include('が不正です')
+    end
+  end
+
+  context 'due_dateが不正な場合' do
+    before do
+      subject.due_date = '2026-02-99'
+    end
+
+    it '無効になる' do
+      expect(subject).not_to be_valid
+      expect(subject.errors[:due_date]).to include('は正しい日付を入力してください')
+    end
+  end
+
+  context 'unit_ids' do
+    let!(:unit1) { create(:unit) }
+    let!(:unit2) { create(:unit) }
+
+    it '空文字やnilを除外してinteger化する' do
+      subject.unit_ids = ['', unit1.id.to_s, nil, unit2.id]
+      subject.valid?
+      expect(subject.unit_ids).to contain_exactly(unit1.id, unit2.id)
+    end
+  end
+end

--- a/rails/spec/forms/student/create_task_form_spec.rb
+++ b/rails/spec/forms/student/create_task_form_spec.rb
@@ -58,6 +58,51 @@ RSpec.describe Student::CreateTaskForm, type: :model do
         expect(task.units).to match_array([unit1, unit2])
       end
     end
+
+    context "値が不正な時" do
+      it "unit_ids に存在しないIDが混ざるとinvalid" do
+        unit1 = create(:unit)
+        invalid_id = 999999
+
+        form = described_class.new(
+          current_user: user,
+          goal_id: goal.id,
+          title: "タスク",
+          content: "内容",
+          priority: 1,
+          due_date: "2026-02-10",
+          unit_ids: [unit1.id, invalid_id]
+        )
+
+        expect(form).not_to be_valid
+        expect(form.errors[:unit_ids]).to include('に不正な値が含まれています')
+      end
+
+      it "必須項目が欠けているとinvalidになる" do
+        form = described_class.new(current_user: user)
+
+        expect(form).not_to be_valid
+        expect(form.errors[:goal_id]).to be_present
+        expect(form.errors[:title]).to be_present
+        expect(form.errors[:content]).to be_present
+        expect(form.errors[:priority]).to be_present
+        expect(form.errors[:due_date]).to be_present
+      end
+
+      it "goal_idがnilだとinvalid" do
+        subject.goal_id = nil
+
+        expect(subject).not_to be_valid
+        expect(subject.errors[:goal_id]).to include("can't be blank")
+      end
+
+      it "存在しないgoal_idだとinvalid" do
+        subject.goal_id = 999999
+
+        expect(subject).not_to be_valid
+        expect(subject.errors[:goal_id]).to include('が不正です')
+      end
+    end
   end
 
   it '有効であること' do

--- a/rails/spec/forms/student/create_task_form_spec.rb
+++ b/rails/spec/forms/student/create_task_form_spec.rb
@@ -38,6 +38,25 @@ RSpec.describe Student::CreateTaskForm, type: :model do
         expect(task.memo).to eq('メモ')
         expect(task.due_date).to eq(Date.new(2026, 2, 10))
       end
+
+      it "unit_idsを渡した場合、task.units が付く" do
+        unit1 = create(:unit)
+        unit2 = create(:unit)
+
+        form = described_class.new(
+          current_user: user,
+          goal_id: goal.id,
+          title: "タスク",
+          content: "内容",
+          priority: 1,
+          due_date: "2026-02-10",
+          unit_ids: [unit1.id, unit2.id]
+        )
+
+        expect { form.save }.to change(Task, :count).by(1)
+        task = Task.last
+        expect(task.units).to match_array([unit1, unit2])
+      end
     end
   end
 

--- a/rails/spec/services/student/create_task_service.rb
+++ b/rails/spec/services/student/create_task_service.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Student::CreateTaskService do
+  subject { described_class.new(form) }
+
+  let(:user) { create(:user) }
+  let(:goal) { create(:goal, user: user) }
+  let!(:unit1) { create(:unit) }
+  let!(:unit2) { create(:unit) }
+
+  let(:form) do
+    instance_double(
+      Student::CreateTaskForm,
+      current_user: user,
+      goal: goal,
+      title: '英文法基礎',
+      content: '学習内容',
+      priority: 3,
+      parsed_due_date: Date.new(2026, 4, 11),
+      memo: 'メモ',
+      unit_ids: [unit1.id, unit2.id]
+    )
+  end
+
+  describe '#call' do
+    it 'TaskとTaskUnitが作成される' do
+      expect do
+        subject.call
+      end.to change(Task, :count).by(1)
+                                 .and change(TaskUnit, :count).by(2)
+
+      task = Task.last
+      expect(task.units).to contain_exactly(unit1, unit2)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
https://www.notion.so/Rails-API-3002946467fd80ce8f00f719bc5f8304
<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細

今フロントの画面で考えているのは
①目標を作成　→「次へ or 登録　を押下」→　②タスク作成(ここで講座(単元)を登録 or 登録なしでもタスクは作成可)
なので①の段階ではgoalのidを返却して、次のタスク作成ページに渡す形にしている。Goalの作成はGoal作成単体なのでFormオブジェクト内で作成する形、Taskは講座の紐付けも行うのでFormクラスではバリデーションと整形だけ行って、サービスクラスもしようする形にした。

<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

## 動作確認

### 目標の作成
<img width="1430" height="731" alt="スクリーンショット 2026-02-10 0 05 11" src="https://github.com/user-attachments/assets/c91f81ab-9ce8-4e17-9e50-e94ec73bb9b3" />

###  タスクの作成(ここで紐付ける講座(単元を選択))※紐付けないこともできる
<img width="1428" height="761" alt="スクリーンショット 2026-02-10 0 11 25" src="https://github.com/user-attachments/assets/9aad692e-ec26-4fa8-9b7a-972b441c839e" />



<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
