### PR TITLE
管理者ダッシュボードAPI実装 (GET /api/v1/admin/dashboard)

### DIFF
--- a/rails/app/controllers/api/v1/admin/dashboards_controller.rb
+++ b/rails/app/controllers/api/v1/admin/dashboards_controller.rb
@@ -5,17 +5,20 @@ module Api
     module Admin
       class DashboardsController < BaseController
         def show
-          role_counts = User.joins(:user_role).group("user_roles.name").count
+          role_counts = User.joins(:user_role).group('user_roles.name').count
           recent_imports = ImportHistory.order(created_at: :desc).limit(5)
 
           render json: {
             stats: {
-              student_count: role_counts["student"] || 0,
-              teacher_count: role_counts["teacher"] || 0,
-              admin_count: role_counts["admin"] || 0,
+              student_count: role_counts['student'] || 0,
+              teacher_count: role_counts['teacher'] || 0,
+              admin_count: role_counts['admin'] || 0,
               total_questions: Question.count
             },
-            recent_imports: ActiveModelSerializers::SerializableResource.new(recent_imports, each_serializer: ImportHistorySerializer)
+            recent_imports: ActiveModelSerializers::SerializableResource.new(
+              recent_imports,
+              each_serializer: ImportHistorySerializer
+            )
           }
         end
       end

--- a/rails/app/controllers/api/v1/admin/dashboards_controller.rb
+++ b/rails/app/controllers/api/v1/admin/dashboards_controller.rb
@@ -5,11 +5,13 @@ module Api
     module Admin
       class DashboardsController < BaseController
         def show
+          role_counts = User.joins(:user_role).group("user_roles.name").count
+
           render json: {
             stats: {
-              student_count: count_by_role(:student),
-              teacher_count: count_by_role(:teacher),
-              admin_count: count_by_role(:admin),
+              student_count: role_counts["student"] || 0,
+              teacher_count: role_counts["teacher"] || 0,
+              admin_count: role_counts["admin"] || 0,
               total_questions: Question.count
             },
             recent_imports: recent_imports
@@ -17,12 +19,6 @@ module Api
         end
 
         private
-
-        def count_by_role(role)
-          User.joins(:user_role)
-              .where(user_roles: { name: UserRole.names[role] })
-              .count
-        end
 
         def recent_imports
           ImportHistory.order(created_at: :desc).limit(5).map do |h|

--- a/rails/app/controllers/api/v1/admin/dashboards_controller.rb
+++ b/rails/app/controllers/api/v1/admin/dashboards_controller.rb
@@ -6,6 +6,7 @@ module Api
       class DashboardsController < BaseController
         def show
           role_counts = User.joins(:user_role).group("user_roles.name").count
+          recent_imports = ImportHistory.order(created_at: :desc).limit(5)
 
           render json: {
             stats: {
@@ -14,24 +15,8 @@ module Api
               admin_count: role_counts["admin"] || 0,
               total_questions: Question.count
             },
-            recent_imports: recent_imports
+            recent_imports: ActiveModelSerializers::SerializableResource.new(recent_imports, each_serializer: ImportHistorySerializer)
           }
-        end
-
-        private
-
-        def recent_imports
-          ImportHistory.order(created_at: :desc).limit(5).map do |h|
-            {
-              id: h.id,
-              file_name: h.file_name,
-              status: h.status,
-              success_count: h.success_count,
-              error_count: h.error_count,
-              total_count: h.total_count,
-              created_at: h.created_at
-            }
-          end
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/dashboards_controller.rb
+++ b/rails/app/controllers/api/v1/admin/dashboards_controller.rb
@@ -9,7 +9,7 @@ module Api
             stats: {
               student_count: count_by_role(:student),
               teacher_count: count_by_role(:teacher),
-              admin_count:   count_by_role(:admin),
+              admin_count: count_by_role(:admin),
               total_questions: Question.count
             },
             recent_imports: recent_imports
@@ -27,13 +27,13 @@ module Api
         def recent_imports
           ImportHistory.order(created_at: :desc).limit(5).map do |h|
             {
-              id:            h.id,
-              file_name:     h.file_name,
-              status:        h.status,
+              id: h.id,
+              file_name: h.file_name,
+              status: h.status,
               success_count: h.success_count,
-              error_count:   h.error_count,
-              total_count:   h.total_count,
-              created_at:    h.created_at
+              error_count: h.error_count,
+              total_count: h.total_count,
+              created_at: h.created_at
             }
           end
         end

--- a/rails/app/controllers/api/v1/admin/dashboards_controller.rb
+++ b/rails/app/controllers/api/v1/admin/dashboards_controller.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class DashboardsController < BaseController
+        def show
+          render json: {
+            stats: {
+              student_count: count_by_role(:student),
+              teacher_count: count_by_role(:teacher),
+              admin_count:   count_by_role(:admin),
+              total_questions: Question.count
+            },
+            recent_imports: recent_imports
+          }
+        end
+
+        private
+
+        def count_by_role(role)
+          User.joins(:user_role)
+              .where(user_roles: { name: UserRole.names[role] })
+              .count
+        end
+
+        def recent_imports
+          ImportHistory.order(created_at: :desc).limit(5).map do |h|
+            {
+              id:            h.id,
+              file_name:     h.file_name,
+              status:        h.status,
+              success_count: h.success_count,
+              error_count:   h.error_count,
+              total_count:   h.total_count,
+              created_at:    h.created_at
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/sessions_controller.rb
+++ b/rails/app/controllers/api/v1/sessions_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class SessionsController < Devise::SessionsController
       respond_to :json
+      skip_before_action :authenticate_user!, only: %i[create]
 
       def create
         request.env['devise.mapping'] = Devise.mappings[:user]

--- a/rails/app/serializers/import_history_serializer.rb
+++ b/rails/app/serializers/import_history_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class ImportHistorySerializer < ActiveModel::Serializer
+  attributes :id, :file_name, :status, :success_count, :error_count, :total_count, :created_at
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
       namespace :teacher do
       end
       namespace :admin do
+        resource :dashboard, only: :show
         resources :courses do
           resources :units do
             resource :import_questions, only: :create

--- a/rails/spec/factories/questions.rb
+++ b/rails/spec/factories/questions.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: questions
+#
+#  id            :bigint           not null, primary key
+#  unit_id       :bigint           not null
+#  question_text :text(65535)      not null
+#  correct_answer :text(65535)     not null
+#  deleted_at    :datetime
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#
+FactoryBot.define do
+  factory :question do
+    association :unit
+    sequence(:question_text) { |n| "問題文#{n}" }
+    correct_answer { '1' }
+  end
+end

--- a/rails/spec/rails_helper.rb
+++ b/rails/spec/rails_helper.rb
@@ -76,6 +76,10 @@ RSpec.configure do |config|
 
   Rails.application.routes.default_url_options[:host] = 'localhost'
 
+  config.before(:each, type: :request) do
+    host! 'localhost'
+  end
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
     DatabaseCleaner.strategy = :transaction

--- a/rails/spec/requests/api/v1/admin/dashboards_spec.rb
+++ b/rails/spec/requests/api/v1/admin/dashboards_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Api::V1::Admin::Dashboards', type: :request do
 
       it 'recent_imports は最大5件返される' do
         subject
-        expect(response.parsed_body['recent_imports'].length).to eq(5)
+        expect(response.parsed_body['recent_imports'].size).to eq(5)
       end
 
       it 'recent_imports に必要なフィールドが含まれる' do

--- a/rails/spec/requests/api/v1/admin/dashboards_spec.rb
+++ b/rails/spec/requests/api/v1/admin/dashboards_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Dashboards', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/admin/dashboard' do
+    context '正常系' do
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:students)   { create_list(:user, 3) }
+      let!(:teachers)   { create_list(:user, 2, :teacher) }
+      let!(:unit)       { create(:unit) }
+      let!(:questions)  { create_list(:question, 4, unit: unit) }
+      let!(:imports)    { create_list(:import_history, 6, user: admin_user, unit: unit) }
+
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      subject { get '/api/v1/admin/dashboard', headers: headers.merge('Cookie' => cookie) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'stats.student_count が正しい' do
+        subject
+        expect(response.parsed_body.dig('stats', 'student_count')).to eq(3)
+      end
+
+      it 'stats.teacher_count が正しい' do
+        subject
+        expect(response.parsed_body.dig('stats', 'teacher_count')).to eq(2)
+      end
+
+      it 'stats.admin_count が正しい' do
+        subject
+        expect(response.parsed_body.dig('stats', 'admin_count')).to eq(1)
+      end
+
+      it 'stats.total_questions が正しい' do
+        subject
+        expect(response.parsed_body.dig('stats', 'total_questions')).to eq(4)
+      end
+
+      it 'recent_imports は最大5件返される' do
+        subject
+        expect(response.parsed_body['recent_imports'].length).to eq(5)
+      end
+
+      it 'recent_imports に必要なフィールドが含まれる' do
+        subject
+        import = response.parsed_body['recent_imports'].first
+        expect(import.keys).to include('id', 'file_name', 'status', 'success_count', 'error_count', 'total_count', 'created_at')
+      end
+    end
+
+    context '異常系 - 未認証アクセス' do
+      it '401が返される' do
+        get '/api/v1/admin/dashboard', headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(student_user)
+        get '/api/v1/admin/dashboard', headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/admin/dashboards_spec.rb
+++ b/rails/spec/requests/api/v1/admin/dashboards_spec.rb
@@ -19,6 +19,8 @@ RSpec.describe 'Api::V1::Admin::Dashboards', type: :request do
 
   describe 'GET /api/v1/admin/dashboard' do
     context '正常系' do
+      subject { get '/api/v1/admin/dashboard', headers: headers.merge('Cookie' => cookie) }
+
       let!(:admin_user) { create(:user, :admin, high_school: nil) }
       let!(:students)   { create_list(:user, 3) }
       let!(:teachers)   { create_list(:user, 2, :teacher) }
@@ -27,8 +29,6 @@ RSpec.describe 'Api::V1::Admin::Dashboards', type: :request do
       let!(:imports)    { create_list(:import_history, 6, user: admin_user, unit: unit) }
 
       let(:cookie) { login_and_get_cookie(admin_user) }
-
-      subject { get '/api/v1/admin/dashboard', headers: headers.merge('Cookie' => cookie) }
 
       it 'ステータス200が返される' do
         subject
@@ -63,7 +63,8 @@ RSpec.describe 'Api::V1::Admin::Dashboards', type: :request do
       it 'recent_imports に必要なフィールドが含まれる' do
         subject
         import = response.parsed_body['recent_imports'].first
-        expect(import.keys).to include('id', 'file_name', 'status', 'success_count', 'error_count', 'total_count', 'created_at')
+        expect(import.keys).to include('id', 'file_name', 'status', 'success_count', 'error_count', 'total_count',
+                                       'created_at')
       end
     end
 


### PR DESCRIPTION
## 概要

https://www.notion.so/Rails-API-GET-api-v1-admin-dashboard-32c2946467fd802dbc96c87ce4d2adf8

管理者用ダッシュボード画面で使用する `GET /api/v1/admin/dashboard` APIを実装しました。

## 詳細

**レスポンス内容:**
- `stats`: 生徒数・教師数・管理者数・総問題数の集計
- `recent_imports`: 最近のCSVインポート履歴（最大5件）

**新規ファイル:**
- `rails/app/controllers/api/v1/admin/dashboards_controller.rb` — ダッシュボードコントローラ
- `rails/spec/requests/api/v1/admin/dashboards_spec.rb` — リクエストスペック（9件）
- `rails/spec/factories/questions.rb` — Questionファクトリ（未作成だったため追加）

**変更ファイル:**
- `rails/config/routes.rb` — `resource :dashboard, only: :show` を追加
- `rails/app/controllers/api/v1/sessions_controller.rb` — `skip_before_action :authenticate_user!` が抜けていたため追加（バグ修正）
- `rails/spec/rails_helper.rb` — `host! 'localhost'` を追加（ActionDispatch::HostAuthorization 対応）

**認可:**
- 未認証 → 401
- 管理者以外 → 403（BaseController の Pundit 認可）
- 管理者 → 200

## 動作確認

全9件のリクエストスペックが通過していることを確認済み。


## その他

特になし

## 参考情報

特になし
