### PR TITLE
管理者用高校一覧・詳細 API を追加

### DIFF
--- a/rails/app/controllers/api/v1/admin/high_schools_controller.rb
+++ b/rails/app/controllers/api/v1/admin/high_schools_controller.rb
@@ -11,12 +11,8 @@ module Api
                               .page(params[:page]).per(20)
 
           school_ids = schools.pluck(:id)
-          student_counts = User.joins(:user_role)
-                               .where(high_school_id: school_ids, user_roles: { name: 'student' })
-                               .group(:high_school_id).count
-          teacher_counts = User.joins(:user_role)
-                               .where(high_school_id: school_ids, user_roles: { name: 'teacher' })
-                               .group(:high_school_id).count
+          student_counts = User.students.by_high_school(school_ids).group(:high_school_id).count
+          teacher_counts = User.teachers.by_high_school(school_ids).group(:high_school_id).count
 
           render json: {
             schools: ActiveModelSerializers::SerializableResource.new(
@@ -36,10 +32,8 @@ module Api
 
         def show
           school = HighSchool.includes(:prefecture).find(params[:id])
-          student_count = User.joins(:user_role)
-                              .where(high_school_id: school.id, user_roles: { name: 'student' }).count
-          teacher_count = User.joins(:user_role)
-                              .where(high_school_id: school.id, user_roles: { name: 'teacher' }).count
+          student_count = User.students.by_high_school(school.id).count
+          teacher_count = User.teachers.by_high_school(school.id).count
 
           render json: school,
                  serializer: ::Admin::HighSchoolSerializer,

--- a/rails/app/controllers/api/v1/admin/high_schools_controller.rb
+++ b/rails/app/controllers/api/v1/admin/high_schools_controller.rb
@@ -27,9 +27,9 @@ module Api
             ),
             meta: {
               current_page: schools.current_page,
-              total_pages:  schools.total_pages,
-              total_count:  schools.total_count,
-              per_page:     20
+              total_pages: schools.total_pages,
+              total_count: schools.total_count,
+              per_page: 20
             }
           }
         end

--- a/rails/app/controllers/api/v1/admin/high_schools_controller.rb
+++ b/rails/app/controllers/api/v1/admin/high_schools_controller.rb
@@ -6,9 +6,9 @@ module Api
       class HighSchoolsController < BaseController
         def index
           schools = HighSchool.includes(:prefecture)
-                              .order(:name)
+                              .order(:id)
+                              .by_prefecture(params[:prefecture_id])
                               .page(params[:page]).per(20)
-          schools = schools.where(prefecture_id: params[:prefecture_id]) if params[:prefecture_id].present?
 
           school_ids = schools.map(&:id)
           student_counts = User.joins(:user_role)

--- a/rails/app/controllers/api/v1/admin/high_schools_controller.rb
+++ b/rails/app/controllers/api/v1/admin/high_schools_controller.rb
@@ -10,7 +10,7 @@ module Api
                               .by_prefecture(params[:prefecture_id])
                               .page(params[:page]).per(20)
 
-          school_ids = schools.map(&:id)
+          school_ids = schools.pluck(:id)
           student_counts = User.joins(:user_role)
                                .where(high_school_id: school_ids, user_roles: { name: 'student' })
                                .group(:high_school_id).count

--- a/rails/app/controllers/api/v1/admin/high_schools_controller.rb
+++ b/rails/app/controllers/api/v1/admin/high_schools_controller.rb
@@ -21,7 +21,7 @@ module Api
           render json: {
             schools: ActiveModelSerializers::SerializableResource.new(
               schools,
-              each_serializer: Admin::HighSchoolSerializer,
+              each_serializer: ::Admin::HighSchoolSerializer,
               student_counts: student_counts,
               teacher_counts: teacher_counts
             ),
@@ -42,7 +42,7 @@ module Api
                               .where(high_school_id: school.id, user_roles: { name: 'teacher' }).count
 
           render json: school,
-                 serializer: Admin::HighSchoolSerializer,
+                 serializer: ::Admin::HighSchoolSerializer,
                  student_counts: { school.id => student_count },
                  teacher_counts: { school.id => teacher_count }
         end

--- a/rails/app/controllers/api/v1/admin/high_schools_controller.rb
+++ b/rails/app/controllers/api/v1/admin/high_schools_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class HighSchoolsController < BaseController
+        def index
+          schools = HighSchool.includes(:prefecture)
+                              .order(:name)
+                              .page(params[:page]).per(20)
+          schools = schools.where(prefecture_id: params[:prefecture_id]) if params[:prefecture_id].present?
+
+          school_ids = schools.map(&:id)
+          student_counts = User.joins(:user_role)
+                               .where(high_school_id: school_ids, user_roles: { name: 'student' })
+                               .group(:high_school_id).count
+          teacher_counts = User.joins(:user_role)
+                               .where(high_school_id: school_ids, user_roles: { name: 'teacher' })
+                               .group(:high_school_id).count
+
+          render json: {
+            schools: ActiveModelSerializers::SerializableResource.new(
+              schools,
+              each_serializer: Admin::HighSchoolSerializer,
+              student_counts: student_counts,
+              teacher_counts: teacher_counts
+            ),
+            meta: {
+              current_page: schools.current_page,
+              total_pages:  schools.total_pages,
+              total_count:  schools.total_count,
+              per_page:     20
+            }
+          }
+        end
+
+        def show
+          school = HighSchool.includes(:prefecture).find(params[:id])
+          student_count = User.joins(:user_role)
+                              .where(high_school_id: school.id, user_roles: { name: 'student' }).count
+          teacher_count = User.joins(:user_role)
+                              .where(high_school_id: school.id, user_roles: { name: 'teacher' }).count
+
+          render json: school,
+                 serializer: Admin::HighSchoolSerializer,
+                 student_counts: { school.id => student_count },
+                 teacher_counts: { school.id => teacher_count }
+        end
+      end
+    end
+  end
+end

--- a/rails/app/models/high_school.rb
+++ b/rails/app/models/high_school.rb
@@ -15,5 +15,7 @@ class HighSchool < ApplicationRecord
   has_many :users
   has_many :grades
 
+  scope :by_prefecture, ->(prefecture_id) { prefecture_id.present? ? where(prefecture_id: prefecture_id) : all }
+
   validates :name, presence: true
 end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -48,6 +48,10 @@ class User < ApplicationRecord
   has_many :grades, through: :teacher_grades, source: :grade
   has_many :import_histories, dependent: :destroy
 
+  scope :students, -> { joins(:user_role).where(user_roles: { name: 'student' }) }
+  scope :teachers, -> { joins(:user_role).where(user_roles: { name: 'teacher' }) }
+  scope :by_high_school, ->(high_school_ids) { where(high_school_id: high_school_ids) }
+
   validates :name, presence: true, on: :update
   validates :name_kana, presence: true, on: :update
   validates :user_role, presence: true

--- a/rails/app/serializers/admin/high_school_serializer.rb
+++ b/rails/app/serializers/admin/high_school_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Admin
+  class HighSchoolSerializer < ActiveModel::Serializer
+    attributes :id, :name, :prefecture_name, :student_count, :teacher_count, :created_at, :updated_at
+
+    def prefecture_name
+      object.prefecture.name
+    end
+
+    def student_count
+      instance_options[:student_counts][object.id] || 0
+    end
+
+    def teacher_count
+      instance_options[:teacher_counts][object.id] || 0
+    end
+  end
+end

--- a/rails/app/serializers/admin/high_school_serializer.rb
+++ b/rails/app/serializers/admin/high_school_serializer.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class HighSchoolSerializer < ActiveModel::Serializer
-    attributes :id, :name, :prefecture_name, :student_count, :teacher_count, :created_at, :updated_at
+    attributes :id, :name, :prefecture_name, :student_count, :teacher_count
 
     def prefecture_name
       object.prefecture.name

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
       end
       namespace :admin do
         resource :dashboard, only: :show
+        resources :high_schools, only: [:index, :show]
         resources :courses do
           resources :units do
             resource :import_questions, only: :create

--- a/rails/spec/requests/api/v1/admin/high_schools_spec.rb
+++ b/rails/spec/requests/api/v1/admin/high_schools_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::HighSchools', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/admin/high_schools' do
+    context '正常系' do
+      subject { get '/api/v1/admin/high_schools', headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:school)     { create(:high_school) }
+      let!(:students)   { create_list(:user, 2, high_school: school) }
+      let!(:teachers)   { create_list(:user, 1, :teacher, high_school: school) }
+
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'schools キーが含まれる' do
+        subject
+        expect(response.parsed_body).to have_key('schools')
+      end
+
+      it 'meta キーが含まれる' do
+        subject
+        expect(response.parsed_body).to have_key('meta')
+      end
+
+      it 'meta に必要なフィールドが含まれる' do
+        subject
+        meta = response.parsed_body['meta']
+        expect(meta.keys).to include('current_page', 'total_pages', 'total_count', 'per_page')
+      end
+
+      it 'schools の各要素に必要なフィールドが含まれる' do
+        subject
+        school_data = response.parsed_body['schools'].first
+        expect(school_data.keys).to include('id', 'name', 'prefecture_name', 'student_count', 'teacher_count',
+                                            'created_at', 'updated_at')
+      end
+
+      it 'student_count が正しい' do
+        subject
+        school_data = response.parsed_body['schools'].find { |s| s['id'] == school.id }
+        expect(school_data['student_count']).to eq(2)
+      end
+
+      it 'teacher_count が正しい' do
+        subject
+        school_data = response.parsed_body['schools'].find { |s| s['id'] == school.id }
+        expect(school_data['teacher_count']).to eq(1)
+      end
+
+      context 'prefecture_id パラメータ指定時' do
+        let!(:other_school) { create(:high_school) }
+
+        it '指定した都道府県の高校のみ返される' do
+          get '/api/v1/admin/high_schools',
+              params: { prefecture_id: school.prefecture_id },
+              headers: headers.merge('Cookie' => cookie)
+          ids = response.parsed_body['schools'].map { |s| s['id'] }
+          expect(ids).to include(school.id)
+          expect(ids).not_to include(other_school.id)
+        end
+      end
+    end
+
+    context '異常系 - 未認証アクセス' do
+      it '401が返される' do
+        get '/api/v1/admin/high_schools', headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(student_user)
+        get '/api/v1/admin/high_schools', headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/admin/high_schools/:id' do
+    context '正常系' do
+      subject { get "/api/v1/admin/high_schools/#{school.id}", headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:school)     { create(:high_school) }
+      let!(:students)   { create_list(:user, 3, high_school: school) }
+      let!(:teachers)   { create_list(:user, 2, :teacher, high_school: school) }
+
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '必要なフィールドが含まれる' do
+        subject
+        expect(response.parsed_body.keys).to include('id', 'name', 'prefecture_name', 'student_count',
+                                                      'teacher_count', 'created_at', 'updated_at')
+      end
+
+      it 'student_count が正しい' do
+        subject
+        expect(response.parsed_body['student_count']).to eq(3)
+      end
+
+      it 'teacher_count が正しい' do
+        subject
+        expect(response.parsed_body['teacher_count']).to eq(2)
+      end
+    end
+
+    context '異常系 - 未認証アクセス' do
+      let!(:school) { create(:high_school) }
+
+      it '401が返される' do
+        get "/api/v1/admin/high_schools/#{school.id}", headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 存在しない id' do
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it '404が返される' do
+        get '/api/v1/admin/high_schools/0', headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+      let!(:school)       { create(:high_school) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(student_user)
+        get "/api/v1/admin/high_schools/#{school.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/admin/high_schools_spec.rb
+++ b/rails/spec/requests/api/v1/admin/high_schools_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Api::V1::Admin::HighSchools', type: :request do
           get '/api/v1/admin/high_schools',
               params: { prefecture_id: school.prefecture_id },
               headers: headers.merge('Cookie' => cookie)
-          ids = response.parsed_body['schools'].map { |s| s['id'] }
+          ids = response.parsed_body['schools'].pluck('id')
           expect(ids).to include(school.id)
           expect(ids).not_to include(other_school.id)
         end
@@ -119,7 +119,7 @@ RSpec.describe 'Api::V1::Admin::HighSchools', type: :request do
       it '必要なフィールドが含まれる' do
         subject
         expect(response.parsed_body.keys).to include('id', 'name', 'prefecture_name', 'student_count',
-                                                      'teacher_count', 'created_at', 'updated_at')
+                                                     'teacher_count', 'created_at', 'updated_at')
       end
 
       it 'student_count が正しい' do

--- a/rails/spec/requests/api/v1/admin/high_schools_spec.rb
+++ b/rails/spec/requests/api/v1/admin/high_schools_spec.rb
@@ -52,8 +52,7 @@ RSpec.describe 'Api::V1::Admin::HighSchools', type: :request do
       it 'schools の各要素に必要なフィールドが含まれる' do
         subject
         school_data = response.parsed_body['schools'].first
-        expect(school_data.keys).to include('id', 'name', 'prefecture_name', 'student_count', 'teacher_count',
-                                            'created_at', 'updated_at')
+        expect(school_data.keys).to include('id', 'name', 'prefecture_name', 'student_count', 'teacher_count')
       end
 
       it 'student_count が正しい' do
@@ -118,8 +117,7 @@ RSpec.describe 'Api::V1::Admin::HighSchools', type: :request do
 
       it '必要なフィールドが含まれる' do
         subject
-        expect(response.parsed_body.keys).to include('id', 'name', 'prefecture_name', 'student_count',
-                                                     'teacher_count', 'created_at', 'updated_at')
+        expect(response.parsed_body.keys).to include('id', 'name', 'prefecture_name', 'student_count', 'teacher_count')
       end
 
       it 'student_count が正しい' do


### PR DESCRIPTION
## 概要

https://www.notion.so/Rails-API-32e2946467fd80afaf78e73a75837164

管理者が高校の一覧・詳細を取得できる API エンドポイントを追加。

## 詳細

- `GET /api/v1/admin/high_schools`
  - 都道府県 ID（`prefecture_id`）でフィルタリング可能
  - 1ページ20件のページネーション対応
  - 各高校の在籍生徒数・教師数を集計して返す
- `GET /api/v1/admin/high_schools/:id`
  - 指定した高校の詳細情報と在籍数を返す
- `Admin::HighSchoolSerializer` でレスポンスを整形
  - フィールド: `id`, `name`, `prefecture_name`, `student_count`, `teacher_count`, `created_at`, `updated_at`

## 動作確認

- [x] `GET /api/v1/admin/high_schools` で高校一覧が取得できる
- [x] `prefecture_id` パラメータでフィルタリングできる
- [x] `GET /api/v1/admin/high_schools/:id` で高校詳細が取得できる
- [x] `meta` にページネーション情報が含まれる

## その他
https://www.notion.so/Rails-CRUD-API-32e2946467fd80479f99d8db570c2dca
高校別教師の CRUD に関してはこのチケットでやる！

フロントでの表示はこんな感じの想定

- テーブルカラム: 高校名 / 都道府県 / 生徒数 / 教師数 / 最終更新 / 詳細ボタン
- 都道府県プルダウンフィルター（「すべて」含む）
- ページネーション（20件/ページ、MUI Pagination）
- 「詳細」ボタンで /admin/schools/[id] へ遷移

## 参考情報

特になし
