### PR TITLE
issue-29  管理者画面に高校一覧ページを実装

### DIFF
--- a/frontend/app/(admin)/admin/(authenticated)/schools/page.tsx
+++ b/frontend/app/(admin)/admin/(authenticated)/schools/page.tsx
@@ -1,0 +1,5 @@
+import { AdminSchools } from "@/features/AdminSchools";
+
+export default function AdminSchoolsPage() {
+  return <AdminSchools />;
+}

--- a/frontend/app/api/admin/schools/route.ts
+++ b/frontend/app/api/admin/schools/route.ts
@@ -1,0 +1,31 @@
+import { RailsUnauthorizedError } from "@/libs/server/rails/railsError";
+import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const page = searchParams.get("page") ?? "1";
+  const prefectureId = searchParams.get("prefecture_id");
+
+  const params = new URLSearchParams({ page });
+  if (prefectureId) params.set("prefecture_id", prefectureId);
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/admin/high_schools?${params.toString()}`,
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    if (error instanceof RailsUnauthorizedError) {
+      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+    }
+
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/features/AdminSchools/Presenter.test.tsx
+++ b/frontend/features/AdminSchools/Presenter.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { Presenter } from "./Presenter";
 import type { AdminSchoolsData } from "./types";
@@ -55,11 +55,12 @@ const defaultProps = {
 describe("AdminSchoolsPresenter", () => {
   it("テーブルヘッダーに「高校名」「都道府県」「生徒数」「教師数」「詳細」が表示される", () => {
     render(<Presenter {...defaultProps} />);
-    expect(screen.getByText("高校名")).toBeInTheDocument();
-    expect(screen.getByText("都道府県")).toBeInTheDocument();
-    expect(screen.getByText("生徒数")).toBeInTheDocument();
-    expect(screen.getByText("教師数")).toBeInTheDocument();
-    expect(screen.getByText("詳細")).toBeInTheDocument();
+    const headers = screen.getAllByRole("columnheader").map((h) => h.textContent);
+    expect(headers).toContain("高校名");
+    expect(headers).toContain("都道府県");
+    expect(headers).toContain("生徒数");
+    expect(headers).toContain("教師数");
+    expect(headers).toContain("詳細");
   });
 
   it("schools データが行として正しくレンダリングされる", () => {
@@ -72,9 +73,11 @@ describe("AdminSchoolsPresenter", () => {
     expect(screen.getByText("大阪府")).toBeInTheDocument();
   });
 
-  it("都道府県プルダウンに「すべて」オプションが表示される", () => {
+  it("都道府県プルダウンを開くと「すべて」オプションが表示される", () => {
     render(<Presenter {...defaultProps} />);
-    expect(screen.getByText("すべて")).toBeInTheDocument();
+    const select = screen.getByRole("combobox");
+    fireEvent.mouseDown(select);
+    expect(screen.getByRole("option", { name: "すべて" })).toBeInTheDocument();
   });
 
   it("ページネーションが表示される", () => {

--- a/frontend/features/AdminSchools/Presenter.test.tsx
+++ b/frontend/features/AdminSchools/Presenter.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Presenter } from "./Presenter";
+import type { AdminSchoolsData } from "./types";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const mockData: AdminSchoolsData = {
+  schools: [
+    {
+      id: 1,
+      name: "東京第一高校",
+      prefecture_name: "東京都",
+      student_count: 300,
+      teacher_count: 20,
+    },
+    {
+      id: 2,
+      name: "大阪中央高校",
+      prefecture_name: "大阪府",
+      student_count: 250,
+      teacher_count: 15,
+    },
+  ],
+  meta: {
+    current_page: 1,
+    total_pages: 3,
+    total_count: 50,
+    per_page: 20,
+  },
+};
+
+const mockPrefectures = [
+  { id: 13, name: "東京都" },
+  { id: 27, name: "大阪府" },
+];
+
+const defaultProps = {
+  data: mockData,
+  prefectures: mockPrefectures,
+  selectedPrefectureId: null,
+  page: 1,
+  onPrefectureChange: vi.fn(),
+  onPageChange: vi.fn(),
+};
+
+describe("AdminSchoolsPresenter", () => {
+  it("テーブルヘッダーに「高校名」「都道府県」「生徒数」「教師数」「詳細」が表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByText("高校名")).toBeInTheDocument();
+    expect(screen.getByText("都道府県")).toBeInTheDocument();
+    expect(screen.getByText("生徒数")).toBeInTheDocument();
+    expect(screen.getByText("教師数")).toBeInTheDocument();
+    expect(screen.getByText("詳細")).toBeInTheDocument();
+  });
+
+  it("schools データが行として正しくレンダリングされる", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByText("東京第一高校")).toBeInTheDocument();
+    expect(screen.getByText("東京都")).toBeInTheDocument();
+    expect(screen.getByText("300")).toBeInTheDocument();
+    expect(screen.getByText("20")).toBeInTheDocument();
+    expect(screen.getByText("大阪中央高校")).toBeInTheDocument();
+    expect(screen.getByText("大阪府")).toBeInTheDocument();
+  });
+
+  it("都道府県プルダウンに「すべて」オプションが表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByText("すべて")).toBeInTheDocument();
+  });
+
+  it("ページネーションが表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+  });
+
+  it("「詳細」リンクが /admin/schools/[id] を指している", () => {
+    render(<Presenter {...defaultProps} />);
+    const detailLinks = screen.getAllByRole("link", { name: "詳細" });
+    expect(detailLinks[0]).toHaveAttribute("href", "/admin/schools/1");
+    expect(detailLinks[1]).toHaveAttribute("href", "/admin/schools/2");
+  });
+
+  it("schools が空のとき「高校が見つかりません」が表示される", () => {
+    render(
+      <Presenter
+        {...defaultProps}
+        data={{ ...mockData, schools: [] }}
+      />,
+    );
+    expect(screen.getByText("高校が見つかりません")).toBeInTheDocument();
+  });
+});

--- a/frontend/features/AdminSchools/Presenter.test.tsx
+++ b/frontend/features/AdminSchools/Presenter.test.tsx
@@ -55,7 +55,9 @@ const defaultProps = {
 describe("AdminSchoolsPresenter", () => {
   it("テーブルヘッダーに「高校名」「都道府県」「生徒数」「教師数」「詳細」が表示される", () => {
     render(<Presenter {...defaultProps} />);
-    const headers = screen.getAllByRole("columnheader").map((h) => h.textContent);
+    const headers = screen
+      .getAllByRole("columnheader")
+      .map((h) => h.textContent);
     expect(headers).toContain("高校名");
     expect(headers).toContain("都道府県");
     expect(headers).toContain("生徒数");
@@ -93,12 +95,7 @@ describe("AdminSchoolsPresenter", () => {
   });
 
   it("schools が空のとき「高校が見つかりません」が表示される", () => {
-    render(
-      <Presenter
-        {...defaultProps}
-        data={{ ...mockData, schools: [] }}
-      />,
-    );
+    render(<Presenter {...defaultProps} data={{ ...mockData, schools: [] }} />);
     expect(screen.getByText("高校が見つかりません")).toBeInTheDocument();
   });
 });

--- a/frontend/features/AdminSchools/Presenter.tsx
+++ b/frontend/features/AdminSchools/Presenter.tsx
@@ -54,13 +54,18 @@ export const Presenter = ({
 
   return (
     <Box sx={{ p: 3 }}>
-      <Typography
-        variant="h5"
-        fontWeight={700}
-        sx={{ mb: 3, color: colors.text.primary }}
-      >
-        高校一覧
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "baseline", gap: 1.5, mb: 3 }}>
+        <Typography
+          variant="h5"
+          fontWeight={700}
+          sx={{ color: colors.text.primary }}
+        >
+          高校一覧
+        </Typography>
+        <Typography variant="body2" sx={{ color: colors.text.muted }}>
+          {meta.total_count} 件
+        </Typography>
+      </Box>
 
       {/* 都道府県フィルター */}
       <Box sx={{ mb: 3 }}>

--- a/frontend/features/AdminSchools/Presenter.tsx
+++ b/frontend/features/AdminSchools/Presenter.tsx
@@ -73,7 +73,9 @@ export const Presenter = ({
           <InputLabel>都道府県</InputLabel>
           <Select
             label="都道府県"
-            value={selectedPrefectureId === null ? "" : String(selectedPrefectureId)}
+            value={
+              selectedPrefectureId === null ? "" : String(selectedPrefectureId)
+            }
             onChange={handlePrefectureChange}
           >
             <MenuItem value="">すべて</MenuItem>
@@ -89,7 +91,11 @@ export const Presenter = ({
       {/* テーブル */}
       <Card
         elevation={0}
-        sx={{ border: `1px solid ${colors.border.light}`, borderRadius: 2, mb: 3 }}
+        sx={{
+          border: `1px solid ${colors.border.light}`,
+          borderRadius: 2,
+          mb: 3,
+        }}
       >
         <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
           {schools.length === 0 ? (

--- a/frontend/features/AdminSchools/Presenter.tsx
+++ b/frontend/features/AdminSchools/Presenter.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { colors } from "@/app/theme/colors";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Pagination,
+  Select,
+  type SelectChangeEvent,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import Link from "next/link";
+import type { AdminSchoolsData } from "./types";
+
+type Prefecture = {
+  id: number;
+  name: string;
+};
+
+type Props = {
+  data: AdminSchoolsData;
+  prefectures: Prefecture[];
+  selectedPrefectureId: number | null;
+  page: number;
+  onPrefectureChange: (id: number | null) => void;
+  onPageChange: (page: number) => void;
+};
+
+export const Presenter = ({
+  data,
+  prefectures,
+  selectedPrefectureId,
+  page,
+  onPrefectureChange,
+  onPageChange,
+}: Props) => {
+  const { schools, meta } = data;
+
+  const handlePrefectureChange = (e: SelectChangeEvent<string>) => {
+    const value = e.target.value;
+    onPrefectureChange(value === "" ? null : Number(value));
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Typography
+        variant="h5"
+        fontWeight={700}
+        sx={{ mb: 3, color: colors.text.primary }}
+      >
+        高校一覧
+      </Typography>
+
+      {/* 都道府県フィルター */}
+      <Box sx={{ mb: 3 }}>
+        <FormControl size="small" sx={{ minWidth: 200 }}>
+          <InputLabel>都道府県</InputLabel>
+          <Select
+            label="都道府県"
+            value={selectedPrefectureId === null ? "" : String(selectedPrefectureId)}
+            onChange={handlePrefectureChange}
+          >
+            <MenuItem value="">すべて</MenuItem>
+            {prefectures.map((pref) => (
+              <MenuItem key={pref.id} value={String(pref.id)}>
+                {pref.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      {/* テーブル */}
+      <Card
+        elevation={0}
+        sx={{ border: `1px solid ${colors.border.light}`, borderRadius: 2, mb: 3 }}
+      >
+        <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
+          {schools.length === 0 ? (
+            <Typography
+              color="text.secondary"
+              sx={{ py: 4, textAlign: "center" }}
+            >
+              高校が見つかりません
+            </Typography>
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow sx={{ bgcolor: colors.surface.light }}>
+                    <TableCell sx={{ fontWeight: 600 }}>高校名</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>都道府県</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>生徒数</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>教師数</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>詳細</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {schools.map((school) => (
+                    <TableRow
+                      key={school.id}
+                      hover
+                      sx={{ "&:last-child td": { border: 0 } }}
+                    >
+                      <TableCell>{school.name}</TableCell>
+                      <TableCell>{school.prefecture_name}</TableCell>
+                      <TableCell>{school.student_count}</TableCell>
+                      <TableCell>{school.teacher_count}</TableCell>
+                      <TableCell>
+                        <Button
+                          component={Link}
+                          href={`/admin/schools/${school.id}`}
+                          size="small"
+                          variant="outlined"
+                          sx={{ fontSize: "0.75rem" }}
+                        >
+                          詳細
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ページネーション */}
+      {meta.total_pages > 1 && (
+        <Box sx={{ display: "flex", justifyContent: "center" }}>
+          <Pagination
+            count={meta.total_pages}
+            page={page}
+            onChange={(_, value) => onPageChange(value)}
+            color="primary"
+          />
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/frontend/features/AdminSchools/index.tsx
+++ b/frontend/features/AdminSchools/index.tsx
@@ -12,7 +12,7 @@ type Prefecture = {
   name: string;
 };
 
-export function AdminSchools() {
+export const AdminSchools = () => {
   const [data, setData] = useState<AdminSchoolsData | null>(null);
   const [prefectures, setPrefectures] = useState<Prefecture[]>([]);
   const [selectedPrefectureId, setSelectedPrefectureId] = useState<
@@ -74,4 +74,4 @@ export function AdminSchools() {
       onPageChange={setPage}
     />
   );
-}
+};

--- a/frontend/features/AdminSchools/index.tsx
+++ b/frontend/features/AdminSchools/index.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, CircularProgress } from "@mui/material";
+import { apiClient } from "@/libs/http/apiClient";
+import { Presenter } from "./Presenter";
+import type { AdminSchoolsData } from "./types";
+
+type Prefecture = {
+  id: number;
+  name: string;
+};
+
+export function AdminSchools() {
+  const [data, setData] = useState<AdminSchoolsData | null>(null);
+  const [prefectures, setPrefectures] = useState<Prefecture[]>([]);
+  const [selectedPrefectureId, setSelectedPrefectureId] = useState<
+    number | null
+  >(null);
+  const [page, setPage] = useState(1);
+  const router = useRouter();
+
+  useEffect(() => {
+    const params: Record<string, string> = { page: String(page) };
+    if (selectedPrefectureId !== null) {
+      params.prefecture_id = String(selectedPrefectureId);
+    }
+
+    apiClient
+      .get<AdminSchoolsData>("/api/admin/schools", { params })
+      .then((res) => setData(res.data))
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          router.push("/login");
+        }
+      });
+  }, [page, selectedPrefectureId, router]);
+
+  useEffect(() => {
+    apiClient
+      .get<Prefecture[]>("/api/auth/prefectures")
+      .then((res) => setPrefectures(res.data))
+      .catch(() => {});
+  }, []);
+
+  const handlePrefectureChange = (id: number | null) => {
+    setSelectedPrefectureId(id);
+    setPage(1);
+  };
+
+  if (!data) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Presenter
+      data={data}
+      prefectures={prefectures}
+      selectedPrefectureId={selectedPrefectureId}
+      page={page}
+      onPrefectureChange={handlePrefectureChange}
+      onPageChange={setPage}
+    />
+  );
+}

--- a/frontend/features/AdminSchools/types.ts
+++ b/frontend/features/AdminSchools/types.ts
@@ -1,0 +1,19 @@
+export type School = {
+  id: number;
+  name: string;
+  prefecture_name: string;
+  student_count: number;
+  teacher_count: number;
+};
+
+export type SchoolMeta = {
+  current_page: number;
+  total_pages: number;
+  total_count: number;
+  per_page: number;
+};
+
+export type AdminSchoolsData = {
+  schools: School[];
+  meta: SchoolMeta;
+};


### PR DESCRIPTION
## 概要

#29 

管理者が高校の一覧を確認できるページが未実装だったため、Container/Presenter パターンで実装した。

## 詳細

### 追加ファイル

- `frontend/features/AdminSchools/types.ts` — 型定義（School, SchoolMeta, AdminSchoolsData）
- `frontend/app/api/admin/schools/route.ts` — Next.js プロキシルート（Rails `/api/v1/admin/high_schools` へ転送）
- `frontend/features/AdminSchools/Presenter.tsx` — UI コンポーネント（MUI Table / Select / Pagination）
- `frontend/features/AdminSchools/Presenter.test.tsx` — Presenter のユニットテスト（TDD）
- `frontend/features/AdminSchools/index.tsx` — Container（API fetch・状態管理・401リダイレクト）
- `frontend/app/(admin)/admin/(authenticated)/schools/page.tsx` — ページエントリ

### 実装方針

- **Container/Presenter パターン**で実装（`AdminDashboard` と同様の構成）
- **都道府県フィルター・ページネーションはサーバーサイド**で処理（`?page=N&prefecture_id=N` をクエリパラメータで Rails に渡す）
- 401 エラー時は `/login` にリダイレクト
- 都道府県プルダウンのデータは既存の `/api/auth/prefectures` を流用
- タイトル横に総件数（`meta.total_count`）を表示
- サイドバーの「高校管理」リンクは既に存在していたため変更なし


## 動作確認
<img width="1345" height="838" alt="スクリーンショット 2026-04-02 14 36 58" src="https://github.com/user-attachments/assets/03796f52-c962-46c8-9fb2-36405454d948" />


- [x] 管理者でログイン → サイドバー「高校管理」クリック → 高校一覧が表示される
- [x] 都道府県プルダウンで絞り込みができる
- [x] ページネーションでページ切り替えができる
- [x] 「詳細」ボタンをクリックすると `/admin/schools/[id]` に遷移する
- [x] 未認証でアクセスすると `/login` にリダイレクトされる

## その他

特になし

## 参考情報

- 既存実装の参考: `features/AdminDashboard/`
- Rails エンドポイント: `GET /api/v1/admin/high_schools`（実装済み・Kaminari ページネーション対応済み）
