### PR TITLE
タスク作成時にTaskUnitテーブルにレコードが作成されないバグ

### DIFF
--- a/rails/app/controllers/api/v1/teacher/announcements_controller.rb
+++ b/rails/app/controllers/api/v1/teacher/announcements_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Teacher
+      class AnnouncementsController < Api::V1::Teacher::BaseController
+        def index
+          announcements = Announcement
+                          .for_user(current_user)
+                          .published
+                          .order(published_at: :desc)
+                          .page(params[:page])
+                          .per(20)
+
+          render json: {
+                   announcements:
+                    ActiveModelSerializers::SerializableResource.new(
+                      announcements,
+                      each_serializer: AnnouncementSerializer
+                    ),
+                   meta: {
+                     current_page: announcements.current_page,
+                     total_pages: announcements.total_pages,
+                     total_count: announcements.total_count,
+                     per_page: 20
+                   }
+                 },
+                 status: :ok
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/teacher/dashboards_controller.rb
+++ b/rails/app/controllers/api/v1/teacher/dashboards_controller.rb
@@ -35,7 +35,7 @@ module Api
         private
 
         def students
-          current_user.high_school.users
+          current_user.high_school.users.students
         end
       end
     end

--- a/rails/app/controllers/api/v1/teacher/dashboards_controller.rb
+++ b/rails/app/controllers/api/v1/teacher/dashboards_controller.rb
@@ -27,7 +27,8 @@ module Api
               grade_two_students_count: grade_counts[2] || 0,
               grade_three_students_count: grade_counts[3] || 0
             },
-            announcements: announcements
+            announcements: ActiveModelSerializers::SerializableResource.new(announcements,
+                                                                            each_serializer: AnnouncementSerializer)
           }, status: :ok
         end
 

--- a/rails/app/controllers/api/v1/teacher/dashboards_controller.rb
+++ b/rails/app/controllers/api/v1/teacher/dashboards_controller.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Teacher
+      class DashboardsController < Api::V1::Teacher::BaseController
+        def show
+          # 利用している所属高校の生徒数
+          grade_counts = students
+                         .high_school_current
+                         .group('grades.year')
+                         .count
+
+          # お知らせ(教師向け5件くらい)
+          announcements = Announcement
+                          .for_user(current_user)
+                          .published
+                          .order(published_at: :desc)
+                          .limit(5)
+
+          # 昨日学習した生徒数(高１〜３年生のみ)
+
+          render json: {
+            stats: {
+              # 利用している所属高校の生徒数(高１〜３年生のみ)
+              grade_one_students_count: grade_counts[1] || 0,
+              grade_two_students_count: grade_counts[2] || 0,
+              grade_three_students_count: grade_counts[3] || 0
+            },
+            announcements: announcements
+          }, status: :ok
+        end
+
+        private
+
+        def students
+          current_user.high_school.users
+        end
+      end
+    end
+  end
+end

--- a/rails/app/models/announcement.rb
+++ b/rails/app/models/announcement.rb
@@ -22,4 +22,39 @@ class Announcement < ApplicationRecord
     scheduled: 1,
     published: 2
   }
+
+  scope :for_user, lambda { |user|
+    base = joins(:announcement_targets)
+
+    base
+      .where(announcement_targets: { target_type: :all_users })
+      .or(
+        base
+          .where(announcement_targets: { target_type: :by_role, user_role_id: user.user_role_id })
+      )
+      .or(
+        base
+          .where(announcement_targets: { target_type: :by_school, high_school_id: user.high_school_id })
+      )
+      .distinct
+  }
+
+  scope :targeting_all_users, lambda {
+    joins(:announcement_targets).where(announcement_targets: { target_type: :all_users })
+  }
+
+  scope :targeting_by_role, lambda { |role_id|
+    joins(:announcement_targets)
+      .where(announcement_targets: { target_type: :by_role, user_role_id: role_id })
+  }
+
+  scope :targeting_by_school, lambda { |school_id|
+    joins(:announcement_targets)
+      .where(announcement_targets: { target_type: :by_school, high_school_id: school_id })
+  }
+
+  scope :targeting_by_grade, lambda { |grade_id|
+    joins(:announcement_targets)
+      .where(announcement_targets: { target_type: :by_grade, grade_id: grade_id })
+  }
 end

--- a/rails/app/models/announcement.rb
+++ b/rails/app/models/announcement.rb
@@ -36,6 +36,10 @@ class Announcement < ApplicationRecord
         base
           .where(announcement_targets: { target_type: :by_school, high_school_id: user.high_school_id })
       )
+      .or(
+        base
+          .where(announcement_targets: { target_type: :by_grade, grade_id: user.grade_id })
+      )
       .distinct
   }
 

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -48,10 +48,6 @@ class User < ApplicationRecord
   has_many :grades, through: :teacher_grades, source: :grade
   has_many :import_histories, dependent: :destroy
 
-  scope :students, -> { joins(:user_role).where(user_roles: { name: 'student' }) }
-  scope :teachers, -> { joins(:user_role).where(user_roles: { name: 'teacher' }) }
-  scope :by_high_school, ->(high_school_ids) { where(high_school_id: high_school_ids) }
-
   validates :name, presence: true, on: :update
   validates :name_kana, presence: true, on: :update
   validates :user_role, presence: true
@@ -93,6 +89,11 @@ class User < ApplicationRecord
       info.birthday.present? &&
       info.gender.present?
   end
+
+  scope :students, -> { joins(:user_role).where(user_roles: { name: 'student' }) }
+  scope :teachers, -> { joins(:user_role).where(user_roles: { name: 'teacher' }) }
+  scope :by_high_school, ->(high_school_ids) { where(high_school_id: high_school_ids) }
+  scope :high_school_current, -> { joins(:grade).where(grades: { year: 1..3 }) }
 
   private
 

--- a/rails/app/serializers/announcement_serializer.rb
+++ b/rails/app/serializers/announcement_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class AnnouncementSerializer < ActiveModel::Serializer
+  attributes :id, :title, :content, :published_at
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -29,10 +29,13 @@ Rails.application.routes.draw do
         resources :tasks
         resources :courses, only: :index
       end
+
       namespace :teacher do
         resources :colleagues, controller: "teachers"
         resources :students
+        resource :dashboard, only: :show
       end
+
       namespace :admin do
         resource :dashboard, only: :show
         resources :high_schools, only: [:index, :show]

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
       namespace :teacher do
         resources :colleagues, controller: "teachers"
         resources :students
+        resources :announcements
         resource :dashboard, only: :show
       end
 

--- a/rails/spec/factories/announcement_targets.rb
+++ b/rails/spec/factories/announcement_targets.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: announcement_targets
+#
+#  id              :bigint           not null, primary key
+#  announcement_id :bigint           not null
+#  user_role_id    :bigint
+#  grade_id        :bigint
+#  high_school_id  :bigint
+#  user_id         :bigint
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+FactoryBot.define do
+  factory :announcement_target do
+    association :announcement
+    target_type { :all_users }
+
+    trait :by_role do
+      target_type { :by_role }
+      user_role_id { 1 }
+    end
+
+    trait :by_school do
+      target_type { :by_school }
+      high_school_id { 1 }
+    end
+
+    trait :by_grade do
+      target_type { :by_grade }
+      grade_id { 1 }
+    end
+  end
+end

--- a/rails/spec/factories/announcements.rb
+++ b/rails/spec/factories/announcements.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: announcements
+#
+#  id           :bigint           not null, primary key
+#  title        :string(255)      not null
+#  content      :text(65535)      not null
+#  status       :integer          default("draft"), not null
+#  published_at :datetime
+#  publisher_id :bigint           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+FactoryBot.define do
+  factory :announcement do
+    title { 'テストタイトル' }
+    content { 'テスト内容' }
+    status { :draft }
+    association :publisher, factory: :user
+  end
+end

--- a/rails/spec/factories/user_roles.rb
+++ b/rails/spec/factories/user_roles.rb
@@ -11,36 +11,20 @@
 #
 FactoryBot.define do
   factory :user_role do
-    trait :student do
-      name { 'student' }
+    name { :student }
 
-      initialize_with do
-        UserRole.find_or_create_by!(name: name)
-      end
-    end
+    initialize_with { UserRole.find_or_create_by!(name: name) }
 
     trait :admin do
-      name { 'admin' }
-
-      initialize_with do
-        UserRole.find_or_create_by!(name: name)
-      end
+      name { :admin }
     end
 
     trait :teacher do
-      name { 'teacher' }
-
-      initialize_with do
-        UserRole.find_or_create_by!(name: name)
-      end
+      name { :teacher }
     end
 
     trait :guardian do
-      name { 'guardian' }
-
-      initialize_with do
-        UserRole.find_or_create_by!(name: name)
-      end
+      name { :guardian }
     end
   end
 end

--- a/rails/spec/models/announcement_spec.rb
+++ b/rails/spec/models/announcement_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Announcement, type: :model do
+  describe 'enum' do
+    it { is_expected.to define_enum_for(:status).with_values(draft: 0, scheduled: 1, published: 2) }
+  end
+
+  describe '.for_user' do
+    let(:role) { UserRole.find_or_create_by!(name: :teacher) }
+    let(:other_role) { UserRole.find_or_create_by!(name: :student) }
+
+    let(:school) { create(:high_school) }
+    let(:other_school) { create(:high_school) }
+
+    let(:grade) { create(:grade) }
+    let(:other_grade) { create(:grade) }
+
+    let(:user) do
+      create(:user,
+             user_role: role,
+             high_school: school,
+             grade: grade)
+    end
+
+    let!(:all_users_announcement) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :all_users)
+      end
+    end
+
+    let!(:role_announcement) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_role,
+               user_role_id: role.id)
+      end
+    end
+
+    let!(:school_announcement) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_school,
+               high_school_id: school.id)
+      end
+    end
+
+    let!(:grade_announcement) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_grade,
+               grade_id: grade.id)
+      end
+    end
+
+    let!(:not_match_announcement) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_role,
+               user_role_id: other_role.id)
+      end
+    end
+
+    it 'ユーザーに該当するお知らせのみ取得する' do
+      result = described_class.for_user(user)
+
+      expect(result).to include(
+        all_users_announcement,
+        role_announcement,
+        school_announcement,
+        grade_announcement
+      )
+
+      expect(result).not_to include(not_match_announcement)
+    end
+  end
+
+  describe '.targeting_all_users' do
+    let!(:target) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :all_users)
+      end
+    end
+
+    let!(:other) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_role,
+               user_role: create(:user_role))
+      end
+    end
+
+    it '全体配信のみ取得する' do
+      expect(described_class.targeting_all_users).to contain_exactly(target)
+    end
+  end
+
+  describe '.targeting_by_role' do
+    let(:role) { create(:user_role, :teacher) }
+    let(:other_role) { create(:user_role, :student) }
+    let!(:match) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_role,
+               user_role_id: role.id)
+      end
+    end
+
+    let!(:not_match) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_role,
+               user_role_id: other_role.id)
+      end
+    end
+
+    it '指定したroleのみ取得する' do
+      expect(described_class.targeting_by_role(role.id)).to contain_exactly(match)
+    end
+  end
+
+  describe '.targeting_by_school' do
+    let(:school) { create(:high_school) }
+    let(:other_school) { create(:high_school) }
+
+    let!(:match) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_school,
+               high_school_id: school.id)
+      end
+    end
+
+    let!(:not_match) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_school,
+               high_school_id: other_school.id)
+      end
+    end
+
+    it '指定したschoolのみ取得する' do
+      expect(described_class.targeting_by_school(school.id)).to contain_exactly(match)
+    end
+  end
+
+  describe '.targeting_by_grade' do
+    let(:grade) { create(:grade) }
+    let(:other_grade) { create(:grade) }
+
+    let!(:match) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_grade,
+               grade_id: grade.id)
+      end
+    end
+
+    let!(:not_match) do
+      create(:announcement).tap do |a|
+        create(:announcement_target,
+               announcement: a,
+               target_type: :by_grade,
+               grade_id: other_grade.id)
+      end
+    end
+
+    it '指定したgradeのみ取得する' do
+      expect(described_class.targeting_by_grade(grade.id)).to contain_exactly(match)
+    end
+  end
+end


### PR DESCRIPTION
## 概要
https://www.notion.so/TaskUnit-3362946467fd80d98425c8978882500c

フロント側から送るパラメーターとRailsで受け取る型が違っていたのでRails側で中間テーブルTaskUnitが作成できていなかった。暫定的に修正し、TaskUnitテーブルが作成できるようにした。

<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細



<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

## 動作確認
・動作確認後、DBeaverでTaskUnitテーブルにレコード作成されていることを確認
<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
