### PR TITLE
タスク作成時にTaskUnitテーブルにレコードが作成されないバグ

### DIFF
--- a/frontend/features/CreateTaskConfirm/hooks.ts
+++ b/frontend/features/CreateTaskConfirm/hooks.ts
@@ -6,7 +6,14 @@ import { DraftTaskType } from "./useFetchDraftTask";
 export const useRegisterTask = () => {
   const registerTask = async (draftTask: DraftTaskType) => {
     const postData = {
-      task: draftTask,
+      task: {
+        goal_id: draftTask.goal_id,
+        title: draftTask.title,
+        content: draftTask.content,
+        priority: draftTask.priority,
+        due_date: draftTask.due_date,
+        unit_ids: draftTask.units.map((u) => u.id),
+      },
     };
 
     return await apiClient.post(`/api/student/tasks`, postData);


### PR DESCRIPTION
## 概要
https://www.notion.so/TaskUnit-3362946467fd80d98425c8978882500c

フロント側から送るパラメーターとRailsで受け取る型が違っていたのでRails側で中間テーブルTaskUnitが作成できていなかった。暫定的に修正し、TaskUnitテーブルが作成できるようにした。
<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細

<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

## 動作確認
- 動作確認後、DBeaverでTaskUnitテーブルにレコード作成されていることを確認
<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
