### PR TITLE
issue-39 高校詳細ページの実装（概要・教師管理タブ骨格）

### DIFF
--- a/frontend/app/(admin)/admin/(authenticated)/schools/[schoolId]/page.tsx
+++ b/frontend/app/(admin)/admin/(authenticated)/schools/[schoolId]/page.tsx
@@ -1,0 +1,10 @@
+import { AdminSchoolDetail } from "@/features/AdminSchoolDetail";
+
+type Props = {
+  params: Promise<{ schoolId: string }>;
+};
+
+export default async function AdminSchoolDetailPage({ params }: Props) {
+  const { schoolId } = await params;
+  return <AdminSchoolDetail schoolId={Number(schoolId)} />;
+}

--- a/frontend/app/(admin)/admin/(authenticated)/schools/[schoolId]/page.tsx
+++ b/frontend/app/(admin)/admin/(authenticated)/schools/[schoolId]/page.tsx
@@ -4,7 +4,9 @@ type Props = {
   params: Promise<{ schoolId: string }>;
 };
 
-export default async function AdminSchoolDetailPage({ params }: Props) {
+const AdminSchoolDetailPage = async ({ params }: Props) => {
   const { schoolId } = await params;
   return <AdminSchoolDetail schoolId={Number(schoolId)} />;
-}
+};
+
+export default AdminSchoolDetailPage;

--- a/frontend/app/api/admin/schools/[schoolId]/route.ts
+++ b/frontend/app/api/admin/schools/[schoolId]/route.ts
@@ -3,7 +3,7 @@ import { railsFetch } from "@/libs/server/rails/railsFetch";
 import { type NextRequest, NextResponse } from "next/server";
 
 export async function GET(
-  _request: NextRequest,
+  _: NextRequest,
   { params }: { params: Promise<{ schoolId: string }> },
 ) {
   const { schoolId } = await params;

--- a/frontend/app/api/admin/schools/[schoolId]/route.ts
+++ b/frontend/app/api/admin/schools/[schoolId]/route.ts
@@ -1,0 +1,29 @@
+import { RailsUnauthorizedError } from "@/libs/server/rails/railsError";
+import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ schoolId: string }> },
+) {
+  const { schoolId } = await params;
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/admin/high_schools/${schoolId}`,
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    if (error instanceof RailsUnauthorizedError) {
+      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+    }
+
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/features/AdminSchoolDetail/Presenter.test.tsx
+++ b/frontend/features/AdminSchoolDetail/Presenter.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Presenter } from "./Presenter";
+import type { AdminSchoolDetail } from "./types";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const mockSchool: AdminSchoolDetail = {
+  id: 1,
+  name: "東京第一高校",
+  prefecture_name: "東京都",
+  student_count: 300,
+  teacher_count: 20,
+};
+
+const defaultProps = {
+  school: mockSchool,
+};
+
+describe("AdminSchoolDetailPresenter", () => {
+  describe("パンくずナビ", () => {
+    it("「高校一覧」リンクが /admin/schools を指している", () => {
+      render(<Presenter {...defaultProps} />);
+      const link = screen.getByRole("link", { name: "高校一覧" });
+      expect(link).toHaveAttribute("href", "/admin/schools");
+    });
+
+    it("パンくずに高校名が表示される", () => {
+      render(<Presenter {...defaultProps} />);
+      // パンくずの高校名（現在地）はリンクなしのテキストとして存在する
+      const breadcrumbItems = screen.getAllByText("東京第一高校");
+      expect(breadcrumbItems.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("ページタイトル", () => {
+    it("高校名が見出しとして表示される", () => {
+      render(<Presenter {...defaultProps} />);
+      expect(
+        screen.getByRole("heading", { name: "東京第一高校" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("タブ", () => {
+    it("「概要」「教師管理」タブが表示される", () => {
+      render(<Presenter {...defaultProps} />);
+      expect(screen.getByRole("tab", { name: "概要" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("tab", { name: "教師管理" }),
+      ).toBeInTheDocument();
+    });
+
+    it("初期表示では「概要」タブが選択されている", () => {
+      render(<Presenter {...defaultProps} />);
+      const overviewTab = screen.getByRole("tab", { name: "概要" });
+      expect(overviewTab).toHaveAttribute("aria-selected", "true");
+    });
+
+    it("「教師管理」タブをクリックすると選択状態が切り替わる", () => {
+      render(<Presenter {...defaultProps} />);
+      const teacherTab = screen.getByRole("tab", { name: "教師管理" });
+      fireEvent.click(teacherTab);
+      expect(teacherTab).toHaveAttribute("aria-selected", "true");
+    });
+  });
+
+  describe("概要タブ", () => {
+    it("生徒数が表示される", () => {
+      render(<Presenter {...defaultProps} />);
+      expect(screen.getByText("300")).toBeInTheDocument();
+    });
+
+    it("教師数が表示される", () => {
+      render(<Presenter {...defaultProps} />);
+      expect(screen.getByText("20")).toBeInTheDocument();
+    });
+
+    it("都道府県名が表示される", () => {
+      render(<Presenter {...defaultProps} />);
+      expect(screen.getByText("東京都")).toBeInTheDocument();
+    });
+  });
+
+  describe("教師管理タブ", () => {
+    it("タブ切り替え後に「最初の教師を追加する」が表示される", () => {
+      render(<Presenter {...defaultProps} />);
+      fireEvent.click(screen.getByRole("tab", { name: "教師管理" }));
+      expect(screen.getByText("最初の教師を追加する")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/features/AdminSchoolDetail/Presenter.test.tsx
+++ b/frontend/features/AdminSchoolDetail/Presenter.test.tsx
@@ -54,9 +54,7 @@ describe("AdminSchoolDetailPresenter", () => {
     it("「概要」「教師管理」タブが表示される", () => {
       render(<Presenter {...defaultProps} />);
       expect(screen.getByRole("tab", { name: "概要" })).toBeInTheDocument();
-      expect(
-        screen.getByRole("tab", { name: "教師管理" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "教師管理" })).toBeInTheDocument();
     });
 
     it("初期表示では「概要」タブが選択されている", () => {

--- a/frontend/features/AdminSchoolDetail/Presenter.test.tsx
+++ b/frontend/features/AdminSchoolDetail/Presenter.test.tsx
@@ -91,10 +91,12 @@ describe("AdminSchoolDetailPresenter", () => {
   });
 
   describe("教師管理タブ", () => {
-    it("タブ切り替え後に「最初の教師を追加する」が表示される", () => {
+    it("タブ切り替え後に「最初の教師を追加する」ボタンが表示される", () => {
       render(<Presenter {...defaultProps} />);
       fireEvent.click(screen.getByRole("tab", { name: "教師管理" }));
-      expect(screen.getByText("最初の教師を追加する")).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "最初の教師を追加する" }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/features/AdminSchoolDetail/Presenter.tsx
+++ b/frontend/features/AdminSchoolDetail/Presenter.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import {
   Box,
   Breadcrumbs,
+  Button,
   Card,
   CardContent,
   Divider,
@@ -118,9 +119,9 @@ export const Presenter = ({ school }: Props) => {
           <Typography variant="h6" sx={{ color: colors.text.secondary }}>
             まだ教師が登録されていません
           </Typography>
-          <Typography variant="body2" sx={{ color: colors.text.muted }}>
+          <Button variant="contained" disabled>
             最初の教師を追加する
-          </Typography>
+          </Button>
         </Box>
       )}
     </Box>

--- a/frontend/features/AdminSchoolDetail/Presenter.tsx
+++ b/frontend/features/AdminSchoolDetail/Presenter.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import {
+  Box,
+  Breadcrumbs,
+  Card,
+  CardContent,
+  Divider,
+  Grid,
+  Tab,
+  Tabs,
+  Typography,
+} from "@mui/material";
+import SchoolIcon from "@mui/icons-material/School";
+import { colors } from "@/app/theme/colors";
+import type { AdminSchoolDetail } from "./types";
+
+type Props = {
+  school: AdminSchoolDetail;
+};
+
+type TabValue = "overview" | "teachers";
+
+export const Presenter = ({ school }: Props) => {
+  const [activeTab, setActiveTab] = useState<TabValue>("overview");
+
+  return (
+    <Box sx={{ p: 3 }}>
+      {/* パンくずナビ */}
+      <Breadcrumbs sx={{ mb: 2 }}>
+        <Link
+          href="/admin/schools"
+          style={{ color: colors.brand.primary, textDecoration: "none" }}
+        >
+          高校一覧
+        </Link>
+        <Typography color="text.primary">{school.name}</Typography>
+      </Breadcrumbs>
+
+      {/* ページタイトル */}
+      <Typography
+        variant="h5"
+        component="h1"
+        fontWeight={700}
+        sx={{ color: colors.text.primary, mb: 3 }}
+      >
+        {school.name}
+      </Typography>
+
+      {/* タブ */}
+      <Box sx={{ borderBottom: 1, borderColor: colors.border.light, mb: 3 }}>
+        <Tabs
+          value={activeTab}
+          onChange={(_, val: TabValue) => setActiveTab(val)}
+        >
+          <Tab label="概要" value="overview" />
+          <Tab label="教師管理" value="teachers" />
+        </Tabs>
+      </Box>
+
+      {/* 概要タブ */}
+      {activeTab === "overview" && (
+        <Card
+          elevation={0}
+          sx={{ border: `1px solid ${colors.border.light}`, borderRadius: 2 }}
+        >
+          <CardContent sx={{ p: 3 }}>
+            <Grid container spacing={3}>
+              <Grid size={{ xs: 12, sm: 6 }}>
+                <Typography
+                  variant="body2"
+                  sx={{ color: colors.text.muted, mb: 0.5 }}
+                >
+                  生徒数
+                </Typography>
+                <Typography variant="h6" fontWeight={700}>
+                  {school.student_count}
+                </Typography>
+              </Grid>
+              <Grid size={{ xs: 12, sm: 6 }}>
+                <Typography
+                  variant="body2"
+                  sx={{ color: colors.text.muted, mb: 0.5 }}
+                >
+                  教師数
+                </Typography>
+                <Typography variant="h6" fontWeight={700}>
+                  {school.teacher_count}
+                </Typography>
+              </Grid>
+            </Grid>
+            <Divider sx={{ my: 2 }} />
+            <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+              <Typography variant="body2" sx={{ color: colors.text.muted }}>
+                都道府県
+              </Typography>
+              <Typography variant="body1">{school.prefecture_name}</Typography>
+            </Box>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* 教師管理タブ */}
+      {activeTab === "teachers" && (
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            py: 10,
+            gap: 2,
+          }}
+        >
+          <SchoolIcon sx={{ fontSize: 64, color: colors.text.muted }} />
+          <Typography variant="h6" sx={{ color: colors.text.secondary }}>
+            まだ教師が登録されていません
+          </Typography>
+          <Typography variant="body2" sx={{ color: colors.text.muted }}>
+            最初の教師を追加する
+          </Typography>
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/frontend/features/AdminSchoolDetail/hooks.ts
+++ b/frontend/features/AdminSchoolDetail/hooks.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient } from "@/libs/http/apiClient";
+import type { AdminSchoolDetail } from "./types";
+
+export const useAdminSchoolDetail = (schoolId: number) => {
+  const [school, setSchool] = useState<AdminSchoolDetail | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    apiClient
+      .get<AdminSchoolDetail>(`/api/admin/schools/${schoolId}`)
+      .then((res) => setSchool(res.data))
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          router.push("/login");
+        }
+      });
+  }, [schoolId, router]);
+
+  return { school };
+};

--- a/frontend/features/AdminSchoolDetail/index.tsx
+++ b/frontend/features/AdminSchoolDetail/index.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Box, CircularProgress } from "@mui/material";
+import { apiClient } from "@/libs/http/apiClient";
+import { Presenter } from "./Presenter";
+import type { AdminSchoolDetail } from "./types";
+
+type Props = {
+  schoolId: number;
+};
+
+export const AdminSchoolDetail = ({ schoolId }: Props) => {
+  const [school, setSchool] = useState<AdminSchoolDetail | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    apiClient
+      .get<AdminSchoolDetail>(`/api/admin/schools/${schoolId}`)
+      .then((res) => setSchool(res.data))
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          router.push("/login");
+        }
+      });
+  }, [schoolId, router]);
+
+  if (!school) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return <Presenter school={school} />;
+};

--- a/frontend/features/AdminSchoolDetail/index.tsx
+++ b/frontend/features/AdminSchoolDetail/index.tsx
@@ -1,30 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import { Box, CircularProgress } from "@mui/material";
-import { apiClient } from "@/libs/http/apiClient";
 import { Presenter } from "./Presenter";
-import type { AdminSchoolDetail } from "./types";
+import { useAdminSchoolDetail } from "./hooks";
 
 type Props = {
   schoolId: number;
 };
 
 export const AdminSchoolDetail = ({ schoolId }: Props) => {
-  const [school, setSchool] = useState<AdminSchoolDetail | null>(null);
-  const router = useRouter();
-
-  useEffect(() => {
-    apiClient
-      .get<AdminSchoolDetail>(`/api/admin/schools/${schoolId}`)
-      .then((res) => setSchool(res.data))
-      .catch((err) => {
-        if (err.response?.status === 401) {
-          router.push("/login");
-        }
-      });
-  }, [schoolId, router]);
+  const { school } = useAdminSchoolDetail(schoolId);
 
   if (!school) {
     return (

--- a/frontend/features/AdminSchoolDetail/types.ts
+++ b/frontend/features/AdminSchoolDetail/types.ts
@@ -1,0 +1,7 @@
+export type AdminSchoolDetail = {
+  id: number;
+  name: string;
+  prefecture_name: string;
+  student_count: number;
+  teacher_count: number;
+};


### PR DESCRIPTION
## 概要

管理者ダッシュボードに高校詳細ページ（`/admin/schools/:id`）を新規実装しました。

issue: #39

---

## 変更内容

### 新規追加

| ファイル | 役割 |
|---|---|
| `features/AdminSchoolDetail/types.ts` | `AdminSchoolDetail` 型定義 |
| `features/AdminSchoolDetail/Presenter.tsx` | UI描画コンポーネント |
| `features/AdminSchoolDetail/Presenter.test.tsx` | Presenterユニットテスト（10件） |
| `features/AdminSchoolDetail/index.tsx` | データ取得Containerコンポーネント |
| `app/api/admin/schools/[schoolId]/route.ts` | Next.js APIプロキシ（→ Rails `GET /api/v1/admin/high_schools/:id`） |
| `app/(admin)/admin/(authenticated)/schools/[schoolId]/page.tsx` | ページルート |

### 画面構成

```
[パンくずナビ]  高校一覧 > ○○高校

[ページタイトル]  ○○高校

[タブ]  概要 | 教師管理

--- 概要タブ ---
生徒数 / 教師数 をカード形式で表示
都道府県名を表示

--- 教師管理タブ（骨格のみ） ---
SchoolIcon
まだ教師が登録されていません
「最初の教師を追加する」ボタン（disabled）
```

---

## 実装の注意点

- 教師CRUD用APIは未実装のため、「最初の教師を追加する」ボタンは `disabled` にしてあります

---

## テスト

- `features/AdminSchoolDetail/Presenter.test.tsx`（10件）
  - パンくずナビのリンク先検証
  - ページタイトル表示
  - タブの初期選択・切り替え
  - 概要タブの各データ表示
  - 教師管理タブの空状態UIボタン表示

## 動作確認
<img width="1094" height="481" alt="スクリーンショット 2026-04-04 12 23 11" src="https://github.com/user-attachments/assets/a9fe25f5-6df7-40f8-bdbc-0efaeb56c583" />
<img width="1085" height="607" alt="スクリーンショット 2026-04-04 12 23 17" src="https://github.com/user-attachments/assets/2ab012b3-e0d5-4b33-8cc6-5ebe72de2b6b" />


- [x] `/admin/schools` の「詳細」ボタンクリックで `/admin/schools/:id` に遷移する
- [x] パンくずの「高校一覧」リンクで一覧ページに戻れる
- [x] 概要タブに生徒数・教師数・都道府県が表示される
- [x] 教師管理タブに空状態UIと「最初の教師を追加する」ボタン（disabled）が表示される
- [x] `npx vitest run features/AdminSchoolDetail/` が全件グリーンになる
