### PR TITLE
[Rails]個人情報シリアライザ改修

### DIFF
--- a/rails/app/serializers/current_user_serializer.rb
+++ b/rails/app/serializers/current_user_serializer.rb
@@ -3,9 +3,9 @@
 class CurrentUserSerializer < ActiveModel::Serializer
   attributes :id, :name, :name_kana, :email, :profile_completed
 
+  has_one :user_personal_info, serializer: UserPersonalInfoSerializer
   belongs_to :user_role
   belongs_to :high_school
-  belongs_to :user_personal_info
 
   def profile_completed
     object.profile_completed?

--- a/rails/app/serializers/user_personal_info_serializer.rb
+++ b/rails/app/serializers/user_personal_info_serializer.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class UserPersonalInfoSerializer < ActiveModel::Serializer
+  attributes :id, :phone_number, :birthday, :gender
+end


### PR DESCRIPTION
## 概要
https://www.notion.so/Rails-3302946467fd80e38e66c23e7f26030b

ユーザーの個人情報を表示する際のリレーション関係のあるUserPersonalInfoモデルのシリアライザを作成(実はCurrentUserSerializerにリレーションが書かれていたが、UserPersonalInfoSerializerが存在していなかったので作成した。合わせてリレーション関係が間違っていたので修正した)
<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細
<img width="2874" height="1618" alt="image" src="https://github.com/user-attachments/assets/c0397ef0-9eda-4ebd-8b21-5289dae9aeff" />


<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

## 動作確認

<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
