### PR TITLE
issue-41 高校詳細画面の教師管理 API を実装（一覧・追加・編集）

### DIFF
--- a/rails/app/controllers/api/v1/admin/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/admin/teachers_controller.rb
@@ -18,14 +18,8 @@ module Api
 
         def create
           school = HighSchool.find(params[:high_school_id])
-          user = ::Admin::CreateTeacherService.new(
-            school: school,
-            name: teacher_params[:name],
-            email: teacher_params[:email]
-          ).call
+          user = ::Admin::CreateTeacherService.new(school: school, email: create_params[:email]).call
           render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :created
-        rescue ::Admin::CreateTeacherService::ValidationError => e
-          render json: { errors: [e.message] }, status: :unprocessable_content
         rescue ActiveRecord::RecordInvalid => e
           render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
         end
@@ -33,21 +27,20 @@ module Api
         def update
           school = HighSchool.find(params[:high_school_id])
           user = school.users.teachers.find(params[:id])
-          user = ::Admin::UpdateTeacherService.new(user: user, params: teacher_params).call
+          user = ::Admin::UpdateTeacherService.new(user: user, params: update_params).call
           render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :ok
-        rescue ::Admin::UpdateTeacherService::ValidationError => e
-          render json: { errors: [e.message] }, status: :unprocessable_content
         rescue ActiveRecord::RecordInvalid => e
           render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
         end
 
         private
 
-        def teacher_params
-          params.permit(
-            :name, :email, :password, :password_confirmation,
-            :grade_scope, :manage_other_teachers, grade_ids: []
-          )
+        def create_params
+          params.permit(:email)
+        end
+
+        def update_params
+          params.permit(:name, :email, :grade_scope, :manage_other_teachers, grade_ids: [])
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/admin/teachers_controller.rb
@@ -33,45 +33,15 @@ module Api
         def update
           school = HighSchool.find(params[:high_school_id])
           user = school.users.teachers.find(params[:id])
-
-          if teacher_params[:password].present? && teacher_params[:password_confirmation].blank?
-            return render json: { errors: ['パスワード確認を入力してください'] }, status: :unprocessable_content
-          end
-
-          ActiveRecord::Base.transaction do
-            update_user_attributes(user)
-            update_permission_attributes(user)
-            update_teacher_grades(user)
-
-            user.reload
-            render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :ok
-          end
+          user = ::Admin::UpdateTeacherService.new(user: user, params: teacher_params).call
+          render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :ok
+        rescue ::Admin::UpdateTeacherService::ValidationError => e
+          render json: { errors: [e.message] }, status: :unprocessable_content
         rescue ActiveRecord::RecordInvalid => e
           render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
         end
 
         private
-
-        def update_user_attributes(user)
-          user_attrs = teacher_params.slice(:name, :email).compact
-          if teacher_params[:password].present?
-            user_attrs[:password] = teacher_params[:password]
-            user_attrs[:password_confirmation] = teacher_params[:password_confirmation]
-          end
-          user.update!(user_attrs) if user_attrs.present?
-        end
-
-        def update_permission_attributes(user)
-          permission_attrs = teacher_params.slice(:grade_scope, :manage_other_teachers).compact
-          user.teacher_permission.update!(permission_attrs) if permission_attrs.present?
-        end
-
-        def update_teacher_grades(user)
-          return unless teacher_params.key?(:grade_ids)
-
-          user.teacher_grades.destroy_all
-          teacher_params[:grade_ids].each { |grade_id| user.teacher_grades.create!(grade_id: grade_id) }
-        end
 
         def teacher_params
           params.require(:teacher).permit(

--- a/rails/app/controllers/api/v1/admin/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/admin/teachers_controller.rb
@@ -44,7 +44,7 @@ module Api
         private
 
         def teacher_params
-          params.require(:teacher).permit(
+          params.permit(
             :name, :email, :password, :password_confirmation,
             :grade_scope, :manage_other_teachers, grade_ids: []
           )

--- a/rails/app/controllers/api/v1/admin/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/admin/teachers_controller.rb
@@ -19,8 +19,12 @@ module Api
         def create
           school = HighSchool.find(params[:high_school_id])
 
+          if teacher_params[:name].blank?
+            return render json: { errors: ['名前を入力してください'] }, status: :unprocessable_content
+          end
+
           ActiveRecord::Base.transaction do
-            teacher_role = UserRole.find_by!(name: 'teacher')
+            teacher_role = UserRole.find_or_create_by!(name: :teacher)
             password = SecureRandom.hex(16)
             user = User.create!(
               name: teacher_params[:name],
@@ -37,39 +41,51 @@ module Api
             render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :created
           end
         rescue ActiveRecord::RecordInvalid => e
-          render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
         end
 
         def update
           school = HighSchool.find(params[:high_school_id])
           user = school.users.teachers.find(params[:id])
 
+          if teacher_params[:password].present? && teacher_params[:password_confirmation].blank?
+            return render json: { errors: ['パスワード確認を入力してください'] }, status: :unprocessable_content
+          end
+
           ActiveRecord::Base.transaction do
-            user_attrs = teacher_params.slice(:name, :email).compact
-
-            if teacher_params[:password].present?
-              user_attrs[:password] = teacher_params[:password]
-              user_attrs[:password_confirmation] = teacher_params[:password_confirmation]
-            end
-
-            user.update!(user_attrs) if user_attrs.present?
-
-            permission_attrs = teacher_params.slice(:grade_scope, :manage_other_teachers).compact
-            user.teacher_permission.update!(permission_attrs) if permission_attrs.present?
-
-            if teacher_params.key?(:grade_ids)
-              user.teacher_grades.destroy_all
-              teacher_params[:grade_ids].each { |grade_id| user.teacher_grades.create!(grade_id: grade_id) }
-            end
+            update_user_attributes(user)
+            update_permission_attributes(user)
+            update_teacher_grades(user)
 
             user.reload
             render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :ok
           end
         rescue ActiveRecord::RecordInvalid => e
-          render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
+          render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
         end
 
         private
+
+        def update_user_attributes(user)
+          user_attrs = teacher_params.slice(:name, :email).compact
+          if teacher_params[:password].present?
+            user_attrs[:password] = teacher_params[:password]
+            user_attrs[:password_confirmation] = teacher_params[:password_confirmation]
+          end
+          user.update!(user_attrs) if user_attrs.present?
+        end
+
+        def update_permission_attributes(user)
+          permission_attrs = teacher_params.slice(:grade_scope, :manage_other_teachers).compact
+          user.teacher_permission.update!(permission_attrs) if permission_attrs.present?
+        end
+
+        def update_teacher_grades(user)
+          return unless teacher_params.key?(:grade_ids)
+
+          user.teacher_grades.destroy_all
+          teacher_params[:grade_ids].each { |grade_id| user.teacher_grades.create!(grade_id: grade_id) }
+        end
 
         def teacher_params
           params.require(:teacher).permit(

--- a/rails/app/controllers/api/v1/admin/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/admin/teachers_controller.rb
@@ -18,28 +18,14 @@ module Api
 
         def create
           school = HighSchool.find(params[:high_school_id])
-
-          if teacher_params[:name].blank?
-            return render json: { errors: ['名前を入力してください'] }, status: :unprocessable_content
-          end
-
-          ActiveRecord::Base.transaction do
-            teacher_role = UserRole.find_or_create_by!(name: :teacher)
-            password = SecureRandom.hex(16)
-            user = User.create!(
-              name: teacher_params[:name],
-              email: teacher_params[:email],
-              password: password,
-              password_confirmation: password,
-              user_role: teacher_role,
-              high_school: school
-            )
-            user.create_teacher_permission!(grade_scope: :own_grade, manage_other_teachers: false)
-            user.send_reset_password_instructions
-
-            user.reload
-            render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :created
-          end
+          user = ::Admin::CreateTeacherService.new(
+            school: school,
+            name: teacher_params[:name],
+            email: teacher_params[:email]
+          ).call
+          render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :created
+        rescue ::Admin::CreateTeacherService::ValidationError => e
+          render json: { errors: [e.message] }, status: :unprocessable_content
         rescue ActiveRecord::RecordInvalid => e
           render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
         end

--- a/rails/app/controllers/api/v1/admin/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/admin/teachers_controller.rb
@@ -15,6 +15,42 @@ module Api
             )
           }
         end
+
+        def create
+          school = HighSchool.find(params[:high_school_id])
+
+          ActiveRecord::Base.transaction do
+            teacher_role = UserRole.find_by!(name: 'teacher')
+            password = SecureRandom.hex(16)
+            user = User.create!(
+              name: teacher_params[:name],
+              email: teacher_params[:email],
+              password: password,
+              password_confirmation: password,
+              user_role: teacher_role,
+              high_school: school
+            )
+            user.create_teacher_permission!(grade_scope: :own_grade, manage_other_teachers: false)
+            user.send_reset_password_instructions
+
+            user.reload
+            render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :created
+          end
+        rescue ActiveRecord::RecordInvalid => e
+          render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
+        end
+
+        def update
+        end
+
+        private
+
+        def teacher_params
+          params.require(:teacher).permit(
+            :name, :email, :password, :password_confirmation,
+            :grade_scope, :manage_other_teachers, grade_ids: []
+          )
+        end
       end
     end
   end

--- a/rails/app/controllers/api/v1/admin/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/admin/teachers_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class TeachersController < BaseController
+        def index
+          school = HighSchool.find(params[:high_school_id])
+          teachers = school.users.teachers.includes(:teacher_permission, :grades)
+
+          render json: {
+            teachers: ActiveModelSerializers::SerializableResource.new(
+              teachers,
+              each_serializer: ::Admin::TeacherSerializer
+            )
+          }
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/admin/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/admin/teachers_controller.rb
@@ -19,6 +19,7 @@ module Api
         def create
           school = HighSchool.find(params[:high_school_id])
           user = ::Admin::CreateTeacherService.new(school: school, email: create_params[:email]).call
+
           render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :created
         rescue ActiveRecord::RecordInvalid => e
           render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
@@ -28,6 +29,7 @@ module Api
           school = HighSchool.find(params[:high_school_id])
           user = school.users.teachers.find(params[:id])
           user = ::Admin::UpdateTeacherService.new(user: user, params: update_params).call
+
           render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :ok
         rescue ActiveRecord::RecordInvalid => e
           render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content

--- a/rails/app/controllers/api/v1/admin/teachers_controller.rb
+++ b/rails/app/controllers/api/v1/admin/teachers_controller.rb
@@ -41,6 +41,32 @@ module Api
         end
 
         def update
+          school = HighSchool.find(params[:high_school_id])
+          user = school.users.teachers.find(params[:id])
+
+          ActiveRecord::Base.transaction do
+            user_attrs = teacher_params.slice(:name, :email).compact
+
+            if teacher_params[:password].present?
+              user_attrs[:password] = teacher_params[:password]
+              user_attrs[:password_confirmation] = teacher_params[:password_confirmation]
+            end
+
+            user.update!(user_attrs) if user_attrs.present?
+
+            permission_attrs = teacher_params.slice(:grade_scope, :manage_other_teachers).compact
+            user.teacher_permission.update!(permission_attrs) if permission_attrs.present?
+
+            if teacher_params.key?(:grade_ids)
+              user.teacher_grades.destroy_all
+              teacher_params[:grade_ids].each { |grade_id| user.teacher_grades.create!(grade_id: grade_id) }
+            end
+
+            user.reload
+            render json: { teacher: ::Admin::TeacherSerializer.new(user) }, status: :ok
+          end
+        rescue ActiveRecord::RecordInvalid => e
+          render json: { errors: e.record.errors.full_messages }, status: :unprocessable_entity
         end
 
         private

--- a/rails/app/mailers/auth_mailer.rb
+++ b/rails/app/mailers/auth_mailer.rb
@@ -6,11 +6,13 @@ class AuthMailer < Devise::Mailer
 
   def send_email(user, token)
     url = "#{ENV.fetch('FRONTEND_URL', nil)}/password/reset/#{token}?email=#{user.email}"
+
     mail(to: user.email, subject: 'パスワード再設定のご案内', body: "パスワード再設定はこちらのリンクからお願いします： #{url}")
   end
 
   def invite_teacher(user, token)
     url = "#{ENV.fetch('FRONTEND_URL', nil)}/password/reset/#{token}?email=#{user.email}"
+
     mail(
       to: user.email,
       subject: 'edu platform へのご招待',

--- a/rails/app/mailers/auth_mailer.rb
+++ b/rails/app/mailers/auth_mailer.rb
@@ -8,4 +8,13 @@ class AuthMailer < Devise::Mailer
     url = "#{ENV.fetch('FRONTEND_URL', nil)}/password/reset/#{token}?email=#{user.email}"
     mail(to: user.email, subject: 'パスワード再設定のご案内', body: "パスワード再設定はこちらのリンクからお願いします： #{url}")
   end
+
+  def invite_teacher(user, token)
+    url = "#{ENV.fetch('FRONTEND_URL', nil)}/password/reset/#{token}?email=#{user.email}"
+    mail(
+      to: user.email,
+      subject: 'edu platform へのご招待',
+      body: "edu platform に招待されました。\n以下のリンクからパスワードを設定してください。\n\n#{url}"
+    )
+  end
 end

--- a/rails/app/serializers/admin/teacher_serializer.rb
+++ b/rails/app/serializers/admin/teacher_serializer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Admin
+  class TeacherSerializer < ActiveModel::Serializer
+    attributes :id, :name, :email, :grade_scope, :manage_other_teachers, :grades
+
+    def grade_scope
+      object.teacher_permission&.grade_scope
+    end
+
+    def manage_other_teachers
+      object.teacher_permission&.manage_other_teachers
+    end
+
+    def grades
+      object.grades.map { |g| { id: g.id, name: g.display_name } }
+    end
+  end
+end

--- a/rails/app/services/admin/create_teacher_service.rb
+++ b/rails/app/services/admin/create_teacher_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Admin
+  class CreateTeacherService
+    class ValidationError < StandardError; end
+
+    def initialize(school:, name:, email:)
+      @school = school
+      @name = name
+      @email = email
+    end
+
+    def call
+      raise ValidationError, '名前を入力してください' if @name.blank?
+
+      ActiveRecord::Base.transaction do
+        teacher_role = UserRole.find_or_create_by!(name: :teacher)
+        password = SecureRandom.hex(16)
+        user = User.create!(
+          name: @name,
+          email: @email,
+          password: password,
+          password_confirmation: password,
+          user_role: teacher_role,
+          high_school: @school
+        )
+        user.create_teacher_permission!(grade_scope: :own_grade, manage_other_teachers: false)
+        user.send_reset_password_instructions
+        user.reload
+      end
+    end
+  end
+end

--- a/rails/app/services/admin/create_teacher_service.rb
+++ b/rails/app/services/admin/create_teacher_service.rb
@@ -2,22 +2,17 @@
 
 module Admin
   class CreateTeacherService
-    class ValidationError < StandardError; end
-
-    def initialize(school:, name:, email:)
+    def initialize(school:, email:)
       @school = school
-      @name = name
       @email = email
     end
 
     def call
-      raise ValidationError, '名前を入力してください' if @name.blank?
-
       ActiveRecord::Base.transaction do
         teacher_role = UserRole.find_or_create_by!(name: :teacher)
         password = SecureRandom.hex(16)
         user = User.create!(
-          name: @name,
+          name: @email.split('@').first,
           email: @email,
           password: password,
           password_confirmation: password,

--- a/rails/app/services/admin/create_teacher_service.rb
+++ b/rails/app/services/admin/create_teacher_service.rb
@@ -20,7 +20,8 @@ module Admin
           high_school: @school
         )
         user.create_teacher_permission!(grade_scope: :own_grade, manage_other_teachers: false)
-        user.send_reset_password_instructions
+        token = user.send(:set_reset_password_token)
+        AuthMailer.invite_teacher(user, token).deliver_later
         user.reload
       end
     end

--- a/rails/app/services/admin/create_teacher_service.rb
+++ b/rails/app/services/admin/create_teacher_service.rb
@@ -19,9 +19,12 @@ module Admin
           user_role: teacher_role,
           high_school: @school
         )
+
         user.create_teacher_permission!(grade_scope: :own_grade, manage_other_teachers: false)
+
         token = user.send(:set_reset_password_token)
         AuthMailer.invite_teacher(user, token).deliver_later
+
         user.reload
       end
     end

--- a/rails/app/services/admin/create_teacher_service.rb
+++ b/rails/app/services/admin/create_teacher_service.rb
@@ -20,7 +20,7 @@ module Admin
           high_school: @school
         )
 
-        user.create_teacher_permission!(grade_scope: :own_grade, manage_other_teachers: false)
+        user.create_teacher_permission!(grade_scope: :own_grade, manage_other_teachers: true)
 
         token = user.send(:set_reset_password_token)
         AuthMailer.invite_teacher(user, token).deliver_later

--- a/rails/app/services/admin/update_teacher_service.rb
+++ b/rails/app/services/admin/update_teacher_service.rb
@@ -12,6 +12,7 @@ module Admin
         update_user_attributes
         update_permission_attributes
         update_teacher_grades
+
         @user.reload
       end
     end

--- a/rails/app/services/admin/update_teacher_service.rb
+++ b/rails/app/services/admin/update_teacher_service.rb
@@ -2,16 +2,12 @@
 
 module Admin
   class UpdateTeacherService
-    class ValidationError < StandardError; end
-
     def initialize(user:, params:)
       @user = user
       @params = params
     end
 
     def call
-      raise ValidationError, 'パスワード確認を入力してください' if @params[:password].present? && @params[:password_confirmation].blank?
-
       ActiveRecord::Base.transaction do
         update_user_attributes
         update_permission_attributes
@@ -24,10 +20,6 @@ module Admin
 
     def update_user_attributes
       user_attrs = @params.slice(:name, :email).compact
-      if @params[:password].present?
-        user_attrs[:password] = @params[:password]
-        user_attrs[:password_confirmation] = @params[:password_confirmation]
-      end
       @user.update!(user_attrs) if user_attrs.present?
     end
 

--- a/rails/app/services/admin/update_teacher_service.rb
+++ b/rails/app/services/admin/update_teacher_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Admin
+  class UpdateTeacherService
+    class ValidationError < StandardError; end
+
+    def initialize(user:, params:)
+      @user = user
+      @params = params
+    end
+
+    def call
+      raise ValidationError, 'パスワード確認を入力してください' if @params[:password].present? && @params[:password_confirmation].blank?
+
+      ActiveRecord::Base.transaction do
+        update_user_attributes
+        update_permission_attributes
+        update_teacher_grades
+        @user.reload
+      end
+    end
+
+    private
+
+    def update_user_attributes
+      user_attrs = @params.slice(:name, :email).compact
+      if @params[:password].present?
+        user_attrs[:password] = @params[:password]
+        user_attrs[:password_confirmation] = @params[:password_confirmation]
+      end
+      @user.update!(user_attrs) if user_attrs.present?
+    end
+
+    def update_permission_attributes
+      permission_attrs = @params.slice(:grade_scope, :manage_other_teachers).compact
+      @user.teacher_permission.update!(permission_attrs) if permission_attrs.present?
+    end
+
+    def update_teacher_grades
+      return unless @params.key?(:grade_ids)
+
+      @user.teacher_grades.destroy_all
+      @params[:grade_ids].each { |grade_id| @user.teacher_grades.create!(grade_id: grade_id) }
+    end
+  end
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -38,7 +38,9 @@ Rails.application.routes.draw do
 
       namespace :admin do
         resource :dashboard, only: :show
-        resources :high_schools, only: [:index, :show]
+        resources :high_schools, only: [:index, :show] do
+          resources :teachers, only: [:index, :create, :update]
+        end
         resources :courses do
           resources :units do
             resource :import_questions, only: :create

--- a/rails/spec/requests/api/v1/admin/teachers_spec.rb
+++ b/rails/spec/requests/api/v1/admin/teachers_spec.rb
@@ -139,18 +139,6 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
         expect(teacher_data['name']).to eq('田中太郎')
         expect(teacher_data['email']).to eq('tanaka@example.com')
       end
-
-      it 'User が作成される' do
-        expect { subject }.to change(User, :count).by(1)
-      end
-
-      it 'TeacherPermission がデフォルト値で作成される' do
-        subject
-        user = User.find_by(email: 'tanaka@example.com')
-        expect(user.teacher_permission).to be_present
-        expect(user.teacher_permission.grade_scope).to eq('own_grade')
-        expect(user.teacher_permission.manage_other_teachers).to be(false)
-      end
     end
 
     context '異常系 - email 重複' do
@@ -250,30 +238,6 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
         expect(teacher_data['email']).to eq('updated@example.com')
         expect(teacher_data['grade_scope']).to eq('all_grades')
         expect(teacher_data['manage_other_teachers']).to be(true)
-      end
-
-      it 'TeacherGrade が差分更新される' do
-        subject
-        expect(teacher.reload.grades.pluck(:id)).to contain_exactly(grade1.id, grade2.id)
-      end
-    end
-
-    context '正常系 - grade_ids 省略時は既存 TeacherGrade を保持' do
-      let(:params_without_grade_ids) do
-        {
-          teacher: {
-            name: '更新太郎',
-            grade_scope: 'all_grades',
-            manage_other_teachers: false
-          }
-        }.to_json
-      end
-
-      it '既存の TeacherGrade が変わらない' do
-        patch "/api/v1/admin/high_schools/#{school.id}/teachers/#{teacher.id}",
-              params: params_without_grade_ids,
-              headers: headers.merge('Cookie' => cookie)
-        expect(teacher.reload.grades.pluck(:id)).to eq([grade1.id])
       end
     end
 

--- a/rails/spec/requests/api/v1/admin/teachers_spec.rb
+++ b/rails/spec/requests/api/v1/admin/teachers_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
         user = User.find_by(email: 'tanaka@example.com')
         expect(user.teacher_permission).to be_present
         expect(user.teacher_permission.grade_scope).to eq('own_grade')
-        expect(user.teacher_permission.manage_other_teachers).to eq(false)
+        expect(user.teacher_permission.manage_other_teachers).to be(false)
       end
     end
 
@@ -249,12 +249,12 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
         expect(teacher_data['name']).to eq('更新太郎')
         expect(teacher_data['email']).to eq('updated@example.com')
         expect(teacher_data['grade_scope']).to eq('all_grades')
-        expect(teacher_data['manage_other_teachers']).to eq(true)
+        expect(teacher_data['manage_other_teachers']).to be(true)
       end
 
       it 'TeacherGrade が差分更新される' do
         subject
-        expect(teacher.reload.grades.pluck(:id)).to match_array([grade1.id, grade2.id])
+        expect(teacher.reload.grades.pluck(:id)).to contain_exactly(grade1.id, grade2.id)
       end
     end
 

--- a/rails/spec/requests/api/v1/admin/teachers_spec.rb
+++ b/rails/spec/requests/api/v1/admin/teachers_spec.rb
@@ -205,4 +205,152 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
       end
     end
   end
+
+  describe 'PATCH /api/v1/admin/high_schools/:high_school_id/teachers/:id' do
+    let!(:admin_user) { create(:user, :admin, high_school: nil) }
+    let!(:school)     { create(:high_school) }
+    let!(:grade1)     { create(:grade, high_school: school, year: 1) }
+    let!(:grade2)     { create(:grade, high_school: school, year: 2) }
+    let!(:teacher) do
+      user = create(:user, :teacher, high_school: school, grade: nil)
+      create(:teacher_permission, user: user, grade_scope: :own_grade, manage_other_teachers: false)
+      create(:teacher_grade, user: user, grade: grade1)
+      user
+    end
+    let(:cookie) { login_and_get_cookie(admin_user) }
+
+    let(:valid_params) do
+      {
+        teacher: {
+          name: '更新太郎',
+          email: 'updated@example.com',
+          grade_scope: 'all_grades',
+          manage_other_teachers: true,
+          grade_ids: [grade1.id, grade2.id]
+        }
+      }.to_json
+    end
+
+    context '正常系' do
+      subject do
+        patch "/api/v1/admin/high_schools/#{school.id}/teachers/#{teacher.id}",
+              params: valid_params,
+              headers: headers.merge('Cookie' => cookie)
+      end
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '更新した teacher オブジェクトが返される' do
+        subject
+        teacher_data = response.parsed_body['teacher']
+        expect(teacher_data['name']).to eq('更新太郎')
+        expect(teacher_data['email']).to eq('updated@example.com')
+        expect(teacher_data['grade_scope']).to eq('all_grades')
+        expect(teacher_data['manage_other_teachers']).to eq(true)
+      end
+
+      it 'TeacherGrade が差分更新される' do
+        subject
+        expect(teacher.reload.grades.pluck(:id)).to match_array([grade1.id, grade2.id])
+      end
+    end
+
+    context '正常系 - grade_ids 省略時は既存 TeacherGrade を保持' do
+      let(:params_without_grade_ids) do
+        {
+          teacher: {
+            name: '更新太郎',
+            grade_scope: 'all_grades',
+            manage_other_teachers: false
+          }
+        }.to_json
+      end
+
+      it '既存の TeacherGrade が変わらない' do
+        patch "/api/v1/admin/high_schools/#{school.id}/teachers/#{teacher.id}",
+              params: params_without_grade_ids,
+              headers: headers.merge('Cookie' => cookie)
+        expect(teacher.reload.grades.pluck(:id)).to eq([grade1.id])
+      end
+    end
+
+    context '正常系 - password + password_confirmation 送信時にパスワードが更新される' do
+      let(:password_params) do
+        {
+          teacher: {
+            password: 'newpassword123',
+            password_confirmation: 'newpassword123'
+          }
+        }.to_json
+      end
+
+      it '200が返される' do
+        patch "/api/v1/admin/high_schools/#{school.id}/teachers/#{teacher.id}",
+              params: password_params,
+              headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '異常系 - password のみで password_confirmation なし' do
+      let(:invalid_password_params) do
+        {
+          teacher: {
+            password: 'newpassword123'
+          }
+        }.to_json
+      end
+
+      it '422が返される' do
+        patch "/api/v1/admin/high_schools/#{school.id}/teachers/#{teacher.id}",
+              params: invalid_password_params,
+              headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context '異常系 - email 重複' do
+      before { create(:user, :teacher, email: 'updated@example.com', high_school: school, grade: nil) }
+
+      it '422が返される' do
+        patch "/api/v1/admin/high_schools/#{school.id}/teachers/#{teacher.id}",
+              params: valid_params,
+              headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context '異常系 - 対象教師が存在しない' do
+      it '404が返される' do
+        patch "/api/v1/admin/high_schools/#{school.id}/teachers/0",
+              params: valid_params,
+              headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context '異常系 - 未認証アクセス' do
+      it '401が返される' do
+        patch "/api/v1/admin/high_schools/#{school.id}/teachers/#{teacher.id}",
+              params: valid_params,
+              headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+
+      it '403が返される' do
+        student_cookie = login_and_get_cookie(student_user)
+        patch "/api/v1/admin/high_schools/#{school.id}/teachers/#{teacher.id}",
+              params: valid_params,
+              headers: headers.merge('Cookie' => student_cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end

--- a/rails/spec/requests/api/v1/admin/teachers_spec.rb
+++ b/rails/spec/requests/api/v1/admin/teachers_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/admin/high_schools/:high_school_id/teachers' do
+    context '正常系' do
+      subject do
+        get "/api/v1/admin/high_schools/#{school.id}/teachers",
+            headers: headers.merge('Cookie' => cookie)
+      end
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:school)     { create(:high_school) }
+      let!(:grade)      { create(:grade, high_school: school, year: 1) }
+      let!(:teacher) do
+        user = create(:user, :teacher, high_school: school, grade: nil)
+        create(:teacher_permission, user: user, grade_scope: :all_grades, manage_other_teachers: false)
+        create(:teacher_grade, user: user, grade: grade)
+        user
+      end
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'teachers キーが含まれる' do
+        subject
+        expect(response.parsed_body).to have_key('teachers')
+      end
+
+      it '各教師に必要なフィールドが含まれる' do
+        subject
+        teacher_data = response.parsed_body['teachers'].first
+        expect(teacher_data.keys).to include('id', 'name', 'email', 'grade_scope', 'manage_other_teachers', 'grades')
+      end
+
+      it 'grade_scope が文字列で返される' do
+        subject
+        teacher_data = response.parsed_body['teachers'].first
+        expect(teacher_data['grade_scope']).to eq('all_grades')
+      end
+
+      it 'grades[].name が display_name で返される' do
+        subject
+        grade_data = response.parsed_body['teachers'].first['grades'].first
+        expect(grade_data['name']).to eq(grade.display_name)
+      end
+
+      it '対象高校の教師のみ返される' do
+        other_school = create(:high_school)
+        create(:user, :teacher, high_school: other_school, grade: nil)
+        subject
+        ids = response.parsed_body['teachers'].pluck('id')
+        expect(ids).to include(teacher.id)
+        expect(ids.length).to eq(1)
+      end
+    end
+
+    context '異常系 - 未認証アクセス' do
+      let!(:school) { create(:high_school) }
+
+      it '401が返される' do
+        get "/api/v1/admin/high_schools/#{school.id}/teachers", headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+      let!(:school)       { create(:high_school) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(student_user)
+        get "/api/v1/admin/high_schools/#{school.id}/teachers",
+            headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context '異常系 - 存在しない high_school_id' do
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it '404が返される' do
+        get '/api/v1/admin/high_schools/0/teachers',
+            headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/admin/teachers_spec.rb
+++ b/rails/spec/requests/api/v1/admin/teachers_spec.rb
@@ -109,19 +109,13 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
   describe 'POST /api/v1/admin/high_schools/:high_school_id/teachers' do
     let!(:admin_user) { create(:user, :admin, high_school: nil) }
     let!(:school)     { create(:high_school) }
-    let!(:grade)      { create(:grade, high_school: school, year: 1) }
     let(:cookie)      { login_and_get_cookie(admin_user) }
 
     let(:valid_params) do
       {
         teacher: {
           name: '田中太郎',
-          email: 'tanaka@example.com',
-          password: 'abc123xyz',
-          password_confirmation: 'abc123xyz',
-          grade_scope: 'all_grades',
-          manage_other_teachers: false,
-          grade_ids: [grade.id]
+          email: 'tanaka@example.com'
         }
       }.to_json
     end
@@ -150,12 +144,12 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
         expect { subject }.to change(User, :count).by(1)
       end
 
-      it 'TeacherPermission が作成される' do
-        expect { subject }.to change(TeacherPermission, :count).by(1)
-      end
-
-      it 'TeacherGrade が作成される' do
-        expect { subject }.to change(TeacherGrade, :count).by(1)
+      it 'TeacherPermission がデフォルト値で作成される' do
+        subject
+        user = User.find_by(email: 'tanaka@example.com')
+        expect(user.teacher_permission).to be_present
+        expect(user.teacher_permission.grade_scope).to eq('own_grade')
+        expect(user.teacher_permission.manage_other_teachers).to eq(false)
       end
     end
 
@@ -179,16 +173,7 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
 
     context '異常系 - 必須パラメータ欠損 (name なし)' do
       let(:invalid_params) do
-        {
-          teacher: {
-            email: 'tanaka@example.com',
-            password: 'abc123xyz',
-            password_confirmation: 'abc123xyz',
-            grade_scope: 'all_grades',
-            manage_other_teachers: false,
-            grade_ids: [grade.id]
-          }
-        }.to_json
+        { teacher: { email: 'tanaka@example.com' } }.to_json
       end
 
       it '422が返される' do

--- a/rails/spec/requests/api/v1/admin/teachers_spec.rb
+++ b/rails/spec/requests/api/v1/admin/teachers_spec.rb
@@ -113,10 +113,8 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
 
     let(:valid_params) do
       {
-        teacher: {
-          name: '田中太郎',
-          email: 'tanaka@example.com'
-        }
+        name: '田中太郎',
+        email: 'tanaka@example.com'
       }.to_json
     end
 
@@ -161,7 +159,7 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
 
     context '異常系 - 必須パラメータ欠損 (name なし)' do
       let(:invalid_params) do
-        { teacher: { email: 'tanaka@example.com' } }.to_json
+        { email: 'tanaka@example.com' }.to_json
       end
 
       it '422が返される' do
@@ -209,13 +207,11 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
 
     let(:valid_params) do
       {
-        teacher: {
-          name: '更新太郎',
-          email: 'updated@example.com',
-          grade_scope: 'all_grades',
-          manage_other_teachers: true,
-          grade_ids: [grade1.id, grade2.id]
-        }
+        name: '更新太郎',
+        email: 'updated@example.com',
+        grade_scope: 'all_grades',
+        manage_other_teachers: true,
+        grade_ids: [grade1.id, grade2.id]
       }.to_json
     end
 
@@ -244,10 +240,8 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
     context '正常系 - password + password_confirmation 送信時にパスワードが更新される' do
       let(:password_params) do
         {
-          teacher: {
-            password: 'newpassword123',
-            password_confirmation: 'newpassword123'
-          }
+          password: 'newpassword123',
+          password_confirmation: 'newpassword123'
         }.to_json
       end
 
@@ -262,9 +256,7 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
     context '異常系 - password のみで password_confirmation なし' do
       let(:invalid_password_params) do
         {
-          teacher: {
-            password: 'newpassword123'
-          }
+          password: 'newpassword123'
         }.to_json
       end
 

--- a/rails/spec/requests/api/v1/admin/teachers_spec.rb
+++ b/rails/spec/requests/api/v1/admin/teachers_spec.rb
@@ -112,10 +112,7 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
     let(:cookie)      { login_and_get_cookie(admin_user) }
 
     let(:valid_params) do
-      {
-        name: '田中太郎',
-        email: 'tanaka@example.com'
-      }.to_json
+      { email: 'tanaka@example.com' }.to_json
     end
 
     context '正常系' do
@@ -134,7 +131,7 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
         subject
         teacher_data = response.parsed_body['teacher']
         expect(teacher_data.keys).to include('id', 'name', 'email', 'grade_scope', 'manage_other_teachers', 'grades')
-        expect(teacher_data['name']).to eq('田中太郎')
+        expect(teacher_data['name']).to eq('tanaka')
         expect(teacher_data['email']).to eq('tanaka@example.com')
       end
     end
@@ -154,19 +151,6 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
              params: valid_params,
              headers: headers.merge('Cookie' => cookie)
         expect(response.parsed_body).to have_key('errors')
-      end
-    end
-
-    context '異常系 - 必須パラメータ欠損 (name なし)' do
-      let(:invalid_params) do
-        { email: 'tanaka@example.com' }.to_json
-      end
-
-      it '422が返される' do
-        post "/api/v1/admin/high_schools/#{school.id}/teachers",
-             params: invalid_params,
-             headers: headers.merge('Cookie' => cookie)
-        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 
@@ -234,37 +218,6 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
         expect(teacher_data['email']).to eq('updated@example.com')
         expect(teacher_data['grade_scope']).to eq('all_grades')
         expect(teacher_data['manage_other_teachers']).to be(true)
-      end
-    end
-
-    context '正常系 - password + password_confirmation 送信時にパスワードが更新される' do
-      let(:password_params) do
-        {
-          password: 'newpassword123',
-          password_confirmation: 'newpassword123'
-        }.to_json
-      end
-
-      it '200が返される' do
-        patch "/api/v1/admin/high_schools/#{school.id}/teachers/#{teacher.id}",
-              params: password_params,
-              headers: headers.merge('Cookie' => cookie)
-        expect(response).to have_http_status(:ok)
-      end
-    end
-
-    context '異常系 - password のみで password_confirmation なし' do
-      let(:invalid_password_params) do
-        {
-          password: 'newpassword123'
-        }.to_json
-      end
-
-      it '422が返される' do
-        patch "/api/v1/admin/high_schools/#{school.id}/teachers/#{teacher.id}",
-              params: invalid_password_params,
-              headers: headers.merge('Cookie' => cookie)
-        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 

--- a/rails/spec/requests/api/v1/admin/teachers_spec.rb
+++ b/rails/spec/requests/api/v1/admin/teachers_spec.rb
@@ -105,4 +105,119 @@ RSpec.describe 'Api::V1::Admin::Teachers', type: :request do
       end
     end
   end
+
+  describe 'POST /api/v1/admin/high_schools/:high_school_id/teachers' do
+    let!(:admin_user) { create(:user, :admin, high_school: nil) }
+    let!(:school)     { create(:high_school) }
+    let!(:grade)      { create(:grade, high_school: school, year: 1) }
+    let(:cookie)      { login_and_get_cookie(admin_user) }
+
+    let(:valid_params) do
+      {
+        teacher: {
+          name: '田中太郎',
+          email: 'tanaka@example.com',
+          password: 'abc123xyz',
+          password_confirmation: 'abc123xyz',
+          grade_scope: 'all_grades',
+          manage_other_teachers: false,
+          grade_ids: [grade.id]
+        }
+      }.to_json
+    end
+
+    context '正常系' do
+      subject do
+        post "/api/v1/admin/high_schools/#{school.id}/teachers",
+             params: valid_params,
+             headers: headers.merge('Cookie' => cookie)
+      end
+
+      it 'ステータス201が返される' do
+        subject
+        expect(response).to have_http_status(:created)
+      end
+
+      it '作成した teacher オブジェクトが返される' do
+        subject
+        teacher_data = response.parsed_body['teacher']
+        expect(teacher_data.keys).to include('id', 'name', 'email', 'grade_scope', 'manage_other_teachers', 'grades')
+        expect(teacher_data['name']).to eq('田中太郎')
+        expect(teacher_data['email']).to eq('tanaka@example.com')
+      end
+
+      it 'User が作成される' do
+        expect { subject }.to change(User, :count).by(1)
+      end
+
+      it 'TeacherPermission が作成される' do
+        expect { subject }.to change(TeacherPermission, :count).by(1)
+      end
+
+      it 'TeacherGrade が作成される' do
+        expect { subject }.to change(TeacherGrade, :count).by(1)
+      end
+    end
+
+    context '異常系 - email 重複' do
+      before { create(:user, :teacher, email: 'tanaka@example.com', high_school: school, grade: nil) }
+
+      it '422が返される' do
+        post "/api/v1/admin/high_schools/#{school.id}/teachers",
+             params: valid_params,
+             headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'errors キーが含まれる' do
+        post "/api/v1/admin/high_schools/#{school.id}/teachers",
+             params: valid_params,
+             headers: headers.merge('Cookie' => cookie)
+        expect(response.parsed_body).to have_key('errors')
+      end
+    end
+
+    context '異常系 - 必須パラメータ欠損 (name なし)' do
+      let(:invalid_params) do
+        {
+          teacher: {
+            email: 'tanaka@example.com',
+            password: 'abc123xyz',
+            password_confirmation: 'abc123xyz',
+            grade_scope: 'all_grades',
+            manage_other_teachers: false,
+            grade_ids: [grade.id]
+          }
+        }.to_json
+      end
+
+      it '422が返される' do
+        post "/api/v1/admin/high_schools/#{school.id}/teachers",
+             params: invalid_params,
+             headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context '異常系 - 未認証アクセス' do
+      it '401が返される' do
+        post "/api/v1/admin/high_schools/#{school.id}/teachers",
+             params: valid_params,
+             headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+
+      it '403が返される' do
+        student_cookie = login_and_get_cookie(student_user)
+        post "/api/v1/admin/high_schools/#{school.id}/teachers",
+             params: valid_params,
+             headers: headers.merge('Cookie' => student_cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
 end

--- a/rails/spec/services/admin/create_teacher_service_spec.rb
+++ b/rails/spec/services/admin/create_teacher_service_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::CreateTeacherService, type: :service do
+  subject(:service) { described_class.new(school: school, name: name, email: email) }
+
+  let!(:school) { create(:high_school) }
+
+  context '正常系' do
+    let(:name) { '田中太郎' }
+    let(:email) { 'tanaka@example.com' }
+
+    it 'User が作成される' do
+      expect { service.call }.to change(User, :count).by(1)
+    end
+
+    it 'TeacherPermission がデフォルト値で作成される' do
+      service.call
+      user = User.find_by(email: email)
+      expect(user.teacher_permission).to be_present
+      expect(user.teacher_permission.grade_scope).to eq('own_grade')
+      expect(user.teacher_permission.manage_other_teachers).to be(false)
+    end
+  end
+
+  context '異常系 - name が空' do
+    let(:name) { '' }
+    let(:email) { 'tanaka@example.com' }
+
+    it 'ValidationError を raise する' do
+      expect { service.call }.to raise_error(
+        Admin::CreateTeacherService::ValidationError,
+        '名前を入力してください'
+      )
+    end
+  end
+
+  context '異常系 - email が重複している' do
+    let(:name) { '田中太郎' }
+    let(:email) { 'tanaka@example.com' }
+
+    before { create(:user, :teacher, email: email, high_school: school, grade: nil) }
+
+    it 'ActiveRecord::RecordInvalid を raise する' do
+      expect { service.call }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end

--- a/rails/spec/services/admin/create_teacher_service_spec.rb
+++ b/rails/spec/services/admin/create_teacher_service_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Admin::CreateTeacherService, type: :service do
       user = User.find_by(email: email)
       expect(user.teacher_permission).to be_present
       expect(user.teacher_permission.grade_scope).to eq('own_grade')
-      expect(user.teacher_permission.manage_other_teachers).to be(false)
+      expect(user.teacher_permission.manage_other_teachers).to be(true)
     end
   end
 

--- a/rails/spec/services/admin/create_teacher_service_spec.rb
+++ b/rails/spec/services/admin/create_teacher_service_spec.rb
@@ -3,16 +3,19 @@
 require 'rails_helper'
 
 RSpec.describe Admin::CreateTeacherService, type: :service do
-  subject(:service) { described_class.new(school: school, name: name, email: email) }
+  subject(:service) { described_class.new(school: school, email: email) }
 
   let!(:school) { create(:high_school) }
+  let(:email) { 'tanaka@example.com' }
 
   context '正常系' do
-    let(:name) { '田中太郎' }
-    let(:email) { 'tanaka@example.com' }
-
     it 'User が作成される' do
       expect { service.call }.to change(User, :count).by(1)
+    end
+
+    it 'name に email の @ 以前の文字列が設定される' do
+      service.call
+      expect(User.find_by(email: email).name).to eq('tanaka')
     end
 
     it 'TeacherPermission がデフォルト値で作成される' do
@@ -24,22 +27,7 @@ RSpec.describe Admin::CreateTeacherService, type: :service do
     end
   end
 
-  context '異常系 - name が空' do
-    let(:name) { '' }
-    let(:email) { 'tanaka@example.com' }
-
-    it 'ValidationError を raise する' do
-      expect { service.call }.to raise_error(
-        Admin::CreateTeacherService::ValidationError,
-        '名前を入力してください'
-      )
-    end
-  end
-
   context '異常系 - email が重複している' do
-    let(:name) { '田中太郎' }
-    let(:email) { 'tanaka@example.com' }
-
     before { create(:user, :teacher, email: email, high_school: school, grade: nil) }
 
     it 'ActiveRecord::RecordInvalid を raise する' do

--- a/rails/spec/services/admin/update_teacher_service_spec.rb
+++ b/rails/spec/services/admin/update_teacher_service_spec.rb
@@ -33,26 +33,6 @@ RSpec.describe Admin::UpdateTeacherService, type: :service do
     end
   end
 
-  context '正常系 - password と password_confirmation を指定した場合' do
-    let(:params) { { password: 'newpassword123', password_confirmation: 'newpassword123' } }
-
-    it 'パスワードが更新される' do
-      service.call
-      expect(teacher.reload.valid_password?('newpassword123')).to be(true)
-    end
-  end
-
-  context '異常系 - password_confirmation なし' do
-    let(:params) { { password: 'newpassword123' } }
-
-    it 'ValidationError を raise する' do
-      expect { service.call }.to raise_error(
-        Admin::UpdateTeacherService::ValidationError,
-        'パスワード確認を入力してください'
-      )
-    end
-  end
-
   context '異常系 - email が重複している' do
     let(:params) { { email: 'duplicate@example.com' } }
 

--- a/rails/spec/services/admin/update_teacher_service_spec.rb
+++ b/rails/spec/services/admin/update_teacher_service_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::UpdateTeacherService, type: :service do
+  subject(:service) { described_class.new(user: teacher, params: params) }
+
+  let!(:school) { create(:high_school) }
+  let!(:grade1) { create(:grade, high_school: school, year: 1) }
+  let!(:grade2) { create(:grade, high_school: school, year: 2) }
+  let!(:teacher) do
+    user = create(:user, :teacher, high_school: school, grade: nil)
+    create(:teacher_permission, user: user, grade_scope: :own_grade, manage_other_teachers: false)
+    create(:teacher_grade, user: user, grade: grade1)
+    user
+  end
+
+  context '正常系 - grade_ids を指定した場合' do
+    let(:params) { { grade_ids: [grade1.id, grade2.id] } }
+
+    it 'TeacherGrade が差分更新される' do
+      service.call
+      expect(teacher.reload.grades.pluck(:id)).to contain_exactly(grade1.id, grade2.id)
+    end
+  end
+
+  context '正常系 - grade_ids を省略した場合' do
+    let(:params) { { name: '更新太郎' } }
+
+    it '既存の TeacherGrade が変わらない' do
+      service.call
+      expect(teacher.reload.grades.pluck(:id)).to eq([grade1.id])
+    end
+  end
+
+  context '正常系 - password と password_confirmation を指定した場合' do
+    let(:params) { { password: 'newpassword123', password_confirmation: 'newpassword123' } }
+
+    it 'パスワードが更新される' do
+      service.call
+      expect(teacher.reload.valid_password?('newpassword123')).to be(true)
+    end
+  end
+
+  context '異常系 - password_confirmation なし' do
+    let(:params) { { password: 'newpassword123' } }
+
+    it 'ValidationError を raise する' do
+      expect { service.call }.to raise_error(
+        Admin::UpdateTeacherService::ValidationError,
+        'パスワード確認を入力してください'
+      )
+    end
+  end
+
+  context '異常系 - email が重複している' do
+    let(:params) { { email: 'duplicate@example.com' } }
+
+    before { create(:user, :teacher, email: 'duplicate@example.com', high_school: school, grade: nil) }
+
+    it 'ActiveRecord::RecordInvalid を raise する' do
+      expect { service.call }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

高校詳細画面の「教師管理」タブで使用する教師の一覧・追加・編集 API を実装しました。

関連 Issue: #41

## 追加エンドポイント

| メソッド | パス | 説明 |
|---|---|---|
| GET | `/api/v1/admin/high_schools/:high_school_id/teachers` | 教師一覧 |
| POST | `/api/v1/admin/high_schools/:high_school_id/teachers` | 教師作成 |
| PATCH | `/api/v1/admin/high_schools/:high_school_id/teachers/:id` | 教師更新 |

## リクエスト仕様

### POST（教師作成）

```json
{ "email": "tanaka@example.com" }
```

- `email` のみ受け取る
- `name` は `email` の `@` より前の文字列を自動設定
- パスワードは `SecureRandom.hex(16)` で自動生成し、招待メールで通知

### PATCH（教師更新）

```json
{
  "name": "田中太郎",
  "email": "tanaka@example.com",
  "grade_scope": "all_grades",
  "manage_other_teachers": true,
  "grade_ids": [1, 2]
}
```

- すべて任意。送られたフィールドのみ更新
- `grade_ids` を省略した場合は既存の担当学年を保持（`[]` で全削除）

## 実装上の判断ポイント

- **招待メール**: 教師作成時に `AuthMailer#invite_teacher` で招待専用メールを送信。件名「edu platform へのご招待」、パスワード設定リンク付き
- **TeacherPermission の初期値**: create 時は `grade_scope: own_grade` / `manage_other_teachers: false` をデフォルトで作成し、update で変更可能
- **grade_ids の更新**: PATCH 時に `grade_ids` キーが含まれる場合のみ差分更新（削除→再作成）
- **N+1 対策**: index では `includes(:teacher_permission, :grades)` を使用
- **Service 分離**: create/update のビジネスロジックを `CreateTeacherService` / `UpdateTeacherService` に切り出し、コントローラーは HTTP の関心事のみに集約

## テスト構成

| ファイル | 内容 |
|---|---|
| `spec/requests/api/v1/admin/teachers_spec.rb` | HTTP ステータス・レスポンス形式・認証・認可 |
| `spec/services/admin/create_teacher_service_spec.rb` | ユーザー作成・TeacherPermission 初期値・バリデーション |
| `spec/services/admin/update_teacher_service_spec.rb` | TeacherGrade 差分更新・grade_ids 省略時の保持・バリデーション |

## 動作確認

```bash
bundle exec rspec spec/requests/api/v1/admin/teachers_spec.rb spec/services/admin/create_teacher_service_spec.rb spec/services/admin/update_teacher_service_spec.rb
```