### PR TITLE
【Rails】単元取得API作成

### DIFF
--- a/rails/app/controllers/api/v1/student/units_controller.rb
+++ b/rails/app/controllers/api/v1/student/units_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Student
+      class UnitsController < Api::V1::Student::BaseController
+        def show
+          task = current_user.tasks.find(params[:task_id])
+          unit = task.units.includes(:course).find(params[:id])
+
+          render json: unit, serializer: UnitSerializer, status: :ok
+        end
+      end
+    end
+  end
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -26,7 +26,9 @@ Rails.application.routes.draw do
         resource :dashboard, only: :show
         resources :goals
         resources :draft_tasks
-        resources :tasks
+        resources :tasks do
+          resources :units, only: :show
+        end
         resources :courses, only: :index
       end
 

--- a/rails/spec/factories/tasks.rb
+++ b/rails/spec/factories/tasks.rb
@@ -29,6 +29,8 @@ FactoryBot.define do
 
     due_date { Time.zone.today + 1.day }
 
+    association :goal
+
     trait :in_progress do
       status { :in_progress }
       completed_at { nil }

--- a/rails/spec/factories/user_roles.rb
+++ b/rails/spec/factories/user_roles.rb
@@ -15,6 +15,10 @@ FactoryBot.define do
 
     initialize_with { UserRole.find_or_create_by!(name: name) }
 
+    trait :student do
+      name { :student }
+    end
+
     trait :admin do
       name { :admin }
     end

--- a/rails/spec/factories/users.rb
+++ b/rails/spec/factories/users.rb
@@ -34,6 +34,10 @@ FactoryBot.define do
     association :grade
     association :address
 
+    trait :student do
+      user_role { association :user_role, :student }
+    end
+
     trait :admin do
       user_role { association :user_role, :admin }
     end

--- a/rails/spec/models/task_spec.rb
+++ b/rails/spec/models/task_spec.rb
@@ -1,5 +1,24 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: tasks
+#
+#  id             :bigint           not null, primary key
+#  user_id        :bigint           not null
+#  goal_id        :bigint
+#  title          :string(100)      not null
+#  content        :text(65535)      not null
+#  priority       :integer          default("normal"), not null
+#  due_date       :date
+#  estimated_time :integer
+#  status         :integer          default("not_started"), not null
+#  memo           :text(65535)
+#  completed_at   :datetime
+#  deleted_at     :datetime
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do

--- a/rails/spec/requests/api/v1/student/tasks_spec.rb
+++ b/rails/spec/requests/api/v1/student/tasks_spec.rb
@@ -191,13 +191,28 @@ RSpec.describe 'Api::V1::Student::Tasks', type: :request do
       end
     end
 
-    context '異常系 - ログイン生徒以外のアクセス' do
+    context '異常系 - ログイン生徒以外のアクセス(ロール)' do
       let!(:other_user) { create(:user, :teacher) }
 
       it '403が返される' do
         cookie = login_and_get_cookie(other_user)
         get '/api/v1/student/tasks/1', headers: headers.merge('Cookie' => cookie)
         expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context '異常系 - 他の生徒のタスクにアクセス' do
+      let!(:user) { create(:user) }
+      let!(:other_user) { create(:user) }
+      let!(:goal) { create(:goal, user: other_user) }
+      let!(:course) { create(:course) }
+      let!(:units) { create_list(:unit, 3, course: course) }
+      let!(:task) { create(:task, user: other_user, goal: goal, units: units) }
+      let!(:cookie) { login_and_get_cookie(user) }
+
+      it '404が返される' do
+        get "/api/v1/student/tasks/#{task.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/rails/spec/requests/api/v1/student/units_spec.rb
+++ b/rails/spec/requests/api/v1/student/units_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Student::Units', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/student/tasks/:task_id/units/:id' do
+    let!(:prefecture) { create(:prefecture, name: '東京都') }
+    let!(:high_school) { create(:high_school, name: 'A高校', prefecture: prefecture) }
+    let!(:user) { create(:user, high_school: high_school) }
+    let!(:goal) { create(:goal, user: user) }
+    let!(:task) { create(:task, user: user, goal: goal) }
+    let!(:course) { create(:course) }
+    let!(:unit) { create(:unit, course: course) }
+
+    before do
+      task.units << unit
+    end
+
+    context '正常系' do
+      subject do
+        get "/api/v1/student/tasks/#{task.id}/units/#{unit.id}",
+            headers: headers.merge('Cookie' => cookie)
+      end
+
+      let!(:cookie) { login_and_get_cookie(user) }
+
+      it '200が返る' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'unitが取得できる' do
+        subject
+        expect(response.parsed_body['id']).to eq(unit.id)
+      end
+    end
+
+    context '異常系 - タスクに紐づかないunit' do
+      let!(:cookie) { login_and_get_cookie(user) }
+      let!(:other_unit) { create(:unit, course: course) }
+
+      it '404が返る' do
+        get "/api/v1/student/tasks/#{task.id}/units/#{other_unit.id}",
+            headers: headers.merge('Cookie' => cookie)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context '異常系 - 未認証' do
+      it '401が返る' do
+        get "/api/v1/student/tasks/#{task.id}/units/#{unit.id}",
+            headers: headers.merge('Cookie' => nil)
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 生徒以外' do
+      let!(:other_user) { create(:user, :teacher) }
+
+      it '403が返る' do
+        cookie = login_and_get_cookie(other_user)
+
+        get "/api/v1/student/tasks/#{task.id}/units/#{unit.id}",
+            headers: headers.merge('Cookie' => cookie)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/student/units_spec.rb
+++ b/rails/spec/requests/api/v1/student/units_spec.rb
@@ -82,5 +82,20 @@ RSpec.describe 'Api::V1::Student::Units', type: :request do
         expect(response).to have_http_status(:forbidden)
       end
     end
+
+    context '異常系 - 他の生徒のタスクにアクセス' do
+      let!(:user) { create(:user) }
+      let!(:other_user) { create(:user) }
+      let!(:goal) { create(:goal, user: other_user) }
+      let!(:course) { create(:course) }
+      let!(:units) { create_list(:unit, 3, course: course) }
+      let!(:task) { create(:task, user: other_user, goal: goal, units: units) }
+      let!(:cookie) { login_and_get_cookie(user) }
+
+      it '404が返される' do
+        get "/api/v1/student/tasks/#{task.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
https://www.notion.so/Rails-API-3422946467fd80c583d5fb8ee361ae68
<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細

API: `/api/v1/student/tasks/:task_id/units/:id `

遷移(２ルート):
- 目標一覧 > 目標詳細 > 目標に紐づくタスク一覧 > タスク詳細 > 単元
- タスク一覧 > タスク詳細 > 単元

現在の状況だと、ユーザーが直接単元に進むことはできない
<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

## 動作確認
<img width="3016" height="1720" alt="image" src="https://github.com/user-attachments/assets/b38b985e-0f64-411d-bb67-d7e2e996b3e8" />

<img width="3024" height="1730" alt="image" src="https://github.com/user-attachments/assets/f14da293-f33b-41be-b115-78c56cfb8d22" />

<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
