### PR TITLE
【Next.js】ホーム画面で目標一覧遷移のボタンが表示されていなかったバグ修正

### DIFF
--- a/frontend/features/Home/Presenter.tsx
+++ b/frontend/features/Home/Presenter.tsx
@@ -102,20 +102,39 @@ export const Presenter = ({
             </Box>
           );
         })}
-        <Box sx={{ display: "flex", justifyContent: "flex-end", mt: 4 }}>
-          <Link
-            href={`/goals/new`}
-            style={{
-              backgroundColor: colors.brand.primary,
-              color: colors.text.inverse,
-              padding: "8px 12px",
-              borderRadius: 10,
-              fontSize: 16,
-              textDecoration: "none",
-            }}
-          >
-            目標追加
-          </Link>
+        <Box
+          sx={{ display: "flex", justifyContent: "flex-end", mt: 4, gap: 2 }}
+        >
+          <Box>
+            <Link
+              href={`/goals`}
+              style={{
+                backgroundColor: colors.brand.primary,
+                color: colors.text.inverse,
+                padding: "8px 12px",
+                borderRadius: 10,
+                fontSize: 16,
+                textDecoration: "none",
+              }}
+            >
+              目標一覧
+            </Link>
+          </Box>
+          <Box>
+            <Link
+              href={`/goals/new`}
+              style={{
+                backgroundColor: colors.brand.primary,
+                color: colors.text.inverse,
+                padding: "8px 12px",
+                borderRadius: 10,
+                fontSize: 16,
+                textDecoration: "none",
+              }}
+            >
+              目標追加
+            </Link>
+          </Box>
         </Box>
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mt: 4 }}>
           {links.map((link) => (


### PR DESCRIPTION
## 概要
https://www.notion.so/Next-js-3512946467fd80c3b860d5afd182bbe9
<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細
- 以前feature/TSK-24で修正したがmergeされた後に、feature/TSK-24にpushしていた為反映されていなかった

<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

## 動作確認
### ボタン表示されるよう修正
<img width="728" height="1574" alt="image" src="https://github.com/user-attachments/assets/b3272629-bde0-4b5c-a39f-06cce1c89010" />

<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
