### PR TITLE
issue-50 管理画面 講座詳細・単元詳細 GET API

### DIFF
--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -6,8 +6,11 @@ module Api
       class CoursesController < BaseController
         def show
           course = Course.includes(:subject, :units).find(params[:id])
+          questions_counts = Question.where(unit_id: course.unit_ids).group(:unit_id).count
 
-          render json: course, serializer: ::Admin::CourseDetailSerializer
+          render json: course,
+                 serializer: ::Admin::CourseDetailSerializer,
+                 questions_counts: questions_counts
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class CoursesController < BaseController
+        def show
+          course = Course.includes(:subject, :units).find(params[:id])
+
+          render json: course, serializer: ::Admin::CourseDetailSerializer
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/admin/units_controller.rb
+++ b/rails/app/controllers/api/v1/admin/units_controller.rb
@@ -5,7 +5,9 @@ module Api
     module Admin
       class UnitsController < BaseController
         def show
-          unit = Unit.find_by(id: params[:id], course_id: params[:course_id])
+          unit = Unit.where(id: params[:id], course_id: params[:course_id])
+                     .includes(questions: %i[question_choices question_hints question_explanations])
+                     .first
           raise ActiveRecord::RecordNotFound.new(nil, Unit.name) if unit.nil?
 
           render json: unit, serializer: ::Admin::UnitDetailSerializer

--- a/rails/app/controllers/api/v1/admin/units_controller.rb
+++ b/rails/app/controllers/api/v1/admin/units_controller.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class UnitsController < BaseController
+        def show
+          unit = Unit.find_by(id: params[:id], course_id: params[:course_id])
+          raise ActiveRecord::RecordNotFound.new(nil, Unit.name) if unit.nil?
+
+          render json: unit, serializer: ::Admin::UnitDetailSerializer
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/admin/units_controller.rb
+++ b/rails/app/controllers/api/v1/admin/units_controller.rb
@@ -5,9 +5,8 @@ module Api
     module Admin
       class UnitsController < BaseController
         def show
-          unit = Unit.where(id: params[:id], course_id: params[:course_id])
-                     .includes(questions: %i[question_choices question_hints question_explanations])
-                     .first
+          unit = Unit.includes(questions: %i[question_choices question_hints question_explanations])
+                     .find_by(id: params[:id], course_id: params[:course_id])
           raise ActiveRecord::RecordNotFound.new(nil, Unit.name) if unit.nil?
 
           render json: unit, serializer: ::Admin::UnitDetailSerializer

--- a/rails/app/serializers/admin/course_detail_serializer.rb
+++ b/rails/app/serializers/admin/course_detail_serializer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Admin
+  class CourseDetailSerializer < ActiveModel::Serializer
+    attributes :id, :subject, :level_number, :level_name, :description, :units
+
+    def subject
+      { id: object.subject.id, name: object.subject.name }
+    end
+
+    def units
+      object.units.order(:id).map do |unit|
+        { id: unit.id, unit_name: unit.unit_name }
+      end
+    end
+  end
+end

--- a/rails/app/serializers/admin/course_detail_serializer.rb
+++ b/rails/app/serializers/admin/course_detail_serializer.rb
@@ -9,8 +9,13 @@ module Admin
     end
 
     def units
+      counts = instance_options[:questions_counts] || {}
       object.units.order(:id).map do |unit|
-        { id: unit.id, unit_name: unit.unit_name }
+        {
+          id: unit.id,
+          unit_name: unit.unit_name,
+          questions_count: counts[unit.id] || 0
+        }
       end
     end
   end

--- a/rails/app/serializers/admin/question_detail_serializer.rb
+++ b/rails/app/serializers/admin/question_detail_serializer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Admin
+  class QuestionDetailSerializer < ActiveModel::Serializer
+    attributes :id, :question_text, :correct_answer, :choices, :hints, :explanations
+
+    def choices
+      object.question_choices.sort_by { |c| c.choice_number || 0 }.map do |c|
+        { id: c.id, choice_number: c.choice_number, choice_text: c.choice_text }
+      end
+    end
+
+    def hints
+      object.question_hints.sort_by { |h| h.step_number || 0 }.map do |h|
+        { id: h.id, step_number: h.step_number, hint_text: h.hint_text }
+      end
+    end
+
+    def explanations
+      object.question_explanations.sort_by(&:id).map do |e|
+        { id: e.id, explanation_type: e.explanation_type, explanation_text: e.explanation_text }
+      end
+    end
+  end
+end

--- a/rails/app/serializers/admin/question_explanation_serializer.rb
+++ b/rails/app/serializers/admin/question_explanation_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Admin
+  class QuestionExplanationSerializer < ActiveModel::Serializer
+    attributes :id, :explanation_type, :explanation_text
+  end
+end

--- a/rails/app/serializers/admin/unit_detail_serializer.rb
+++ b/rails/app/serializers/admin/unit_detail_serializer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Admin
+  class UnitDetailSerializer < ActiveModel::Serializer
+    attributes :id, :course_id, :unit_name, :questions, :recent_import_histories
+
+    def questions
+      []
+    end
+
+    def recent_import_histories
+      []
+    end
+  end
+end

--- a/rails/app/serializers/admin/unit_detail_serializer.rb
+++ b/rails/app/serializers/admin/unit_detail_serializer.rb
@@ -5,7 +5,10 @@ module Admin
     attributes :id, :course_id, :unit_name, :questions, :recent_import_histories
 
     def questions
-      []
+      ActiveModelSerializers::SerializableResource.new(
+        object.questions.order(:id),
+        each_serializer: ::Admin::QuestionDetailSerializer
+      ).as_json
     end
 
     def recent_import_histories

--- a/rails/app/serializers/admin/unit_detail_serializer.rb
+++ b/rails/app/serializers/admin/unit_detail_serializer.rb
@@ -4,6 +4,8 @@ module Admin
   class UnitDetailSerializer < ActiveModel::Serializer
     attributes :id, :course_id, :unit_name, :questions, :recent_import_histories
 
+    RECENT_IMPORT_HISTORIES_LIMIT = 5
+
     def questions
       ActiveModelSerializers::SerializableResource.new(
         object.questions.order(:id),
@@ -12,7 +14,10 @@ module Admin
     end
 
     def recent_import_histories
-      []
+      ActiveModelSerializers::SerializableResource.new(
+        object.import_histories.order(started_at: :desc).limit(RECENT_IMPORT_HISTORIES_LIMIT),
+        each_serializer: ::ImportHistorySerializer
+      ).as_json
     end
   end
 end

--- a/rails/spec/factories/question_explanations.rb
+++ b/rails/spec/factories/question_explanations.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: question_explanations
+#
+#  id               :bigint           not null, primary key
+#  question_id      :bigint           not null
+#  explanation_type :string(255)
+#  explanation_text :text(65535)
+#  deleted_at       :datetime
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#
+FactoryBot.define do
+  factory :question_explanation do
+    association :question
+    explanation_type { QuestionExplanation::BASIC }
+    explanation_text { '解説文' }
+  end
+end

--- a/rails/spec/factories/question_hints.rb
+++ b/rails/spec/factories/question_hints.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: question_hints
+#
+#  id          :bigint           not null, primary key
+#  question_id :bigint           not null
+#  step_number :integer
+#  hint_text   :text(65535)
+#  deleted_at  :datetime
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+FactoryBot.define do
+  factory :question_hint do
+    association :question
+    step_number { 1 }
+    hint_text { 'ヒント1' }
+  end
+end

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Courses', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/admin/courses/:id' do
+    context '正常系' do
+      subject { get "/api/v1/admin/courses/#{course.id}", headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:subject_record) { create(:subject, name: '数学') }
+      let!(:course) do
+        create(:course,
+               subject: subject_record,
+               level_number: 2,
+               level_name: '標準',
+               description: '標準レベルのコース')
+      end
+      let!(:units) { create_list(:unit, 2, course: course) }
+
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '講座の基本フィールドが含まれる' do
+        subject
+        body = response.parsed_body
+        expect(body.keys).to include('id', 'subject', 'level_number', 'level_name', 'description', 'units')
+      end
+
+      it 'id / level_number / level_name / description が正しい' do
+        subject
+        body = response.parsed_body
+        expect(body['id']).to eq(course.id)
+        expect(body['level_number']).to eq(2)
+        expect(body['level_name']).to eq('標準')
+        expect(body['description']).to eq('標準レベルのコース')
+      end
+
+      it 'subject は id と name を含む' do
+        subject
+        body = response.parsed_body
+        expect(body['subject']).to eq('id' => subject_record.id, 'name' => '数学')
+      end
+
+      it 'units 配列に course に紐づく全 unit が id 昇順で含まれる' do
+        subject
+        body = response.parsed_body
+        unit_ids = body['units'].pluck('id')
+        expect(unit_ids).to eq(units.map(&:id).sort)
+      end
+
+      it '各 unit に id / unit_name が含まれる' do
+        subject
+        body = response.parsed_body
+        unit_data = body['units'].first
+        expect(unit_data.keys).to include('id', 'unit_name')
+      end
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -73,6 +73,27 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
         unit_data = body['units'].first
         expect(unit_data.keys).to include('id', 'unit_name')
       end
+
+      context 'unit に紐づく問題が存在する場合' do
+        let!(:questions_for_first_unit) { create_list(:question, 3, unit: units.first) }
+        let!(:questions_for_second_unit) { create_list(:question, 1, unit: units.last) }
+
+        it '各 unit に questions_count が含まれ、正しい数が返る' do
+          subject
+          body = response.parsed_body
+          counts = body['units'].to_h { |u| [u['id'], u['questions_count']] }
+          expect(counts[units.first.id]).to eq(3)
+          expect(counts[units.last.id]).to eq(1)
+        end
+      end
+
+      context 'unit に紐づく問題が存在しない場合' do
+        it 'questions_count は 0 として返る' do
+          subject
+          body = response.parsed_body
+          expect(body['units'].pluck('questions_count')).to all(eq(0))
+        end
+      end
     end
   end
 end

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -95,5 +95,46 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
         end
       end
     end
+
+    context '異常系 - 未認証アクセス' do
+      let!(:course) { create(:course) }
+
+      it '401が返される' do
+        get "/api/v1/admin/courses/#{course.id}", headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+      let!(:course) { create(:course) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(student_user)
+        get "/api/v1/admin/courses/#{course.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（教員）' do
+      let!(:teacher_user) { create(:user, :teacher) }
+      let!(:course) { create(:course) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(teacher_user)
+        get "/api/v1/admin/courses/#{course.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context '異常系 - 存在しない id' do
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it '404が返される' do
+        get '/api/v1/admin/courses/0', headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 end

--- a/rails/spec/requests/api/v1/admin/units_spec.rb
+++ b/rails/spec/requests/api/v1/admin/units_spec.rb
@@ -49,6 +49,61 @@ RSpec.describe 'Api::V1::Admin::Units', type: :request do
         expect(body['course_id']).to eq(course.id)
         expect(body['unit_name']).to eq('単元A')
       end
+
+      context 'questions が存在する場合' do
+        let!(:question1) do
+          create(:question, unit: unit, question_text: '問題1', correct_answer: '2')
+        end
+        let!(:question2) do
+          create(:question, unit: unit, question_text: '問題2', correct_answer: '3')
+        end
+        let!(:choice1_b) { create(:question_choice, question: question1, choice_number: 2, choice_text: 'B') }
+        let!(:choice1_a) { create(:question_choice, question: question1, choice_number: 1, choice_text: 'A') }
+        let!(:hint1_step2) { create(:question_hint, question: question1, step_number: 2, hint_text: 'ヒント2') }
+        let!(:hint1_step1) { create(:question_hint, question: question1, step_number: 1, hint_text: 'ヒント1') }
+        let!(:explanation1) do
+          create(:question_explanation,
+                 question: question1,
+                 explanation_type: QuestionExplanation::BASIC,
+                 explanation_text: '基本解説テキスト')
+        end
+
+        it 'questions は id 昇順で全件返る' do
+          subject
+          ids = response.parsed_body['questions'].pluck('id')
+          expect(ids).to eq([question1.id, question2.id])
+        end
+
+        it '各 question に id / question_text / correct_answer / choices / hints / explanations が含まれる' do
+          subject
+          q = response.parsed_body['questions'].first
+          expect(q.keys).to include('id', 'question_text', 'correct_answer', 'choices', 'hints', 'explanations')
+          expect(q['question_text']).to eq('問題1')
+          expect(q['correct_answer']).to eq('2')
+        end
+
+        it 'choices は choice_number 昇順で id / choice_number / choice_text を含む' do
+          subject
+          choices = response.parsed_body['questions'].first['choices']
+          expect(choices.pluck('choice_number')).to eq([1, 2])
+          expect(choices.first.keys).to include('id', 'choice_number', 'choice_text')
+        end
+
+        it 'hints は step_number 昇順で id / step_number / hint_text を含む' do
+          subject
+          hints = response.parsed_body['questions'].first['hints']
+          expect(hints.pluck('step_number')).to eq([1, 2])
+          expect(hints.first.keys).to include('id', 'step_number', 'hint_text')
+        end
+
+        it 'explanations は id / explanation_type / explanation_text を含む' do
+          subject
+          explanations = response.parsed_body['questions'].first['explanations']
+          expect(explanations.first.keys).to include('id', 'explanation_type', 'explanation_text')
+          expect(explanations.first['explanation_type']).to eq(QuestionExplanation::BASIC)
+          expect(explanations.first['explanation_text']).to eq('基本解説テキスト')
+        end
+      end
     end
   end
 end

--- a/rails/spec/requests/api/v1/admin/units_spec.rb
+++ b/rails/spec/requests/api/v1/admin/units_spec.rb
@@ -104,6 +104,37 @@ RSpec.describe 'Api::V1::Admin::Units', type: :request do
           expect(explanations.first['explanation_text']).to eq('基本解説テキスト')
         end
       end
+
+      context 'recent_import_histories' do
+        let(:base_time) { Time.zone.local(2026, 4, 1, 9, 0, 0) }
+        let!(:histories) do
+          6.times.map do |i|
+            create(:import_history,
+                   user: admin_user,
+                   unit: unit,
+                   file_name: "questions_#{i}.csv",
+                   started_at: base_time + i.hours)
+          end
+        end
+
+        it '最大 5 件、started_at の降順で返る' do
+          subject
+          body = response.parsed_body
+          expect(body['recent_import_histories'].size).to eq(5)
+          file_names = body['recent_import_histories'].pluck('file_name')
+          expect(file_names).to eq(
+            %w[questions_5.csv questions_4.csv questions_3.csv questions_2.csv questions_1.csv]
+          )
+        end
+
+        it '必要なフィールドが含まれる' do
+          subject
+          h = response.parsed_body['recent_import_histories'].first
+          expect(h.keys).to include(
+            'id', 'file_name', 'status', 'total_count', 'success_count', 'error_count', 'created_at'
+          )
+        end
+      end
     end
   end
 end

--- a/rails/spec/requests/api/v1/admin/units_spec.rb
+++ b/rails/spec/requests/api/v1/admin/units_spec.rb
@@ -136,5 +136,67 @@ RSpec.describe 'Api::V1::Admin::Units', type: :request do
         end
       end
     end
+
+    context '異常系 - 未認証アクセス' do
+      let!(:course) { create(:course) }
+      let!(:unit)   { create(:unit, course: course) }
+
+      it '401が返される' do
+        get "/api/v1/admin/courses/#{course.id}/units/#{unit.id}", headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+      let!(:course)       { create(:course) }
+      let!(:unit)         { create(:unit, course: course) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(student_user)
+        get "/api/v1/admin/courses/#{course.id}/units/#{unit.id}",
+            headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（教員）' do
+      let!(:teacher_user) { create(:user, :teacher) }
+      let!(:course)       { create(:course) }
+      let!(:unit)         { create(:unit, course: course) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(teacher_user)
+        get "/api/v1/admin/courses/#{course.id}/units/#{unit.id}",
+            headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context '異常系 - 存在しない unit_id' do
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:course)     { create(:course) }
+      let(:cookie)      { login_and_get_cookie(admin_user) }
+
+      it '404が返される' do
+        get "/api/v1/admin/courses/#{course.id}/units/0",
+            headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context '異常系 - course_id と unit.course_id が不整合' do
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:course)     { create(:course) }
+      let!(:other_course) { create(:course) }
+      let!(:unit) { create(:unit, course: other_course) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it '404が返される' do
+        get "/api/v1/admin/courses/#{course.id}/units/#{unit.id}",
+            headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 end

--- a/rails/spec/requests/api/v1/admin/units_spec.rb
+++ b/rails/spec/requests/api/v1/admin/units_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'Api::V1::Admin::Units', type: :request do
       context 'recent_import_histories' do
         let(:base_time) { Time.zone.local(2026, 4, 1, 9, 0, 0) }
         let!(:histories) do
-          6.times.map do |i|
+          Array.new(6) do |i|
             create(:import_history,
                    user: admin_user,
                    unit: unit,

--- a/rails/spec/requests/api/v1/admin/units_spec.rb
+++ b/rails/spec/requests/api/v1/admin/units_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Units', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/admin/courses/:course_id/units/:id' do
+    context '正常系' do
+      subject do
+        get "/api/v1/admin/courses/#{course.id}/units/#{unit.id}",
+            headers: headers.merge('Cookie' => cookie)
+      end
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:course)     { create(:course) }
+      let!(:unit)       { create(:unit, course: course, unit_name: '単元A') }
+
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '基本フィールドが含まれる' do
+        subject
+        expect(response.parsed_body.keys).to include(
+          'id', 'course_id', 'unit_name', 'questions', 'recent_import_histories'
+        )
+      end
+
+      it 'id / course_id / unit_name が正しい' do
+        subject
+        body = response.parsed_body
+        expect(body['id']).to eq(unit.id)
+        expect(body['course_id']).to eq(course.id)
+        expect(body['unit_name']).to eq('単元A')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

issue #50 の対応。管理画面の「講座詳細」「単元詳細」が必要とする GET API を実装。

- `GET /api/v1/admin/courses/:id` — 講座詳細（id, subject, level_number, level_name, description, units[{ id, unit_name, questions_count }]）
- `GET /api/v1/admin/courses/:course_id/units/:id` — 単元詳細（id, course_id, unit_name, questions[{ id, question_text, correct_answer, choices, hints, explanations }], recent_import_histories[最新5件]）

## 詳細


### 実装上のポイント

- 既存の admin API（`Admin::HighSchoolsController`）のパターンに揃え、`Admin::BaseController#authorize_admin_service`（Pundit `AdminServicePolicy#access?`）を継承。
- 認証は既存と同じ Cookie + JWT（devise-jwt）。
- 詳細 API は単一リソース取得のためページネーション無し。
- `Unit#show` で URL の `course_id` と `unit.course_id` を `Unit.where(id:, course_id:).first` で同時検証し、不整合は `ActiveRecord::RecordNotFound` で 404。
- `recent_import_histories` は `started_at DESC` 上位 5 件。
- 子要素並び順: choices は `choice_number ASC`、hints は `step_number ASC`、explanations は `id ASC`。
- N+1 回避:
  - `Course#show` の `questions_count` は `Question.where(unit_id: course.unit_ids).group(:unit_id).count` を 1 クエリ取得し、serializer に `instance_options` 経由で渡す（既存 `HighSchoolsController#index` の batch count パターン踏襲）。
  - `Unit#show` は `includes(questions: %i[question_choices question_hints question_explanations])`。
- 既存 serializer `QuestionChoiceSerializer` / `QuestionHintSerializer` / `ImportHistorySerializer` を流用。`QuestionExplanation` 用は既存に無かったため `Admin::QuestionExplanationSerializer` を新規追加。
- `:question_hint` / `:question_explanation` の FactoryBot factory が無かったため追加。

### 異常系

| ケース | ステータス |
| --- | --- |
| 未認証アクセス | 401 |
| 非 admin（生徒・教員）アクセス | 403 |
| 存在しない id | 404 |
| `course_id` と `unit.course_id` の不整合（Unit#show） | 404 |

すべて `ApplicationController` の既存 `rescue_from`（Pundit::NotAuthorizedError → 403、ActiveRecord::RecordNotFound → 404）で集約。

## 動作確認

### 自動テスト

- `docker compose exec rails bundle exec rspec spec/requests/api/v1/admin/courses_spec.rb spec/requests/api/v1/admin/units_spec.rb` → **27 examples, 0 failures**
- `docker compose exec rails bundle exec rspec` 全体 → **382 examples, 0 failures, 2 pending**（pending は既存の未実装スケルトンのみ、本 PR とは無関係）
- `docker compose exec rails bundle exec rubocop` 対象ファイル → **0 offenses**

### 手動確認手順（参考）

```sh
# admin ユーザーでログイン → Cookie 取得
curl -i -X POST http://localhost:5001/api/v1/user/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"admin@example.com","password":"password"}' -c /tmp/cookie.txt

# 講座詳細
curl -i http://localhost:5001/api/v1/admin/courses/1 -b /tmp/cookie.txt

# 単元詳細
curl -i http://localhost:5001/api/v1/admin/courses/1/units/1 -b /tmp/cookie.txt
```

## その他

- 新規 gem 追加なし。

## 参考情報

- issue: #50
- 親 issue: #49