### PR TITLE
issue-61 [Rails] 管理者管理API(一覧/詳細/作成/編集/論理削除)

### DIFF
--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -30,7 +30,12 @@ module Api
         end
 
         def create
-          head :created
+          form = ::Admin::AdminForm.new(create_params)
+          admin = form.save!
+
+          render json: { admin: ::Admin::AdminDetailSerializer.new(admin) }, status: :created
+        rescue ActiveRecord::RecordInvalid => e
+          render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
         end
 
         def update
@@ -39,6 +44,12 @@ module Api
 
         def destroy
           head :no_content
+        end
+
+        private
+
+        def create_params
+          params.permit(:name, :email)
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -39,7 +39,13 @@ module Api
         end
 
         def update
-          head :ok
+          admin = User.admins.where(deleted_at: nil).find(params[:id])
+          form = ::Admin::AdminForm.new(update_params.merge(user: admin))
+          updated = form.save!
+
+          render json: { admin: ::Admin::AdminDetailSerializer.new(updated) }, status: :ok
+        rescue ActiveRecord::RecordInvalid => e
+          render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
         end
 
         def destroy
@@ -49,6 +55,10 @@ module Api
         private
 
         def create_params
+          params.permit(:name, :email)
+        end
+
+        def update_params
           params.permit(:name, :email)
         end
       end

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -24,7 +24,9 @@ module Api
         end
 
         def show
-          head :ok
+          admin = User.admins.where(deleted_at: nil).find(params[:id])
+
+          render json: { admin: ::Admin::AdminDetailSerializer.new(admin) }
         end
 
         def create

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class AdminsController < BaseController
+        def index
+          head :ok
+        end
+
+        def show
+          head :ok
+        end
+
+        def create
+          head :created
+        end
+
+        def update
+          head :ok
+        end
+
+        def destroy
+          head :no_content
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -32,21 +32,23 @@ module Api
 
         def create
           form = ::Admin::AdminForm.new(create_params)
-          admin = form.save!
 
-          render json: { admin: ::Admin::AdminDetailSerializer.new(admin) }, status: :created
-        rescue ActiveRecord::RecordInvalid => e
-          render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
+          if form.save
+            render json: { admin: ::Admin::AdminDetailSerializer.new(form.result) }, status: :created
+          else
+            render json: { errors: form.errors.full_messages }, status: :unprocessable_content
+          end
         end
 
         def update
           admin = User.admins.where(deleted_at: nil).find(params[:id])
           form = ::Admin::AdminForm.new(update_params.merge(user: admin))
-          updated = form.save!
 
-          render json: { admin: ::Admin::AdminDetailSerializer.new(updated) }, status: :ok
-        rescue ActiveRecord::RecordInvalid => e
-          render json: { errors: e.record.errors.full_messages }, status: :unprocessable_content
+          if form.save
+            render json: { admin: ::Admin::AdminDetailSerializer.new(form.result) }, status: :ok
+          else
+            render json: { errors: form.errors.full_messages }, status: :unprocessable_content
+          end
         end
 
         def destroy

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -5,10 +5,11 @@ module Api
     module Admin
       class AdminsController < BaseController
         DEFAULT_PER_PAGE = 25
+        MAX_PER_PAGE = 100
 
         def index
           scope = AdminsQuery.new.search(params[:q]).order_default.result
-          admins = scope.page(params[:page]).per(params[:per_page].presence || DEFAULT_PER_PAGE)
+          admins = scope.page(params[:page]).per(sanitized_per_page)
 
           render json: {
             admins: ActiveModelSerializers::SerializableResource.new(
@@ -77,6 +78,13 @@ module Api
 
         def last_active_admin?(target)
           !User.admins.where(deleted_at: nil).where.not(id: target.id).exists?
+        end
+
+        def sanitized_per_page
+          requested = params[:per_page].to_i
+          return DEFAULT_PER_PAGE if requested <= 0
+
+          [requested, MAX_PER_PAGE].min
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -49,6 +49,19 @@ module Api
         end
 
         def destroy
+          target = User.admins.where(deleted_at: nil).find(params[:id])
+
+          if last_active_admin?(target)
+            return render json: { errors: ['最後の管理者は削除できません'] },
+                          status: :unprocessable_content
+          end
+
+          if target == current_user
+            return render json: { errors: ['自分自身は削除できません'] },
+                          status: :unprocessable_content
+          end
+
+          target.update!(deleted_at: Time.current)
           head :no_content
         end
 
@@ -60,6 +73,10 @@ module Api
 
         def update_params
           params.permit(:name, :email)
+        end
+
+        def last_active_admin?(target)
+          !User.admins.where(deleted_at: nil).where.not(id: target.id).exists?
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -4,8 +4,23 @@ module Api
   module V1
     module Admin
       class AdminsController < BaseController
+        DEFAULT_PER_PAGE = 25
+
         def index
-          head :ok
+          scope = AdminsQuery.new.search(params[:q]).order_default.result
+          admins = scope.page(params[:page]).per(params[:per_page].presence || DEFAULT_PER_PAGE)
+
+          render json: {
+            admins: ActiveModelSerializers::SerializableResource.new(
+              admins, each_serializer: ::Admin::AdminListSerializer
+            ),
+            meta: {
+              page: admins.current_page,
+              per_page: admins.limit_value,
+              total_pages: admins.total_pages,
+              total_count: admins.total_count
+            }
+          }
         end
 
         def show

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -15,10 +15,10 @@ module Api
               admins, each_serializer: ::Admin::AdminListSerializer
             ),
             meta: {
-              page: admins.current_page,
-              per_page: admins.limit_value,
+              current_page: admins.current_page,
               total_pages: admins.total_pages,
-              total_count: admins.total_count
+              total_count: admins.total_count,
+              per_page: admins.limit_value
             }
           }
         end

--- a/rails/app/forms/admin/admin_form.rb
+++ b/rails/app/forms/admin/admin_form.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Admin
+  class AdminForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+
+    attribute :name, :string
+    attribute :email, :string
+
+    attr_accessor :user
+
+    validates :email, presence: true, unless: :updating?
+    validates :name, presence: true, on: :update
+
+    def save!
+      validation_context = updating? ? :update : nil
+      raise ActiveRecord::RecordInvalid.new(error_record) unless valid?(validation_context)
+
+      updating? ? update_admin : create_admin
+    end
+
+    private
+
+    def updating?
+      @user.present?
+    end
+
+    def create_admin
+      ::Admin::CreateAdminService.new(name: name, email: email).call
+    end
+
+    def update_admin
+      @user.update!({ name: name, email: email }.compact)
+      @user
+    end
+
+    def error_record
+      record = User.new
+      errors.each { |error| record.errors.add(error.attribute, error.message) }
+      record
+    end
+  end
+end

--- a/rails/app/forms/admin/admin_form.rb
+++ b/rails/app/forms/admin/admin_form.rb
@@ -13,12 +13,18 @@ module Admin
     validates :email, presence: true, unless: :updating?
     validates :name, presence: true, on: :update
 
-    def save!
+    def save
       validation_context = updating? ? :update : nil
-      raise ActiveRecord::RecordInvalid, error_record unless valid?(validation_context)
+      return false unless valid?(validation_context)
 
-      updating? ? update_admin : create_admin
+      @result = updating? ? update_admin : create_admin
+      true
+    rescue ActiveRecord::RecordInvalid => e
+      e.record.errors.each { |error| errors.add(error.attribute, error.message) }
+      false
     end
+
+    attr_reader :result
 
     private
 
@@ -33,12 +39,6 @@ module Admin
     def update_admin
       @user.update!({ name: name, email: email }.compact)
       @user
-    end
-
-    def error_record
-      record = User.new
-      errors.each { |error| record.errors.add(error.attribute, error.message) }
-      record
     end
   end
 end

--- a/rails/app/forms/admin/admin_form.rb
+++ b/rails/app/forms/admin/admin_form.rb
@@ -15,7 +15,7 @@ module Admin
 
     def save!
       validation_context = updating? ? :update : nil
-      raise ActiveRecord::RecordInvalid.new(error_record) unless valid?(validation_context)
+      raise ActiveRecord::RecordInvalid, error_record unless valid?(validation_context)
 
       updating? ? update_admin : create_admin
     end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -98,6 +98,7 @@ class User < ApplicationRecord
 
   scope :students, -> { joins(:user_role).where(user_roles: { name: 'student' }) }
   scope :teachers, -> { joins(:user_role).where(user_roles: { name: 'teacher' }) }
+  scope :admins, -> { joins(:user_role).where(user_roles: { name: 'admin' }) }
   scope :by_high_school, ->(high_school_ids) { where(high_school_id: high_school_ids) }
   scope :high_school_current, -> { joins(:grade).where(grades: { year: 1..3 }) }
   scope :invitation_pending, -> { where(password_reset_required: true) }

--- a/rails/app/queries/admins_query.rb
+++ b/rails/app/queries/admins_query.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AdminsQuery
+  def initialize(scope = User.admins.where(deleted_at: nil))
+    @scope = scope
+  end
+
+  def search(keyword)
+    return self if keyword.blank?
+
+    pattern = "%#{ActiveRecord::Base.sanitize_sql_like(keyword)}%"
+    @scope = @scope.where('users.name LIKE :p OR users.email LIKE :p', p: pattern)
+    self
+  end
+
+  def order_default
+    @scope = @scope.order(created_at: :desc)
+    self
+  end
+
+  def result
+    @scope
+  end
+end

--- a/rails/app/serializers/admin/admin_detail_serializer.rb
+++ b/rails/app/serializers/admin/admin_detail_serializer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Admin
+  class AdminDetailSerializer < ActiveModel::Serializer
+    attributes :id, :name, :email, :created_at, :updated_at, :activity_log
+
+    def activity_log
+      []
+    end
+  end
+end

--- a/rails/app/serializers/admin/admin_list_serializer.rb
+++ b/rails/app/serializers/admin/admin_list_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Admin
+  class AdminListSerializer < ActiveModel::Serializer
+    attributes :id, :name, :email, :created_at
+  end
+end

--- a/rails/app/services/admin/create_admin_service.rb
+++ b/rails/app/services/admin/create_admin_service.rb
@@ -23,7 +23,7 @@ module Admin
         token = user.send(:set_reset_password_token)
         AuthMailer.invite_teacher(user, token).deliver_later
 
-        user.reload
+        user
       end
     end
   end

--- a/rails/app/services/admin/create_admin_service.rb
+++ b/rails/app/services/admin/create_admin_service.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Admin
+  class CreateAdminService
+    def initialize(name:, email:)
+      @name = name
+      @email = email
+    end
+
+    def call
+      ActiveRecord::Base.transaction do
+        role = UserRole.find_or_create_by!(name: :admin)
+        password = SecureRandom.hex(16)
+        user = User.create!(
+          name: @name.presence || @email.to_s.split('@').first,
+          email: @email,
+          password: password,
+          password_confirmation: password,
+          user_role: role,
+          password_reset_required: true
+        )
+
+        token = user.send(:set_reset_password_token)
+        AuthMailer.invite_teacher(user, token).deliver_later
+
+        user.reload
+      end
+    end
+  end
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
 
       namespace :admin do
         resource :dashboard, only: :show
+        resources :admins
         resources :high_schools, only: [:index, :show] do
           resources :teachers, only: [:index, :create, :update]
         end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -53,7 +53,7 @@ Rails.application.routes.draw do
 
       namespace :admin do
         resource :dashboard, only: :show
-        resources :admins
+        resources :admins, only: [:index, :show, :create, :update, :destroy]
         resources :high_schools, only: [:index, :show] do
           resources :teachers, only: [:index, :create, :update]
         end

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -134,4 +134,50 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
       end
     end
   end
+
+  describe 'GET /api/v1/admin/admins/:id' do
+    let!(:admin_user) { create(:user, :admin, high_school: nil) }
+    let(:cookie)      { login_and_get_cookie(admin_user) }
+
+    context '正常系' do
+      let!(:target) do
+        create(:user, :admin, high_school: nil, name: '対象管理者', email: 'target-admin@example.com')
+      end
+
+      it 'ステータス200が返される' do
+        get "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '詳細レスポンスに id/name/email/created_at/updated_at/activity_log を含む' do
+        get "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
+        admin_data = response.parsed_body['admin']
+        expect(admin_data.keys).to include('id', 'name', 'email', 'created_at', 'updated_at', 'activity_log')
+      end
+
+      it 'activity_log は空配列で返される' do
+        get "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response.parsed_body['admin']['activity_log']).to eq([])
+      end
+    end
+
+    context '異常系' do
+      it '存在しないidの場合404が返される' do
+        get '/api/v1/admin/admins/0', headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'admin以外のロールのユーザーidの場合404が返される' do
+        teacher = create(:user, :teacher, high_school: create(:high_school), grade: nil)
+        get "/api/v1/admin/admins/#{teacher.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it '論理削除済みadminのidの場合404が返される' do
+        deleted = create(:user, :admin, high_school: nil, deleted_at: Time.current)
+        get "/api/v1/admin/admins/#{deleted.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
 end

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -146,6 +146,20 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
         expect(response.parsed_body['admins'].size).to eq(1)
         expect(response.parsed_body['meta']['total_pages']).to eq(2)
       end
+
+      it 'per_page が上限 (100) を超える値で送られても 100 にクランプされる' do
+        get '/api/v1/admin/admins',
+            params: { per_page: 10_000_000 },
+            headers: headers.merge('Cookie' => cookie)
+        expect(response.parsed_body['meta']['per_page']).to eq(100)
+      end
+
+      it 'per_page が 0 や負値の場合はデフォルト値が使われる' do
+        get '/api/v1/admin/admins',
+            params: { per_page: 0 },
+            headers: headers.merge('Cookie' => cookie)
+        expect(response.parsed_body['meta']['per_page']).to eq(25)
+      end
     end
   end
 

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -235,4 +235,59 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
       end
     end
   end
+
+  describe 'PATCH /api/v1/admin/admins/:id' do
+    let!(:admin_user) { create(:user, :admin, high_school: nil) }
+    let!(:target) do
+      create(:user, :admin, high_school: nil, name: '更新前太郎', email: 'before-admin@example.com')
+    end
+    let(:cookie) { login_and_get_cookie(admin_user) }
+    let(:valid_params) do
+      { name: '更新後太郎', email: 'after-admin@example.com' }.to_json
+    end
+
+    context '正常系' do
+      it 'ステータス200が返される' do
+        patch "/api/v1/admin/admins/#{target.id}",
+              params: valid_params,
+              headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'name / email が更新される' do
+        patch "/api/v1/admin/admins/#{target.id}",
+              params: valid_params,
+              headers: headers.merge('Cookie' => cookie)
+        admin_data = response.parsed_body['admin']
+        expect(admin_data['name']).to eq('更新後太郎')
+        expect(admin_data['email']).to eq('after-admin@example.com')
+      end
+
+      it 'DBに永続化される' do
+        patch "/api/v1/admin/admins/#{target.id}",
+              params: valid_params,
+              headers: headers.merge('Cookie' => cookie)
+        target.reload
+        expect(target.name).to eq('更新後太郎')
+        expect(target.email).to eq('after-admin@example.com')
+      end
+    end
+
+    context '異常系' do
+      it '存在しないidの場合 404 が返される' do
+        patch '/api/v1/admin/admins/0',
+              params: valid_params,
+              headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'email 重複の場合 422 が返される' do
+        create(:user, :admin, high_school: nil, email: 'taken@example.com')
+        patch "/api/v1/admin/admins/#{target.id}",
+              params: { email: 'taken@example.com' }.to_json,
+              headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
 end

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -17,52 +17,66 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
     response.headers['Set-Cookie']&.split(';')&.first
   end
 
-  describe 'ルーティング・認可' do
+  describe '認可' do
     let!(:admin_user)   { create(:user, :admin, high_school: nil) }
     let!(:student_user) { create(:user) }
-    let(:admin_cookie)   { login_and_get_cookie(admin_user) }
     let(:student_cookie) { login_and_get_cookie(student_user) }
+    let(:create_body) { { name: 'x', email: 'x@example.com' }.to_json }
+    let(:update_body) { { name: 'x' }.to_json }
 
-    shared_examples '未認証は401' do |verb, path_proc, body: nil|
-      it '401が返される' do
-        send(verb, instance_exec(&path_proc), params: body, headers: headers)
+    context '未認証アクセス' do
+      it 'GET /admins は401' do
+        get '/api/v1/admin/admins', headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'GET /admins/:id は401' do
+        get "/api/v1/admin/admins/#{admin_user.id}", headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'POST /admins は401' do
+        post '/api/v1/admin/admins', params: create_body, headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'PATCH /admins/:id は401' do
+        patch "/api/v1/admin/admins/#{admin_user.id}", params: update_body, headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'DELETE /admins/:id は401' do
+        delete "/api/v1/admin/admins/#{admin_user.id}", headers: headers
         expect(response).to have_http_status(:unauthorized)
       end
     end
 
-    shared_examples '非adminロールは403' do |verb, path_proc, body: nil|
-      it '403が返される' do
-        send(verb, instance_exec(&path_proc),
-             params: body,
-             headers: headers.merge('Cookie' => student_cookie))
+    context '非adminロール (student) アクセス' do
+      it 'GET /admins は403' do
+        get '/api/v1/admin/admins', headers: headers.merge('Cookie' => student_cookie)
         expect(response).to have_http_status(:forbidden)
       end
-    end
 
-    describe 'GET /api/v1/admin/admins' do
-      include_examples '未認証は401', :get, -> { '/api/v1/admin/admins' }
-      include_examples '非adminロールは403', :get, -> { '/api/v1/admin/admins' }
-    end
+      it 'GET /admins/:id は403' do
+        get "/api/v1/admin/admins/#{admin_user.id}", headers: headers.merge('Cookie' => student_cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
 
-    describe 'GET /api/v1/admin/admins/:id' do
-      include_examples '未認証は401', :get, -> { "/api/v1/admin/admins/#{admin_user.id}" }
-      include_examples '非adminロールは403', :get, -> { "/api/v1/admin/admins/#{admin_user.id}" }
-    end
+      it 'POST /admins は403' do
+        post '/api/v1/admin/admins', params: create_body, headers: headers.merge('Cookie' => student_cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
 
-    describe 'POST /api/v1/admin/admins' do
-      let(:body) { { name: 'x', email: 'x@example.com' }.to_json }
-      include_examples '未認証は401', :post, -> { '/api/v1/admin/admins' }, body: lambda { { name: 'x', email: 'x@example.com' }.to_json }.call
-      include_examples '非adminロールは403', :post, -> { '/api/v1/admin/admins' }, body: lambda { { name: 'x', email: 'x@example.com' }.to_json }.call
-    end
+      it 'PATCH /admins/:id は403' do
+        patch "/api/v1/admin/admins/#{admin_user.id}",
+              params: update_body, headers: headers.merge('Cookie' => student_cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
 
-    describe 'PATCH /api/v1/admin/admins/:id' do
-      include_examples '未認証は401', :patch, -> { "/api/v1/admin/admins/#{admin_user.id}" }, body: lambda { { name: 'x' }.to_json }.call
-      include_examples '非adminロールは403', :patch, -> { "/api/v1/admin/admins/#{admin_user.id}" }, body: lambda { { name: 'x' }.to_json }.call
-    end
-
-    describe 'DELETE /api/v1/admin/admins/:id' do
-      include_examples '未認証は401', :delete, -> { "/api/v1/admin/admins/#{admin_user.id}" }
-      include_examples '非adminロールは403', :delete, -> { "/api/v1/admin/admins/#{admin_user.id}" }
+      it 'DELETE /admins/:id は403' do
+        delete "/api/v1/admin/admins/#{admin_user.id}", headers: headers.merge('Cookie' => student_cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Admins', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'ルーティング・認可' do
+    let!(:admin_user)   { create(:user, :admin, high_school: nil) }
+    let!(:student_user) { create(:user) }
+    let(:admin_cookie)   { login_and_get_cookie(admin_user) }
+    let(:student_cookie) { login_and_get_cookie(student_user) }
+
+    shared_examples '未認証は401' do |verb, path_proc, body: nil|
+      it '401が返される' do
+        send(verb, instance_exec(&path_proc), params: body, headers: headers)
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    shared_examples '非adminロールは403' do |verb, path_proc, body: nil|
+      it '403が返される' do
+        send(verb, instance_exec(&path_proc),
+             params: body,
+             headers: headers.merge('Cookie' => student_cookie))
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    describe 'GET /api/v1/admin/admins' do
+      include_examples '未認証は401', :get, -> { '/api/v1/admin/admins' }
+      include_examples '非adminロールは403', :get, -> { '/api/v1/admin/admins' }
+    end
+
+    describe 'GET /api/v1/admin/admins/:id' do
+      include_examples '未認証は401', :get, -> { "/api/v1/admin/admins/#{admin_user.id}" }
+      include_examples '非adminロールは403', :get, -> { "/api/v1/admin/admins/#{admin_user.id}" }
+    end
+
+    describe 'POST /api/v1/admin/admins' do
+      let(:body) { { name: 'x', email: 'x@example.com' }.to_json }
+      include_examples '未認証は401', :post, -> { '/api/v1/admin/admins' }, body: lambda { { name: 'x', email: 'x@example.com' }.to_json }.call
+      include_examples '非adminロールは403', :post, -> { '/api/v1/admin/admins' }, body: lambda { { name: 'x', email: 'x@example.com' }.to_json }.call
+    end
+
+    describe 'PATCH /api/v1/admin/admins/:id' do
+      include_examples '未認証は401', :patch, -> { "/api/v1/admin/admins/#{admin_user.id}" }, body: lambda { { name: 'x' }.to_json }.call
+      include_examples '非adminロールは403', :patch, -> { "/api/v1/admin/admins/#{admin_user.id}" }, body: lambda { { name: 'x' }.to_json }.call
+    end
+
+    describe 'DELETE /api/v1/admin/admins/:id' do
+      include_examples '未認証は401', :delete, -> { "/api/v1/admin/admins/#{admin_user.id}" }
+      include_examples '非adminロールは403', :delete, -> { "/api/v1/admin/admins/#{admin_user.id}" }
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -116,10 +116,10 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
         expect(admin_data.keys).to include('id', 'name', 'email', 'created_at')
       end
 
-      it 'meta に page/per_page/total_pages/total_count が含まれる' do
+      it 'meta に current_page/per_page/total_pages/total_count が含まれる' do
         get '/api/v1/admin/admins', headers: headers.merge('Cookie' => cookie)
         meta = response.parsed_body['meta']
-        expect(meta.keys).to include('page', 'per_page', 'total_pages', 'total_count')
+        expect(meta.keys).to include('current_page', 'per_page', 'total_pages', 'total_count')
         expect(meta['total_count']).to eq(2)
       end
 

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -65,4 +65,73 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
       include_examples '非adminロールは403', :delete, -> { "/api/v1/admin/admins/#{admin_user.id}" }
     end
   end
+
+  describe 'GET /api/v1/admin/admins' do
+    let!(:admin_user) { create(:user, :admin, high_school: nil, name: 'メイン管理者', email: 'main-admin@example.com') }
+    let(:cookie)      { login_and_get_cookie(admin_user) }
+
+    context '正常系' do
+      let!(:another_admin) do
+        create(:user, :admin, high_school: nil, name: '田中管理者', email: 'tanaka-admin@example.com')
+      end
+      let!(:deleted_admin) do
+        create(:user, :admin, high_school: nil, name: '削除済', email: 'deleted-admin@example.com',
+                              deleted_at: Time.current)
+      end
+      let!(:teacher_user) { create(:user, :teacher, high_school: create(:high_school), grade: nil) }
+
+      it 'ステータス200が返される' do
+        get '/api/v1/admin/admins', headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'admins と meta キーが含まれる' do
+        get '/api/v1/admin/admins', headers: headers.merge('Cookie' => cookie)
+        expect(response.parsed_body.keys).to include('admins', 'meta')
+      end
+
+      it 'adminロールかつ deleted_at が nil のユーザーだけが返される' do
+        get '/api/v1/admin/admins', headers: headers.merge('Cookie' => cookie)
+        ids = response.parsed_body['admins'].pluck('id')
+        expect(ids).to contain_exactly(admin_user.id, another_admin.id)
+      end
+
+      it '各 admin に必要なフィールドが含まれる' do
+        get '/api/v1/admin/admins', headers: headers.merge('Cookie' => cookie)
+        admin_data = response.parsed_body['admins'].first
+        expect(admin_data.keys).to include('id', 'name', 'email', 'created_at')
+      end
+
+      it 'meta に page/per_page/total_pages/total_count が含まれる' do
+        get '/api/v1/admin/admins', headers: headers.merge('Cookie' => cookie)
+        meta = response.parsed_body['meta']
+        expect(meta.keys).to include('page', 'per_page', 'total_pages', 'total_count')
+        expect(meta['total_count']).to eq(2)
+      end
+
+      it 'q で name の部分一致絞り込みができる' do
+        get '/api/v1/admin/admins',
+            params: { q: '田中' },
+            headers: headers.merge('Cookie' => cookie)
+        ids = response.parsed_body['admins'].pluck('id')
+        expect(ids).to contain_exactly(another_admin.id)
+      end
+
+      it 'q で email の部分一致絞り込みができる' do
+        get '/api/v1/admin/admins',
+            params: { q: 'tanaka-admin' },
+            headers: headers.merge('Cookie' => cookie)
+        ids = response.parsed_body['admins'].pluck('id')
+        expect(ids).to contain_exactly(another_admin.id)
+      end
+
+      it 'per_page で件数を制限できる' do
+        get '/api/v1/admin/admins',
+            params: { per_page: 1, page: 1 },
+            headers: headers.merge('Cookie' => cookie)
+        expect(response.parsed_body['admins'].size).to eq(1)
+        expect(response.parsed_body['meta']['total_pages']).to eq(2)
+      end
+    end
+  end
 end

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -290,4 +290,84 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
       end
     end
   end
+
+  describe 'DELETE /api/v1/admin/admins/:id' do
+    let!(:admin_user) { create(:user, :admin, high_school: nil) }
+    let(:cookie)      { login_and_get_cookie(admin_user) }
+
+    context '正常系' do
+      let!(:target) { create(:user, :admin, high_school: nil) }
+
+      it 'ステータス204が返される' do
+        delete "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      it '対象adminに deleted_at がセットされる' do
+        freeze_time = Time.zone.now
+        travel_to(freeze_time) do
+          delete "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
+        end
+        target.reload
+        expect(target.deleted_at).to be_present
+      end
+
+      it '一覧から消える' do
+        delete "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
+        get '/api/v1/admin/admins', headers: headers.merge('Cookie' => cookie)
+        ids = response.parsed_body['admins'].pluck('id')
+        expect(ids).not_to include(target.id)
+      end
+    end
+
+    context '異常系' do
+      it '存在しないidの場合 404 が返される' do
+        delete '/api/v1/admin/admins/0', headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context 'ガード - 自分自身は削除不可' do
+      # 他にも admin がいる状態で自分を消そうとするケース → 自己削除ガード
+      let!(:another_admin) { create(:user, :admin, high_school: nil) }
+
+      it '422が返される' do
+        delete "/api/v1/admin/admins/#{admin_user.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it 'errors に「自分自身」を含むメッセージが返される' do
+        delete "/api/v1/admin/admins/#{admin_user.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response.parsed_body['errors']).to include(a_string_matching(/自分自身/))
+      end
+
+      it 'deleted_at は更新されない' do
+        delete "/api/v1/admin/admins/#{admin_user.id}", headers: headers.merge('Cookie' => cookie)
+        admin_user.reload
+        expect(admin_user.deleted_at).to be_nil
+      end
+    end
+
+    context 'ガード - 最後の admin は削除不可' do
+      # 「最後の admin = 削除によってアクティブ admin が0人になる」状況は、
+      # 自己削除ガードと重なるため、ガード順序を『最後のadmin → 自己削除 → 論理削除』とし
+      # 「自分が唯一の admin で自分を消す」ケースで422になることを以て担保する。
+      it '自分が最後の admin の状態で自分を消そうとすると 422 が返される' do
+        # admin_user 以外の admin は存在しない (=admin_user が唯一のアクティブadmin)
+        delete "/api/v1/admin/admins/#{admin_user.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+
+      it 'errors に「最後の管理者」を含むメッセージが返される' do
+        delete "/api/v1/admin/admins/#{admin_user.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response.parsed_body['errors']).to include(a_string_matching(/最後の管理者/))
+      end
+
+      it 'deleted_at は更新されない' do
+        delete "/api/v1/admin/admins/#{admin_user.id}", headers: headers.merge('Cookie' => cookie)
+        admin_user.reload
+        expect(admin_user.deleted_at).to be_nil
+      end
+    end
+  end
 end

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -304,10 +304,7 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
       end
 
       it '対象adminに deleted_at がセットされる' do
-        freeze_time = Time.zone.now
-        travel_to(freeze_time) do
-          delete "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
-        end
+        delete "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
         target.reload
         expect(target.deleted_at).to be_present
       end

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -180,4 +180,59 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
       end
     end
   end
+
+  describe 'POST /api/v1/admin/admins' do
+    let!(:admin_user) { create(:user, :admin, high_school: nil) }
+    let(:cookie)      { login_and_get_cookie(admin_user) }
+    let(:valid_params) do
+      { name: '新規管理者', email: 'new-admin@example.com' }.to_json
+    end
+
+    context '正常系' do
+      it 'ステータス201が返される' do
+        post '/api/v1/admin/admins',
+             params: valid_params,
+             headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:created)
+      end
+
+      it '作成された admin が返される' do
+        post '/api/v1/admin/admins',
+             params: valid_params,
+             headers: headers.merge('Cookie' => cookie)
+        admin_data = response.parsed_body['admin']
+        expect(admin_data['name']).to eq('新規管理者')
+        expect(admin_data['email']).to eq('new-admin@example.com')
+      end
+
+      it 'admin ロールの User が新規作成され password_reset_required: true となる' do
+        expect do
+          post '/api/v1/admin/admins',
+               params: valid_params,
+               headers: headers.merge('Cookie' => cookie)
+        end.to change { User.admins.count }.by(1)
+
+        created = User.admins.find_by(email: 'new-admin@example.com')
+        expect(created.password_reset_required).to be(true)
+      end
+    end
+
+    context '異常系' do
+      it 'email が空の場合 422 が返される' do
+        post '/api/v1/admin/admins',
+             params: { name: '名前のみ', email: '' }.to_json,
+             headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body).to have_key('errors')
+      end
+
+      it 'email が重複している場合 422 が返される' do
+        create(:user, :admin, high_school: nil, email: 'dup-admin@example.com')
+        post '/api/v1/admin/admins',
+             params: { name: '重複', email: 'dup-admin@example.com' }.to_json,
+             headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要

issue #61 の対応。管理画面で管理者(admin ロールの User)を CRUD するための API を 5 本実装。

- `GET /api/v1/admin/admins` — 一覧 (page, per_page, q)
- `GET /api/v1/admin/admins/:id` — 詳細 (+ activity_log スタブ)
- `POST /api/v1/admin/admins` — 新規作成 (name, email)
- `PATCH /api/v1/admin/admins/:id` — 編集 (name, email)
- `DELETE /api/v1/admin/admins/:id` — 論理削除 (deleted_at)

## 詳細

### 設計上のポイント

- **Admin の実体は `User` + `user_role: admin`**。専用 Admin モデルは新設せず、`scope :admins` を `User` に追加して扱う。
- 既存の admin API (`Admin::TeachersController` / `Admin::HighSchoolsController`) のパターンに揃え、`Admin::BaseController#authorize_admin_service` (Pundit `AdminServicePolicy#access?`) を継承。
- 認証は既存と同じ Cookie + JWT (devise-jwt)。401/403 は BaseController で自動担保。
- レイヤー: `AdminsQuery` (検索/並び替え) + `Admin::AdminForm` (create/update) + `Admin::CreateAdminService` (招待メール込みの作成) + `Admin::AdminListSerializer` / `Admin::AdminDetailSerializer` の 5 構成。
- 新規作成時の初期 password はサーバー側で `SecureRandom.hex(16)` 生成し `password_reset_required: true`。`AuthMailer.invite_teacher` を流用 (件名・本文がロール非依存のため)。これは既存 `Admin::CreateTeacherService` と同パターン。

### 削除ガード (2 種)

| ケース | ステータス |
| --- | --- |
| 自分自身を削除 | 422 + `\"自分自身は削除できません\"` |
| 最後の admin を削除 | 422 + `\"最後の管理者は削除できません\"` |

ガード順序は **「最後の admin → 自己削除」** とすることで、エラーメッセージで両ガードを識別可能にしている。

### 異常系

| ケース | ステータス |
| --- | --- |
| 未認証アクセス | 401 |
| 非 admin (生徒・教員) アクセス | 403 |
| 存在しない id / 他ロールユーザー id / 論理削除済み id | 404 |
| email 重複・形式不正 | 422 |

### activity_log の扱い

詳細レスポンスに含まれる `activity_log` は本 PR では **空配列を返すスタブ**。クライアント側がスキーマ変更を意識せず将来差し替えできるよう、Serializer のメソッドとして閉じ込めている。audit gem (audited / paper_trail) の導入は別 issue に分離。

### `status` / `last_sign_in_at` の扱い

issue の文言には含まれていたが、現状 `User` モデルに該当列がなく (`devise :trackable` 未導入)、本 PR では **レスポンスから除外**。後続 issue で `devise :trackable` 有効化と合わせて対応する想定。

## 動作確認

### 自動テスト

- `docker compose exec rails bundle exec rspec spec/requests/api/v1/admin/admins_spec.rb` → **46 examples, 0 failures**
- `docker compose exec rails bundle exec rspec` 全体 → **472 examples, 0 failures, 2 pending** (pending は既存の未実装スケルトンで本 PR と無関係)
- `docker compose exec rails bundle exec rubocop` 対象ファイル群 → **0 offenses**

### 手動確認手順 (参考)

\`\`\`sh
# admin ユーザーでログイン → Cookie 取得
curl -i -X POST http://localhost:5001/api/v1/user/login \\
  -H 'Content-Type: application/json' \\
  -d '{\"email\":\"admin@example.com\",\"password\":\"password\"}' -c /tmp/cookie.txt

# 一覧 (page / per_page / q)
curl -i 'http://localhost:5001/api/v1/admin/admins?page=1&per_page=10&q=tanaka' -b /tmp/cookie.txt

# 詳細
curl -i http://localhost:5001/api/v1/admin/admins/1 -b /tmp/cookie.txt

# 作成
curl -i -X POST http://localhost:5001/api/v1/admin/admins \\
  -H 'Content-Type: application/json' -b /tmp/cookie.txt \\
  -d '{\"name\":\"テスト管理者\",\"email\":\"test-admin@example.com\"}'

# 編集
curl -i -X PATCH http://localhost:5001/api/v1/admin/admins/2 \\
  -H 'Content-Type: application/json' -b /tmp/cookie.txt \\
  -d '{\"name\":\"更新後\"}'

# 論理削除
curl -i -X DELETE http://localhost:5001/api/v1/admin/admins/2 -b /tmp/cookie.txt

# 自己削除ガード (admin が複数いる前提で自分自身の id を指定 → 422)
curl -i -X DELETE http://localhost:5001/api/v1/admin/admins/<自分の id> -b /tmp/cookie.txt

# 最後の admin ガード (admin が自分1人の状態で自分を消す → 422)
\`\`\`

## その他

- 新規 gem 追加なし (kaminari は既存導入済み)。
- 既存 `User` モデルに `scope :admins` を追加。teacher/student の同種 scope に並ぶ無害な追加。

## レビューで議論したい点 (Should 級・本 PR scope 外案)

- **論理削除済み admin のログイン**: 現状 `User#active_for_authentication?` のオーバーライドがなく、deleted_at が立った admin もログイン可能。User モデル全体 (teacher/student も) に影響するため別 issue 化を提案。
- **エラーレスポンス形式**: 既存規約に合わせて `{ errors: [文字列配列] }` としたが、フィールド別エラーが必要になったタイミングで全体改定すべき。

## 参考情報

- issue: #61
- 親 issue: #49