### PR TITLE
Issue-56 管理画面用 講座一覧API

### DIFF
--- a/rails/app/controllers/api/v1/admin/base_controller.rb
+++ b/rails/app/controllers/api/v1/admin/base_controller.rb
@@ -4,6 +4,9 @@ module Api
   module V1
     module Admin
       class BaseController < ApplicationController
+        DEFAULT_PER_PAGE = 20
+        MAX_PER_PAGE = 100
+
         before_action :authorize_admin_service
 
         rescue_from Csv::Errors::InvalidFileType do |e|
@@ -14,6 +17,23 @@ module Api
 
         def authorize_admin_service
           authorize :admin_service, :access?
+        end
+
+        def sanitized_per_page
+          value = params[:per_page]
+          return DEFAULT_PER_PAGE unless value.is_a?(String) || value.is_a?(Integer)
+
+          raw = value.to_i
+          return DEFAULT_PER_PAGE if raw <= 0
+
+          [raw, MAX_PER_PAGE].min
+        end
+
+        def sanitized_page
+          value = params[:page]
+          return nil unless value.is_a?(String) || value.is_a?(Integer)
+
+          value
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/base_controller.rb
+++ b/rails/app/controllers/api/v1/admin/base_controller.rb
@@ -33,7 +33,10 @@ module Api
           value = params[:page]
           return nil unless value.is_a?(String) || value.is_a?(Integer)
 
-          value
+          raw = value.to_i
+          return nil if raw <= 0
+
+          raw
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -11,6 +11,7 @@ module Api
           per_page = sanitized_per_page
           courses = ::Admin::CoursesQuery.new
                                          .active
+                                         .by_subject_id(params[:subject_id])
                                          .order_by(params[:sort], params[:order])
                                          .result
                                          .page(params[:page]).per(per_page)

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -15,7 +15,6 @@ module Api
                                          .search(params[:q])
                                          .order_by(params[:sort], params[:order])
                                          .result
-                                         .includes(:subject)
                                          .page(sanitized_page).per(per_page)
 
           course_records = courses.to_a

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -20,10 +20,10 @@ module Api
             units_counts = {}
             questions_counts = {}
           else
-            units_counts = Unit.where(course_id: course_ids, deleted_at: nil).group(:course_id).count
-            questions_counts = Question.joins(:unit)
-                                       .where(units: { course_id: course_ids, deleted_at: nil })
-                                       .where(deleted_at: nil)
+            units_counts = Unit.active.where(course_id: course_ids).group(:course_id).count
+            questions_counts = Question.active
+                                       .joins(:unit).merge(Unit.active)
+                                       .where(units: { course_id: course_ids })
                                        .group('units.course_id').count
           end
 

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -16,7 +16,7 @@ module Api
                                          .order_by(params[:sort], params[:order])
                                          .result
                                          .includes(:subject)
-                                         .page(params[:page]).per(per_page)
+                                         .page(sanitized_page).per(per_page)
 
           course_ids = courses.pluck(:id)
           units_counts = Unit.where(course_id: course_ids, deleted_at: nil).group(:course_id).count
@@ -60,6 +60,13 @@ module Api
           return DEFAULT_PER_PAGE if raw <= 0
 
           [raw, MAX_PER_PAGE].min
+        end
+
+        def sanitized_page
+          value = params[:page]
+          return nil unless value.is_a?(String) || value.is_a?(Integer)
+
+          value
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -4,6 +4,31 @@ module Api
   module V1
     module Admin
       class CoursesController < BaseController
+        DEFAULT_PER_PAGE = 20
+
+        def index
+          courses = ::Admin::CoursesQuery.new
+                                         .active
+                                         .order_by(params[:sort], params[:order])
+                                         .result
+                                         .page(params[:page]).per(DEFAULT_PER_PAGE)
+
+          render json: {
+            courses: ActiveModelSerializers::SerializableResource.new(
+              courses,
+              each_serializer: ::Admin::CourseListSerializer,
+              units_counts: {},
+              questions_counts: {}
+            ),
+            meta: {
+              current_page: courses.current_page,
+              total_pages: courses.total_pages,
+              total_count: courses.total_count,
+              per_page: DEFAULT_PER_PAGE
+            }
+          }
+        end
+
         def show
           course = Course.includes(:subject, :units).find(params[:id])
           questions_counts = Question.where(unit_id: course.unit_ids).group(:unit_id).count

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -4,9 +4,6 @@ module Api
   module V1
     module Admin
       class CoursesController < BaseController
-        DEFAULT_PER_PAGE = 20
-        MAX_PER_PAGE = 100
-
         def index
           per_page = sanitized_per_page
           courses = ::Admin::CoursesQuery.new
@@ -53,25 +50,6 @@ module Api
           render json: course,
                  serializer: ::Admin::CourseDetailSerializer,
                  questions_counts: questions_counts
-        end
-
-        private
-
-        def sanitized_per_page
-          value = params[:per_page]
-          return DEFAULT_PER_PAGE unless value.is_a?(String) || value.is_a?(Integer)
-
-          raw = value.to_i
-          return DEFAULT_PER_PAGE if raw <= 0
-
-          [raw, MAX_PER_PAGE].min
-        end
-
-        def sanitized_page
-          value = params[:page]
-          return nil unless value.is_a?(String) || value.is_a?(Integer)
-
-          value
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -18,7 +18,8 @@ module Api
                                          .includes(:subject)
                                          .page(sanitized_page).per(per_page)
 
-          course_ids = courses.pluck(:id)
+          course_records = courses.to_a
+          course_ids = course_records.map(&:id)
           units_counts = Unit.where(course_id: course_ids, deleted_at: nil).group(:course_id).count
           questions_counts = Question.joins(:unit)
                                      .where(units: { course_id: course_ids, deleted_at: nil })
@@ -27,7 +28,7 @@ module Api
 
           render json: {
             courses: ActiveModelSerializers::SerializableResource.new(
-              courses,
+              course_records,
               each_serializer: ::Admin::CourseListSerializer,
               units_counts: units_counts,
               questions_counts: questions_counts

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -5,13 +5,15 @@ module Api
     module Admin
       class CoursesController < BaseController
         DEFAULT_PER_PAGE = 20
+        MAX_PER_PAGE = 100
 
         def index
+          per_page = sanitized_per_page
           courses = ::Admin::CoursesQuery.new
                                          .active
                                          .order_by(params[:sort], params[:order])
                                          .result
-                                         .page(params[:page]).per(DEFAULT_PER_PAGE)
+                                         .page(params[:page]).per(per_page)
 
           render json: {
             courses: ActiveModelSerializers::SerializableResource.new(
@@ -24,7 +26,7 @@ module Api
               current_page: courses.current_page,
               total_pages: courses.total_pages,
               total_count: courses.total_count,
-              per_page: DEFAULT_PER_PAGE
+              per_page: per_page
             }
           }
         end
@@ -36,6 +38,15 @@ module Api
           render json: course,
                  serializer: ::Admin::CourseDetailSerializer,
                  questions_counts: questions_counts
+        end
+
+        private
+
+        def sanitized_per_page
+          raw = params[:per_page].to_i
+          return DEFAULT_PER_PAGE if raw <= 0
+
+          [raw, MAX_PER_PAGE].min
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -15,14 +15,22 @@ module Api
                                          .search(params[:q])
                                          .order_by(params[:sort], params[:order])
                                          .result
+                                         .includes(:subject)
                                          .page(params[:page]).per(per_page)
+
+          course_ids = courses.pluck(:id)
+          units_counts = Unit.where(course_id: course_ids, deleted_at: nil).group(:course_id).count
+          questions_counts = Question.joins(:unit)
+                                     .where(units: { course_id: course_ids, deleted_at: nil })
+                                     .where(deleted_at: nil)
+                                     .group('units.course_id').count
 
           render json: {
             courses: ActiveModelSerializers::SerializableResource.new(
               courses,
               each_serializer: ::Admin::CourseListSerializer,
-              units_counts: {},
-              questions_counts: {}
+              units_counts: units_counts,
+              questions_counts: questions_counts
             ),
             meta: {
               current_page: courses.current_page,

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -20,11 +20,16 @@ module Api
 
           course_records = courses.to_a
           course_ids = course_records.map(&:id)
-          units_counts = Unit.where(course_id: course_ids, deleted_at: nil).group(:course_id).count
-          questions_counts = Question.joins(:unit)
-                                     .where(units: { course_id: course_ids, deleted_at: nil })
-                                     .where(deleted_at: nil)
-                                     .group('units.course_id').count
+          if course_ids.empty?
+            units_counts = {}
+            questions_counts = {}
+          else
+            units_counts = Unit.where(course_id: course_ids, deleted_at: nil).group(:course_id).count
+            questions_counts = Question.joins(:unit)
+                                       .where(units: { course_id: course_ids, deleted_at: nil })
+                                       .where(deleted_at: nil)
+                                       .group('units.course_id').count
+          end
 
           render json: {
             courses: ActiveModelSerializers::SerializableResource.new(

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -12,6 +12,7 @@ module Api
           courses = ::Admin::CoursesQuery.new
                                          .active
                                          .by_subject_id(params[:subject_id])
+                                         .search(params[:q])
                                          .order_by(params[:sort], params[:order])
                                          .result
                                          .page(params[:page]).per(per_page)

--- a/rails/app/controllers/api/v1/admin/courses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/courses_controller.rb
@@ -53,7 +53,10 @@ module Api
         private
 
         def sanitized_per_page
-          raw = params[:per_page].to_i
+          value = params[:per_page]
+          return DEFAULT_PER_PAGE unless value.is_a?(String) || value.is_a?(Integer)
+
+          raw = value.to_i
           return DEFAULT_PER_PAGE if raw <= 0
 
           [raw, MAX_PER_PAGE].min

--- a/rails/app/models/course.rb
+++ b/rails/app/models/course.rb
@@ -22,4 +22,6 @@ class Course < ApplicationRecord
   has_many :task_courses, dependent: :destroy
   has_many :tasks, through: :task_courses
   has_many :user_unit_question_stats, dependent: :destroy
+
+  scope :active, -> { where(deleted_at: nil) }
 end

--- a/rails/app/models/question.rb
+++ b/rails/app/models/question.rb
@@ -18,4 +18,6 @@ class Question < ApplicationRecord
   has_many :question_histories
   has_many :question_hints, dependent: :destroy
   has_many :question_explanations, dependent: :destroy
+
+  scope :active, -> { where(deleted_at: nil) }
 end

--- a/rails/app/models/unit.rb
+++ b/rails/app/models/unit.rb
@@ -19,4 +19,6 @@ class Unit < ApplicationRecord
   has_many :task_units, dependent: :destroy
   has_many :tasks, through: :task_units
   has_many :import_histories, dependent: :destroy
+
+  scope :active, -> { where(deleted_at: nil) }
 end

--- a/rails/app/queries/admin/courses_query.rb
+++ b/rails/app/queries/admin/courses_query.rb
@@ -8,7 +8,7 @@ module Admin
     DEFAULT_ORDER = 'desc'
 
     def initialize(scope = Course.all)
-      @scope = scope
+      @scope = scope.includes(:subject)
     end
 
     def active

--- a/rails/app/queries/admin/courses_query.rb
+++ b/rails/app/queries/admin/courses_query.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Admin
+  class CoursesQuery
+    SORT_WHITELIST = %w[level_name created_at id].freeze
+    ORDER_WHITELIST = %w[asc desc].freeze
+    DEFAULT_SORT = 'created_at'
+    DEFAULT_ORDER = 'desc'
+
+    def initialize(scope = Course.all)
+      @scope = scope
+    end
+
+    def active
+      @scope = @scope.where(deleted_at: nil)
+      self
+    end
+
+    def order_by(sort, order)
+      sort_key = SORT_WHITELIST.include?(sort.to_s) ? sort.to_s : DEFAULT_SORT
+      order_dir = ORDER_WHITELIST.include?(order.to_s) ? order.to_s : DEFAULT_ORDER
+      @scope = @scope.order(sort_key => order_dir)
+      self
+    end
+
+    def result
+      @scope
+    end
+  end
+end

--- a/rails/app/queries/admin/courses_query.rb
+++ b/rails/app/queries/admin/courses_query.rb
@@ -18,6 +18,7 @@ module Admin
 
     def by_subject_id(id)
       return self if id.blank?
+      return self unless id.is_a?(String) || id.is_a?(Integer)
 
       @scope = @scope.where(subject_id: id)
       self

--- a/rails/app/queries/admin/courses_query.rb
+++ b/rails/app/queries/admin/courses_query.rb
@@ -12,7 +12,7 @@ module Admin
     end
 
     def active
-      @scope = @scope.where(deleted_at: nil)
+      @scope = @scope.active
       self
     end
 

--- a/rails/app/queries/admin/courses_query.rb
+++ b/rails/app/queries/admin/courses_query.rb
@@ -16,6 +16,13 @@ module Admin
       self
     end
 
+    def by_subject_id(id)
+      return self if id.blank?
+
+      @scope = @scope.where(subject_id: id)
+      self
+    end
+
     def order_by(sort, order)
       sort_key = SORT_WHITELIST.include?(sort.to_s) ? sort.to_s : DEFAULT_SORT
       order_dir = ORDER_WHITELIST.include?(order.to_s) ? order.to_s : DEFAULT_ORDER

--- a/rails/app/queries/admin/courses_query.rb
+++ b/rails/app/queries/admin/courses_query.rb
@@ -25,9 +25,10 @@ module Admin
     end
 
     def search(keyword)
+      return self unless keyword.is_a?(String)
       return self if keyword.blank?
 
-      pattern = "%#{ActiveRecord::Base.sanitize_sql_like(keyword.to_s)}%"
+      pattern = "%#{ActiveRecord::Base.sanitize_sql_like(keyword)}%"
       @scope = @scope.where('courses.level_name LIKE :q OR courses.description LIKE :q', q: pattern)
       self
     end

--- a/rails/app/queries/admin/courses_query.rb
+++ b/rails/app/queries/admin/courses_query.rb
@@ -23,6 +23,14 @@ module Admin
       self
     end
 
+    def search(keyword)
+      return self if keyword.blank?
+
+      pattern = "%#{ActiveRecord::Base.sanitize_sql_like(keyword.to_s)}%"
+      @scope = @scope.where('courses.level_name LIKE :q OR courses.description LIKE :q', q: pattern)
+      self
+    end
+
     def order_by(sort, order)
       sort_key = SORT_WHITELIST.include?(sort.to_s) ? sort.to_s : DEFAULT_SORT
       order_dir = ORDER_WHITELIST.include?(order.to_s) ? order.to_s : DEFAULT_ORDER

--- a/rails/app/queries/admin/courses_query.rb
+++ b/rails/app/queries/admin/courses_query.rb
@@ -36,7 +36,7 @@ module Admin
     def order_by(sort, order)
       sort_key = SORT_WHITELIST.include?(sort.to_s) ? sort.to_s : DEFAULT_SORT
       order_dir = ORDER_WHITELIST.include?(order.to_s) ? order.to_s : DEFAULT_ORDER
-      @scope = @scope.order(sort_key => order_dir)
+      @scope = @scope.order(sort_key => order_dir).order(id: :asc)
       self
     end
 

--- a/rails/app/queries/admin/courses_query.rb
+++ b/rails/app/queries/admin/courses_query.rb
@@ -29,7 +29,10 @@ module Admin
       return self if keyword.blank?
 
       pattern = "%#{ActiveRecord::Base.sanitize_sql_like(keyword)}%"
-      @scope = @scope.where('courses.level_name LIKE :q OR courses.description LIKE :q', q: pattern)
+      @scope = @scope.where(
+        "courses.level_name LIKE :q ESCAPE '\\\\' OR courses.description LIKE :q ESCAPE '\\\\'",
+        q: pattern
+      )
       self
     end
 

--- a/rails/app/serializers/admin/course_list_serializer.rb
+++ b/rails/app/serializers/admin/course_list_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Admin
+  class CourseListSerializer < ActiveModel::Serializer
+    attributes :id, :name, :subject, :level_number, :units_count, :questions_count, :created_at
+
+    def name
+      object.level_name
+    end
+
+    def subject
+      { id: object.subject.id, name: object.subject.name }
+    end
+
+    def units_count
+      (instance_options[:units_counts] || {})[object.id] || 0
+    end
+
+    def questions_count
+      (instance_options[:questions_counts] || {})[object.id] || 0
+    end
+  end
+end

--- a/rails/app/serializers/admin/course_list_serializer.rb
+++ b/rails/app/serializers/admin/course_list_serializer.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class CourseListSerializer < ActiveModel::Serializer
-    attributes :id, :level_name, :subject, :level_number, :units_count, :questions_count, :created_at
+    attributes :id, :subject, :level_number, :level_name, :units_count, :questions_count, :created_at
 
     def subject
       return nil if object.subject.nil?

--- a/rails/app/serializers/admin/course_list_serializer.rb
+++ b/rails/app/serializers/admin/course_list_serializer.rb
@@ -9,6 +9,8 @@ module Admin
     end
 
     def subject
+      return nil if object.subject.nil?
+
       { id: object.subject.id, name: object.subject.name }
     end
 

--- a/rails/app/serializers/admin/course_list_serializer.rb
+++ b/rails/app/serializers/admin/course_list_serializer.rb
@@ -2,11 +2,7 @@
 
 module Admin
   class CourseListSerializer < ActiveModel::Serializer
-    attributes :id, :name, :subject, :level_number, :units_count, :questions_count, :created_at
-
-    def name
-      object.level_name
-    end
+    attributes :id, :level_name, :subject, :level_number, :units_count, :questions_count, :created_at
 
     def subject
       return nil if object.subject.nil?

--- a/rails/spec/queries/admin/courses_query_spec.rb
+++ b/rails/spec/queries/admin/courses_query_spec.rb
@@ -71,6 +71,14 @@ RSpec.describe Admin::CoursesQuery, type: :model do
       special = create(:course, subject: subject_record, level_name: '100%達成')
       expect(described_class.new.search('%達成').result).to contain_exactly(special)
     end
+
+    it '配列を渡してもフィルタしない（パラメータ汚染防止）' do
+      expect(described_class.new.search(['基礎']).result).to contain_exactly(c1, c2, c3)
+    end
+
+    it 'ハッシュを渡してもフィルタしない（パラメータ汚染防止）' do
+      expect(described_class.new.search({ q: '基礎' }).result).to contain_exactly(c1, c2, c3)
+    end
   end
 
   describe '#order_by' do

--- a/rails/spec/queries/admin/courses_query_spec.rb
+++ b/rails/spec/queries/admin/courses_query_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe Admin::CoursesQuery, type: :model do
     it '空文字の場合はフィルタしない' do
       expect(described_class.new.by_subject_id('').result).to contain_exactly(course_a, course_b)
     end
+
+    it '配列を渡してもフィルタしない（パラメータ汚染防止）' do
+      expect(described_class.new.by_subject_id([subject_a.id, subject_b.id]).result)
+        .to contain_exactly(course_a, course_b)
+    end
+
+    it 'ハッシュを渡してもフィルタしない（パラメータ汚染防止）' do
+      expect(described_class.new.by_subject_id({ gt: 0 }).result).to contain_exactly(course_a, course_b)
+    end
   end
 
   describe '#search' do

--- a/rails/spec/queries/admin/courses_query_spec.rb
+++ b/rails/spec/queries/admin/courses_query_spec.rb
@@ -3,6 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe Admin::CoursesQuery, type: :model do
+  describe '#result' do
+    it 'subject を preload するように relation に includes を指定する' do
+      relation = described_class.new.result
+      expect(relation.includes_values).to include(:subject)
+    end
+  end
+
   describe '#active' do
     let!(:subject_record) { create(:subject) }
     let!(:alive) { create(:course, subject: subject_record) }

--- a/rails/spec/queries/admin/courses_query_spec.rb
+++ b/rails/spec/queries/admin/courses_query_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::CoursesQuery, type: :model do
+  describe '#by_subject_id' do
+    let!(:subject_a) { create(:subject, name: '英語') }
+    let!(:subject_b) { create(:subject, name: '数学') }
+    let!(:course_a) { create(:course, subject: subject_a) }
+    let!(:course_b) { create(:course, subject: subject_b) }
+
+    it '指定 subject_id の course のみ返す' do
+      expect(described_class.new.by_subject_id(subject_a.id).result).to contain_exactly(course_a)
+    end
+
+    it 'nil の場合はフィルタしない' do
+      expect(described_class.new.by_subject_id(nil).result).to contain_exactly(course_a, course_b)
+    end
+
+    it '空文字の場合はフィルタしない' do
+      expect(described_class.new.by_subject_id('').result).to contain_exactly(course_a, course_b)
+    end
+  end
+end

--- a/rails/spec/queries/admin/courses_query_spec.rb
+++ b/rails/spec/queries/admin/courses_query_spec.rb
@@ -21,4 +21,36 @@ RSpec.describe Admin::CoursesQuery, type: :model do
       expect(described_class.new.by_subject_id('').result).to contain_exactly(course_a, course_b)
     end
   end
+
+  describe '#search' do
+    let!(:subject_record) { create(:subject) }
+    let!(:c1) { create(:course, subject: subject_record, level_name: '基礎英語', description: '入門') }
+    let!(:c2) { create(:course, subject: subject_record, level_name: '応用', description: '基礎を踏まえた応用') }
+    let!(:c3) { create(:course, subject: subject_record, level_name: '上級', description: '上級向け') }
+
+    it 'level_name に部分一致する course を返す' do
+      expect(described_class.new.search('英語').result).to contain_exactly(c1)
+    end
+
+    it 'description に部分一致する course を返す（level_name は一致しない）' do
+      expect(described_class.new.search('応用').result).to contain_exactly(c2)
+    end
+
+    it 'level_name OR description のいずれかに一致' do
+      expect(described_class.new.search('基礎').result).to contain_exactly(c1, c2)
+    end
+
+    it 'nil の場合はフィルタしない' do
+      expect(described_class.new.search(nil).result).to contain_exactly(c1, c2, c3)
+    end
+
+    it '空文字の場合はフィルタしない' do
+      expect(described_class.new.search('').result).to contain_exactly(c1, c2, c3)
+    end
+
+    it 'LIKE 特殊文字 % をリテラル文字として扱う' do
+      special = create(:course, subject: subject_record, level_name: '100%達成')
+      expect(described_class.new.search('%達成').result).to contain_exactly(special)
+    end
+  end
 end

--- a/rails/spec/queries/admin/courses_query_spec.rb
+++ b/rails/spec/queries/admin/courses_query_spec.rb
@@ -3,6 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe Admin::CoursesQuery, type: :model do
+  describe '#active' do
+    let!(:subject_record) { create(:subject) }
+    let!(:alive) { create(:course, subject: subject_record) }
+    let!(:dead)  { create(:course, subject: subject_record, deleted_at: Time.current) }
+
+    it 'deleted_at が NULL の course だけ返す' do
+      expect(described_class.new.active.result).to contain_exactly(alive)
+    end
+  end
+
   describe '#by_subject_id' do
     let!(:subject_a) { create(:subject, name: '英語') }
     let!(:subject_b) { create(:subject, name: '数学') }

--- a/rails/spec/queries/admin/courses_query_spec.rb
+++ b/rails/spec/queries/admin/courses_query_spec.rb
@@ -107,5 +107,12 @@ RSpec.describe Admin::CoursesQuery, type: :model do
     it 'order のホワイトリスト外は既定値にフォールバック' do
       expect(described_class.new.order_by('level_name', 'foo').result.to_a).to eq([c_mid, c_new, c_old])
     end
+
+    context '主ソートキーで同値が並ぶ場合' do
+      it 'id がタイブレーカーとして SQL に含まれる' do
+        sql = described_class.new.order_by('level_name', 'asc').result.to_sql
+        expect(sql).to match(/ORDER BY .*level_name.*ASC.*id/i)
+      end
+    end
   end
 end

--- a/rails/spec/queries/admin/courses_query_spec.rb
+++ b/rails/spec/queries/admin/courses_query_spec.rb
@@ -114,5 +114,12 @@ RSpec.describe Admin::CoursesQuery, type: :model do
         expect(sql).to match(/ORDER BY .*level_name.*ASC.*id/i)
       end
     end
+
+    it 'ソートカラムが courses テーブルに修飾されている (将来の JOIN で曖昧にならない)' do
+      sql = described_class.new.order_by('created_at', 'desc').result.to_sql
+      order_clause = sql[/ORDER BY .*/i]
+      expect(order_clause).to match(/`courses`\.`created_at`/)
+      expect(order_clause).to match(/`courses`\.`id`/)
+    end
   end
 end

--- a/rails/spec/queries/admin/courses_query_spec.rb
+++ b/rails/spec/queries/admin/courses_query_spec.rb
@@ -53,4 +53,32 @@ RSpec.describe Admin::CoursesQuery, type: :model do
       expect(described_class.new.search('%達成').result).to contain_exactly(special)
     end
   end
+
+  describe '#order_by' do
+    let!(:subject_record) { create(:subject) }
+    let!(:c_old) { create(:course, subject: subject_record, level_name: 'A', created_at: 3.days.ago) }
+    let!(:c_mid) { create(:course, subject: subject_record, level_name: 'C', created_at: 2.days.ago) }
+    let!(:c_new) { create(:course, subject: subject_record, level_name: 'B', created_at: 1.day.ago) }
+
+    it 'デフォルトは created_at desc' do
+      expect(described_class.new.order_by(nil, nil).result.to_a).to eq([c_new, c_mid, c_old])
+    end
+
+    it 'level_name asc を許可' do
+      expect(described_class.new.order_by('level_name', 'asc').result.to_a).to eq([c_old, c_new, c_mid])
+    end
+
+    it 'id asc を許可' do
+      expect(described_class.new.order_by('id', 'asc').result.to_a).to eq([c_old, c_mid, c_new])
+    end
+
+    it 'sort のホワイトリスト外は既定値 created_at にフォールバック（order は渡された値を尊重）' do
+      # sort=subject_id（ホワイトリスト外）→ created_at に。order=asc は有効なので created_at asc
+      expect(described_class.new.order_by('subject_id', 'asc').result.to_a).to eq([c_old, c_mid, c_new])
+    end
+
+    it 'order のホワイトリスト外は既定値にフォールバック' do
+      expect(described_class.new.order_by('level_name', 'foo').result.to_a).to eq([c_mid, c_new, c_old])
+    end
+  end
 end

--- a/rails/spec/queries/admin/courses_query_spec.rb
+++ b/rails/spec/queries/admin/courses_query_spec.rb
@@ -86,6 +86,11 @@ RSpec.describe Admin::CoursesQuery, type: :model do
     it 'ハッシュを渡してもフィルタしない（パラメータ汚染防止）' do
       expect(described_class.new.search({ q: '基礎' }).result).to contain_exactly(c1, c2, c3)
     end
+
+    it 'LIKE 文に ESCAPE 句を明示する (NO_BACKSLASH_ESCAPES sql_mode 下での安全性)' do
+      sql = described_class.new.search('基礎').result.to_sql
+      expect(sql).to match(/LIKE .* ESCAPE/i)
+    end
   end
 
   describe '#order_by' do

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -283,6 +283,18 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
         expect(group_by_queries).to eq(2)
       end
 
+      it 'courses への SELECT が 1 本に保たれる (pluck + AMS の二重ロードを起こさない)' do
+        2.times { create(:course, subject: subject_record) }
+
+        queries = []
+        callback = lambda { |_n, _s, _f, _id, payload|
+          queries << payload[:sql] if payload[:name] != 'SCHEMA'
+        }
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
+        courses_selects = queries.count { |sql| sql.match?(/SELECT.*FROM `courses`/i) && sql.exclude?('COUNT') }
+        expect(courses_selects).to eq(1)
+      end
+
       it 'subject が preload され、コース数を増やしても subjects への SELECT が 1 本に保たれる' do
         # 各 course に異なる subject を割り当てて preload の効果を確実に検証
         4.times do

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -284,6 +284,26 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
       end
     end
 
+    context '紐づく subject が DB レベルで欠損している場合' do
+      subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:subject_record) { create(:subject, name: '英語') }
+      let!(:course) { create(:course, subject: subject_record) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      before do
+        course.update_column(:subject_id, nil)
+      end
+
+      it '500 にならず subject フィールドを nil で返す' do
+        subject
+        expect(response).to have_http_status(:ok)
+        item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
+        expect(item['subject']).to be_nil
+      end
+    end
+
     context '異常系 - 未認証アクセス' do
       it '401が返される' do
         get '/api/v1/admin/courses', headers: headers

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
           'per_page' => 20
         )
       end
+
+      it 'course_ids が空なら units / questions への集計クエリは発行しない' do
+        queries = []
+        callback = lambda { |_n, _s, _f, _id, payload|
+          queries << payload[:sql] if payload[:name] != 'SCHEMA'
+        }
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
+        expect(queries.any? { |sql| sql.match?(/FROM `units`/i) && sql.include?('GROUP BY') }).to be(false)
+        expect(queries.any? { |sql| sql.match?(/FROM `questions`/i) && sql.include?('GROUP BY') }).to be(false)
+      end
     end
 
     context '正常系 - 1件の講座が存在する場合' do

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -18,399 +18,403 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
   end
 
   describe 'GET /api/v1/admin/courses' do
-    context '正常系 - 講座が存在しない場合' do
-      subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
+    context '正常系' do
+      context '講座が存在しない場合' do
+        subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
 
-      let!(:admin_user) { create(:user, :admin, high_school: nil) }
-      let(:cookie) { login_and_get_cookie(admin_user) }
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
 
-      it 'ステータス200が返される' do
-        subject
-        expect(response).to have_http_status(:ok)
-      end
-
-      it 'courses は空配列、meta は 0件の値を返す' do
-        subject
-        body = response.parsed_body
-        expect(body['courses']).to eq([])
-        expect(body['meta']).to include(
-          'current_page' => 1,
-          'total_pages' => 0,
-          'total_count' => 0,
-          'per_page' => 20
-        )
-      end
-
-      it 'course_ids が空なら units / questions への集計クエリは発行しない' do
-        queries = []
-        callback = lambda { |_n, _s, _f, _id, payload|
-          queries << payload[:sql] if payload[:name] != 'SCHEMA'
-        }
-        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
-        expect(queries.any? { |sql| sql.match?(/FROM `units`/i) && sql.include?('GROUP BY') }).to be(false)
-        expect(queries.any? { |sql| sql.match?(/FROM `questions`/i) && sql.include?('GROUP BY') }).to be(false)
-      end
-    end
-
-    context '正常系 - 1件の講座が存在する場合' do
-      subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
-
-      let!(:admin_user) { create(:user, :admin, high_school: nil) }
-      let!(:subject_record) { create(:subject, name: '英語') }
-      let!(:course) do
-        create(:course, subject: subject_record, level_name: '基礎', level_number: 1)
-      end
-      let(:cookie) { login_and_get_cookie(admin_user) }
-
-      it '必要なフィールドが含まれる' do
-        subject
-        item = response.parsed_body['courses'].first
-        expect(item.keys).to include('id', 'level_name', 'subject', 'level_number',
-                                     'units_count', 'questions_count', 'created_at')
-      end
-
-      it 'level_name を直接返す (detail シリアライザと同名)' do
-        subject
-        expect(response.parsed_body['courses'].first['level_name']).to eq('基礎')
-      end
-
-      it '旧フィールド名 name は返さない' do
-        subject
-        expect(response.parsed_body['courses'].first).not_to have_key('name')
-      end
-
-      it 'subject は id と name を含む' do
-        subject
-        expect(response.parsed_body['courses'].first['subject']).to eq(
-          'id' => subject_record.id, 'name' => '英語'
-        )
-      end
-
-      it 'id / level_number / units_count / questions_count が正しい' do
-        subject
-        item = response.parsed_body['courses'].first
-        expect(item['id']).to eq(course.id)
-        expect(item['level_number']).to eq(1)
-        expect(item['units_count']).to eq(0)
-        expect(item['questions_count']).to eq(0)
-      end
-
-      it 'meta.total_count が 1 になる' do
-        subject
-        expect(response.parsed_body['meta']['total_count']).to eq(1)
-      end
-    end
-
-    context 'ページネーション' do
-      subject { get '/api/v1/admin/courses', params: query_params, headers: headers.merge('Cookie' => cookie) }
-
-      let!(:admin_user) { create(:user, :admin, high_school: nil) }
-      let!(:subject_record) { create(:subject) }
-      let(:cookie) { login_and_get_cookie(admin_user) }
-
-      before do
-        25.times { |i| create(:course, subject: subject_record, level_name: "Lv#{i}") }
-      end
-
-      context 'デフォルト per_page=20' do
-        let(:query_params) { {} }
-
-        it '20件返し、meta に current_page/per_page/total_count が入る' do
-          subject
-          body = response.parsed_body
-          expect(body['courses'].size).to eq(20)
-          expect(body['meta']).to include('current_page' => 1, 'per_page' => 20, 'total_count' => 25)
-        end
-      end
-
-      context 'page=2 を指定' do
-        let(:query_params) { { page: 2 } }
-
-        it '残り5件を返し、current_page=2 になる' do
-          subject
-          body = response.parsed_body
-          expect(body['courses'].size).to eq(5)
-          expect(body['meta']['current_page']).to eq(2)
-        end
-      end
-
-      context 'per_page=5 を指定' do
-        let(:query_params) { { per_page: 5 } }
-
-        it '5件返し、meta.per_page=5 になる' do
-          subject
-          body = response.parsed_body
-          expect(body['courses'].size).to eq(5)
-          expect(body['meta']['per_page']).to eq(5)
-        end
-      end
-
-      context 'per_page=150 を指定（上限超過）' do
-        let(:query_params) { { per_page: 150 } }
-
-        it 'meta.per_page は 100 に丸められる' do
-          subject
-          expect(response.parsed_body['meta']['per_page']).to eq(100)
-        end
-      end
-
-      context 'per_page=0 や負数を指定' do
-        let(:query_params) { { per_page: 0 } }
-
-        it 'デフォルト 20 にフォールバックする' do
-          subject
-          expect(response.parsed_body['meta']['per_page']).to eq(20)
-        end
-      end
-
-      context 'per_page を配列で送ってきた場合' do
-        let(:query_params) { { per_page: ['10'] } }
-
-        it '500 にならずデフォルト 20 にフォールバックする' do
+        it 'ステータス200が返される' do
           subject
           expect(response).to have_http_status(:ok)
-          expect(response.parsed_body['meta']['per_page']).to eq(20)
         end
-      end
 
-      context 'page を配列で送ってきた場合' do
-        let(:query_params) { { page: ['2'] } }
-
-        it '500 にならず 1 ページ目を返す' do
+        it 'courses は空配列、meta は 0件の値を返す' do
           subject
-          expect(response).to have_http_status(:ok)
-          expect(response.parsed_body['meta']['current_page']).to eq(1)
+          body = response.parsed_body
+          expect(body['courses']).to eq([])
+          expect(body['meta']).to include(
+            'current_page' => 1,
+            'total_pages' => 0,
+            'total_count' => 0,
+            'per_page' => 20
+          )
+        end
+
+        it 'course_ids が空なら units / questions への集計クエリは発行しない' do
+          queries = []
+          callback = lambda { |_n, _s, _f, _id, payload|
+            queries << payload[:sql] if payload[:name] != 'SCHEMA'
+          }
+          ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
+          expect(queries.any? { |sql| sql.match?(/FROM `units`/i) && sql.include?('GROUP BY') }).to be(false)
+          expect(queries.any? { |sql| sql.match?(/FROM `questions`/i) && sql.include?('GROUP BY') }).to be(false)
         end
       end
-    end
 
-    context 'q パラメータ指定時' do
-      subject do
-        get '/api/v1/admin/courses',
-            params: { q: '基礎' },
-            headers: headers.merge('Cookie' => cookie)
-      end
+      context '1件の講座が存在する場合' do
+        subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
 
-      let!(:admin_user) { create(:user, :admin, high_school: nil) }
-      let!(:subject_record) { create(:subject) }
-      let!(:hit) { create(:course, subject: subject_record, level_name: '基礎英語') }
-      let!(:miss) { create(:course, subject: subject_record, level_name: '上級', description: '上級向け') }
-      let(:cookie) { login_and_get_cookie(admin_user) }
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:subject_record) { create(:subject, name: '英語') }
+        let!(:course) do
+          create(:course, subject: subject_record, level_name: '基礎', level_number: 1)
+        end
+        let(:cookie) { login_and_get_cookie(admin_user) }
 
-      it 'level_name に部分一致する講座のみ返す' do
-        subject
-        ids = response.parsed_body['courses'].pluck('id')
-        expect(ids).to include(hit.id)
-        expect(ids).not_to include(miss.id)
-      end
-    end
-
-    context 'sort/order パラメータ指定時' do
-      subject { get '/api/v1/admin/courses', params: query_params, headers: headers.merge('Cookie' => cookie) }
-
-      let!(:admin_user) { create(:user, :admin, high_school: nil) }
-      let!(:subject_record) { create(:subject) }
-      let!(:c1) { create(:course, subject: subject_record, level_name: 'A', created_at: 2.days.ago) }
-      let!(:c2) { create(:course, subject: subject_record, level_name: 'B', created_at: 1.day.ago) }
-      let(:cookie) { login_and_get_cookie(admin_user) }
-
-      context 'sort=level_name & order=asc' do
-        let(:query_params) { { sort: 'level_name', order: 'asc' } }
-
-        it '昇順で返る' do
+        it '必要なフィールドが含まれる' do
           subject
-          expect(response.parsed_body['courses'].pluck('id')).to eq([c1.id, c2.id])
+          item = response.parsed_body['courses'].first
+          expect(item.keys).to include('id', 'level_name', 'subject', 'level_number',
+                                       'units_count', 'questions_count', 'created_at')
         end
-      end
 
-      context '不正な sort 値（order 未指定）' do
-        let(:query_params) { { sort: 'malicious' } }
-
-        it '既定 created_at desc にフォールバック' do
+        it 'level_name を直接返す (detail シリアライザと同名)' do
           subject
-          expect(response.parsed_body['courses'].pluck('id')).to eq([c2.id, c1.id])
+          expect(response.parsed_body['courses'].first['level_name']).to eq('基礎')
         end
-      end
 
-      context '不正な order 値' do
-        let(:query_params) { { sort: 'level_name', order: 'malicious' } }
-
-        it '既定 desc にフォールバック (level_name desc)' do
+        it '旧フィールド名 name は返さない' do
           subject
-          expect(response.parsed_body['courses'].pluck('id')).to eq([c2.id, c1.id])
-        end
-      end
-    end
-
-    context 'units_count / questions_count' do
-      subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
-
-      let!(:admin_user) { create(:user, :admin, high_school: nil) }
-      let!(:subject_record) { create(:subject) }
-      let!(:course) { create(:course, subject: subject_record) }
-      let!(:units) { create_list(:unit, 3, course: course) }
-      let(:cookie) { login_and_get_cookie(admin_user) }
-
-      before do
-        create_list(:question, 2, unit: units[0])
-        create_list(:question, 4, unit: units[1])
-      end
-
-      it 'units_count は course 配下の unit 数を返す' do
-        subject
-        item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
-        expect(item['units_count']).to eq(3)
-      end
-
-      it 'units_count は soft-deleted な unit を除外する' do
-        units[2].update!(deleted_at: Time.current)
-        subject
-        item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
-        expect(item['units_count']).to eq(2)
-      end
-
-      it 'questions_count はコース配下の全 unit の question 数の合計' do
-        subject
-        item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
-        expect(item['questions_count']).to eq(6)
-      end
-
-      it 'questions_count は soft-deleted な unit / question を除外する' do
-        units[1].questions.first.update!(deleted_at: Time.current)
-        subject
-        item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
-        expect(item['questions_count']).to eq(5)
-      end
-
-      it 'コース件数を増やしても counts 集計クエリは 2 本に保たれる (N+1 が発生しない)' do
-        extra_subject = create(:subject)
-        2.times do
-          extra_course = create(:course, subject: extra_subject)
-          create(:unit, course: extra_course)
+          expect(response.parsed_body['courses'].first).not_to have_key('name')
         end
 
-        queries = []
-        callback = lambda { |_n, _s, _f, _id, payload|
-          queries << payload[:sql] if payload[:name] != 'SCHEMA'
-        }
-        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
-        group_by_queries = queries.count { |sql| sql.include?('GROUP BY') }
-        expect(group_by_queries).to eq(2)
+        it 'subject は id と name を含む' do
+          subject
+          expect(response.parsed_body['courses'].first['subject']).to eq(
+            'id' => subject_record.id, 'name' => '英語'
+          )
+        end
+
+        it 'id / level_number / units_count / questions_count が正しい' do
+          subject
+          item = response.parsed_body['courses'].first
+          expect(item['id']).to eq(course.id)
+          expect(item['level_number']).to eq(1)
+          expect(item['units_count']).to eq(0)
+          expect(item['questions_count']).to eq(0)
+        end
+
+        it 'meta.total_count が 1 になる' do
+          subject
+          expect(response.parsed_body['meta']['total_count']).to eq(1)
+        end
       end
 
-      it 'courses への SELECT が 1 本に保たれる (pluck + AMS の二重ロードを起こさない)' do
-        2.times { create(:course, subject: subject_record) }
+      context 'ページネーション' do
+        subject { get '/api/v1/admin/courses', params: query_params, headers: headers.merge('Cookie' => cookie) }
 
-        queries = []
-        callback = lambda { |_n, _s, _f, _id, payload|
-          queries << payload[:sql] if payload[:name] != 'SCHEMA'
-        }
-        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
-        courses_selects = queries.count { |sql| sql.match?(/SELECT.*FROM `courses`/i) && sql.exclude?('COUNT') }
-        expect(courses_selects).to eq(1)
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:subject_record) { create(:subject) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        before do
+          25.times { |i| create(:course, subject: subject_record, level_name: "Lv#{i}") }
+        end
+
+        context 'デフォルト per_page=20' do
+          let(:query_params) { {} }
+
+          it '20件返し、meta に current_page/per_page/total_count が入る' do
+            subject
+            body = response.parsed_body
+            expect(body['courses'].size).to eq(20)
+            expect(body['meta']).to include('current_page' => 1, 'per_page' => 20, 'total_count' => 25)
+          end
+        end
+
+        context 'page=2 を指定' do
+          let(:query_params) { { page: 2 } }
+
+          it '残り5件を返し、current_page=2 になる' do
+            subject
+            body = response.parsed_body
+            expect(body['courses'].size).to eq(5)
+            expect(body['meta']['current_page']).to eq(2)
+          end
+        end
+
+        context 'per_page=5 を指定' do
+          let(:query_params) { { per_page: 5 } }
+
+          it '5件返し、meta.per_page=5 になる' do
+            subject
+            body = response.parsed_body
+            expect(body['courses'].size).to eq(5)
+            expect(body['meta']['per_page']).to eq(5)
+          end
+        end
+
+        context 'per_page=150 を指定（上限超過）' do
+          let(:query_params) { { per_page: 150 } }
+
+          it 'meta.per_page は 100 に丸められる' do
+            subject
+            expect(response.parsed_body['meta']['per_page']).to eq(100)
+          end
+        end
+
+        context 'per_page=0 や負数を指定' do
+          let(:query_params) { { per_page: 0 } }
+
+          it 'デフォルト 20 にフォールバックする' do
+            subject
+            expect(response.parsed_body['meta']['per_page']).to eq(20)
+          end
+        end
+
+        context 'per_page を配列で送ってきた場合' do
+          let(:query_params) { { per_page: ['10'] } }
+
+          it '500 にならずデフォルト 20 にフォールバックする' do
+            subject
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body['meta']['per_page']).to eq(20)
+          end
+        end
+
+        context 'page を配列で送ってきた場合' do
+          let(:query_params) { { page: ['2'] } }
+
+          it '500 にならず 1 ページ目を返す' do
+            subject
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body['meta']['current_page']).to eq(1)
+          end
+        end
       end
 
-      it 'subject が preload され、コース数を増やしても subjects への SELECT が 1 本に保たれる' do
-        # 各 course に異なる subject を割り当てて preload の効果を確実に検証
-        4.times do
+      context 'q パラメータ指定時' do
+        subject do
+          get '/api/v1/admin/courses',
+              params: { q: '基礎' },
+              headers: headers.merge('Cookie' => cookie)
+        end
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:subject_record) { create(:subject) }
+        let!(:hit) { create(:course, subject: subject_record, level_name: '基礎英語') }
+        let!(:miss) { create(:course, subject: subject_record, level_name: '上級', description: '上級向け') }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it 'level_name に部分一致する講座のみ返す' do
+          subject
+          ids = response.parsed_body['courses'].pluck('id')
+          expect(ids).to include(hit.id)
+          expect(ids).not_to include(miss.id)
+        end
+      end
+
+      context 'sort/order パラメータ指定時' do
+        subject { get '/api/v1/admin/courses', params: query_params, headers: headers.merge('Cookie' => cookie) }
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:subject_record) { create(:subject) }
+        let!(:c1) { create(:course, subject: subject_record, level_name: 'A', created_at: 2.days.ago) }
+        let!(:c2) { create(:course, subject: subject_record, level_name: 'B', created_at: 1.day.ago) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        context 'sort=level_name & order=asc' do
+          let(:query_params) { { sort: 'level_name', order: 'asc' } }
+
+          it '昇順で返る' do
+            subject
+            expect(response.parsed_body['courses'].pluck('id')).to eq([c1.id, c2.id])
+          end
+        end
+
+        context '不正な sort 値（order 未指定）' do
+          let(:query_params) { { sort: 'malicious' } }
+
+          it '既定 created_at desc にフォールバック' do
+            subject
+            expect(response.parsed_body['courses'].pluck('id')).to eq([c2.id, c1.id])
+          end
+        end
+
+        context '不正な order 値' do
+          let(:query_params) { { sort: 'level_name', order: 'malicious' } }
+
+          it '既定 desc にフォールバック (level_name desc)' do
+            subject
+            expect(response.parsed_body['courses'].pluck('id')).to eq([c2.id, c1.id])
+          end
+        end
+      end
+
+      context 'units_count / questions_count' do
+        subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:subject_record) { create(:subject) }
+        let!(:course) { create(:course, subject: subject_record) }
+        let!(:units) { create_list(:unit, 3, course: course) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        before do
+          create_list(:question, 2, unit: units[0])
+          create_list(:question, 4, unit: units[1])
+        end
+
+        it 'units_count は course 配下の unit 数を返す' do
+          subject
+          item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
+          expect(item['units_count']).to eq(3)
+        end
+
+        it 'units_count は soft-deleted な unit を除外する' do
+          units[2].update!(deleted_at: Time.current)
+          subject
+          item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
+          expect(item['units_count']).to eq(2)
+        end
+
+        it 'questions_count はコース配下の全 unit の question 数の合計' do
+          subject
+          item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
+          expect(item['questions_count']).to eq(6)
+        end
+
+        it 'questions_count は soft-deleted な unit / question を除外する' do
+          units[1].questions.first.update!(deleted_at: Time.current)
+          subject
+          item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
+          expect(item['questions_count']).to eq(5)
+        end
+
+        it 'コース件数を増やしても counts 集計クエリは 2 本に保たれる (N+1 が発生しない)' do
           extra_subject = create(:subject)
-          create(:course, subject: extra_subject)
+          2.times do
+            extra_course = create(:course, subject: extra_subject)
+            create(:unit, course: extra_course)
+          end
+
+          queries = []
+          callback = lambda { |_n, _s, _f, _id, payload|
+            queries << payload[:sql] if payload[:name] != 'SCHEMA'
+          }
+          ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
+          group_by_queries = queries.count { |sql| sql.include?('GROUP BY') }
+          expect(group_by_queries).to eq(2)
         end
 
-        queries = []
-        callback = lambda { |_n, _s, _f, _id, payload|
-          queries << payload[:sql] if payload[:name] != 'SCHEMA'
-        }
-        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
-        subjects_selects = queries.count { |sql| sql.match?(/SELECT.*FROM `subjects`/i) }
-        expect(subjects_selects).to eq(1)
+        it 'courses への SELECT が 1 本に保たれる (pluck + AMS の二重ロードを起こさない)' do
+          2.times { create(:course, subject: subject_record) }
+
+          queries = []
+          callback = lambda { |_n, _s, _f, _id, payload|
+            queries << payload[:sql] if payload[:name] != 'SCHEMA'
+          }
+          ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
+          courses_selects = queries.count { |sql| sql.match?(/SELECT.*FROM `courses`/i) && sql.exclude?('COUNT') }
+          expect(courses_selects).to eq(1)
+        end
+
+        it 'subject が preload され、コース数を増やしても subjects への SELECT が 1 本に保たれる' do
+          # 各 course に異なる subject を割り当てて preload の効果を確実に検証
+          4.times do
+            extra_subject = create(:subject)
+            create(:course, subject: extra_subject)
+          end
+
+          queries = []
+          callback = lambda { |_n, _s, _f, _id, payload|
+            queries << payload[:sql] if payload[:name] != 'SCHEMA'
+          }
+          ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
+          subjects_selects = queries.count { |sql| sql.match?(/SELECT.*FROM `subjects`/i) }
+          expect(subjects_selects).to eq(1)
+        end
+      end
+
+      context '紐づく subject が DB レベルで欠損している場合' do
+        subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:subject_record) { create(:subject, name: '英語') }
+        let!(:course) { create(:course, subject: subject_record) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        before do
+          course.update_column(:subject_id, nil)
+        end
+
+        it '500 にならず subject フィールドを nil で返す' do
+          subject
+          expect(response).to have_http_status(:ok)
+          item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
+          expect(item['subject']).to be_nil
+        end
+      end
+
+      context 'ソフト削除済みの講座' do
+        subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:subject_record) { create(:subject) }
+        let!(:alive) { create(:course, subject: subject_record) }
+        let!(:dead)  { create(:course, subject: subject_record, deleted_at: Time.current) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it 'レスポンスに含まれず total_count にも数えない' do
+          subject
+          ids = response.parsed_body['courses'].pluck('id')
+          expect(ids).to include(alive.id)
+          expect(ids).not_to include(dead.id)
+          expect(response.parsed_body['meta']['total_count']).to eq(1)
+        end
+      end
+
+      context 'subject_id パラメータ指定時' do
+        subject do
+          get '/api/v1/admin/courses',
+              params: { subject_id: subject_a.id },
+              headers: headers.merge('Cookie' => cookie)
+        end
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:subject_a) { create(:subject, name: '英語') }
+        let!(:subject_b) { create(:subject, name: '数学') }
+        let!(:course_a) { create(:course, subject: subject_a) }
+        let!(:course_b) { create(:course, subject: subject_b) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '指定教科の講座のみ返す' do
+          subject
+          ids = response.parsed_body['courses'].pluck('id')
+          expect(ids).to include(course_a.id)
+          expect(ids).not_to include(course_b.id)
+        end
       end
     end
 
-    context '紐づく subject が DB レベルで欠損している場合' do
-      subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
-
-      let!(:admin_user) { create(:user, :admin, high_school: nil) }
-      let!(:subject_record) { create(:subject, name: '英語') }
-      let!(:course) { create(:course, subject: subject_record) }
-      let(:cookie) { login_and_get_cookie(admin_user) }
-
-      before do
-        course.update_column(:subject_id, nil)
+    context '異常系' do
+      context '未認証アクセス' do
+        it '401が返される' do
+          get '/api/v1/admin/courses', headers: headers
+          expect(response).to have_http_status(:unauthorized)
+        end
       end
 
-      it '500 にならず subject フィールドを nil で返す' do
-        subject
-        expect(response).to have_http_status(:ok)
-        item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
-        expect(item['subject']).to be_nil
-      end
-    end
+      context '管理者以外のアクセス（生徒）' do
+        let!(:student_user) { create(:user) }
 
-    context '異常系 - 未認証アクセス' do
-      it '401が返される' do
-        get '/api/v1/admin/courses', headers: headers
-        expect(response).to have_http_status(:unauthorized)
-      end
-    end
-
-    context '異常系 - 管理者以外のアクセス（生徒）' do
-      let!(:student_user) { create(:user) }
-
-      it '403が返される' do
-        cookie = login_and_get_cookie(student_user)
-        get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie)
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    context '異常系 - 管理者以外のアクセス（教員）' do
-      let!(:teacher_user) { create(:user, :teacher) }
-
-      it '403が返される' do
-        cookie = login_and_get_cookie(teacher_user)
-        get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie)
-        expect(response).to have_http_status(:forbidden)
-      end
-    end
-
-    context 'ソフト削除済みの講座' do
-      subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
-
-      let!(:admin_user) { create(:user, :admin, high_school: nil) }
-      let!(:subject_record) { create(:subject) }
-      let!(:alive) { create(:course, subject: subject_record) }
-      let!(:dead)  { create(:course, subject: subject_record, deleted_at: Time.current) }
-      let(:cookie) { login_and_get_cookie(admin_user) }
-
-      it 'レスポンスに含まれず total_count にも数えない' do
-        subject
-        ids = response.parsed_body['courses'].pluck('id')
-        expect(ids).to include(alive.id)
-        expect(ids).not_to include(dead.id)
-        expect(response.parsed_body['meta']['total_count']).to eq(1)
-      end
-    end
-
-    context 'subject_id パラメータ指定時' do
-      subject do
-        get '/api/v1/admin/courses',
-            params: { subject_id: subject_a.id },
-            headers: headers.merge('Cookie' => cookie)
+        it '403が返される' do
+          cookie = login_and_get_cookie(student_user)
+          get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie)
+          expect(response).to have_http_status(:forbidden)
+        end
       end
 
-      let!(:admin_user) { create(:user, :admin, high_school: nil) }
-      let!(:subject_a) { create(:subject, name: '英語') }
-      let!(:subject_b) { create(:subject, name: '数学') }
-      let!(:course_a) { create(:course, subject: subject_a) }
-      let!(:course_b) { create(:course, subject: subject_b) }
-      let(:cookie) { login_and_get_cookie(admin_user) }
+      context '管理者以外のアクセス（教員）' do
+        let!(:teacher_user) { create(:user, :teacher) }
 
-      it '指定教科の講座のみ返す' do
-        subject
-        ids = response.parsed_body['courses'].pluck('id')
-        expect(ids).to include(course_a.id)
-        expect(ids).not_to include(course_b.id)
+        it '403が返される' do
+          cookie = login_and_get_cookie(teacher_user)
+          get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie)
+          expect(response).to have_http_status(:forbidden)
+        end
       end
     end
   end

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -17,6 +17,32 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
     response.headers['Set-Cookie']&.split(';')&.first
   end
 
+  describe 'GET /api/v1/admin/courses' do
+    context '正常系 - 講座が存在しない場合' do
+      subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'courses は空配列、meta は 0件の値を返す' do
+        subject
+        body = response.parsed_body
+        expect(body['courses']).to eq([])
+        expect(body['meta']).to include(
+          'current_page' => 1,
+          'total_pages' => 0,
+          'total_count' => 0,
+          'per_page' => 20
+        )
+      end
+    end
+  end
+
   describe 'GET /api/v1/admin/courses/:id' do
     context '正常系' do
       subject { get "/api/v1/admin/courses/#{course.id}", headers: headers.merge('Cookie' => cookie) }

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -147,6 +147,16 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
           expect(response.parsed_body['meta']['per_page']).to eq(20)
         end
       end
+
+      context 'per_page を配列で送ってきた場合' do
+        let(:query_params) { { per_page: ['10'] } }
+
+        it '500 にならずデフォルト 20 にフォールバックする' do
+          subject
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body['meta']['per_page']).to eq(20)
+        end
+      end
     end
 
     context 'q パラメータ指定時' do

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -85,6 +85,70 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
         expect(response.parsed_body['meta']['total_count']).to eq(1)
       end
     end
+
+    context 'ページネーション' do
+      subject { get '/api/v1/admin/courses', params: query_params, headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:subject_record) { create(:subject) }
+
+      before do
+        25.times { |i| create(:course, subject: subject_record, level_name: "Lv#{i}") }
+      end
+
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      context 'デフォルト per_page=20' do
+        let(:query_params) { {} }
+
+        it '20件返し、meta に current_page/per_page/total_count が入る' do
+          subject
+          body = response.parsed_body
+          expect(body['courses'].size).to eq(20)
+          expect(body['meta']).to include('current_page' => 1, 'per_page' => 20, 'total_count' => 25)
+        end
+      end
+
+      context 'page=2 を指定' do
+        let(:query_params) { { page: 2 } }
+
+        it '残り5件を返し、current_page=2 になる' do
+          subject
+          body = response.parsed_body
+          expect(body['courses'].size).to eq(5)
+          expect(body['meta']['current_page']).to eq(2)
+        end
+      end
+
+      context 'per_page=5 を指定' do
+        let(:query_params) { { per_page: 5 } }
+
+        it '5件返し、meta.per_page=5 になる' do
+          subject
+          body = response.parsed_body
+          expect(body['courses'].size).to eq(5)
+          expect(body['meta']['per_page']).to eq(5)
+        end
+      end
+
+      context 'per_page=150 を指定（上限超過）' do
+        let(:query_params) { { per_page: 150 } }
+
+        it 'meta.per_page は 100 に丸められる' do
+          subject
+          expect(response.parsed_body['meta']['per_page']).to eq(100)
+        end
+      end
+
+      context 'per_page=0 や負数を指定' do
+        let(:query_params) { { per_page: 0 } }
+
+        it 'デフォルト 20 にフォールバックする' do
+          subject
+          expect(response.parsed_body['meta']['per_page']).to eq(20)
+        end
+      end
+    end
   end
 
   describe 'GET /api/v1/admin/courses/:id' do

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -65,13 +65,18 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
       it '必要なフィールドが含まれる' do
         subject
         item = response.parsed_body['courses'].first
-        expect(item.keys).to include('id', 'name', 'subject', 'level_number',
+        expect(item.keys).to include('id', 'level_name', 'subject', 'level_number',
                                      'units_count', 'questions_count', 'created_at')
       end
 
-      it 'name は level_name を返す' do
+      it 'level_name を直接返す (detail シリアライザと同名)' do
         subject
-        expect(response.parsed_body['courses'].first['name']).to eq('基礎')
+        expect(response.parsed_body['courses'].first['level_name']).to eq('基礎')
+      end
+
+      it '旧フィールド名 name は返さない' do
+        subject
+        expect(response.parsed_body['courses'].first).not_to have_key('name')
       end
 
       it 'subject は id と name を含む' do

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -282,6 +282,22 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
         group_by_queries = queries.count { |sql| sql.include?('GROUP BY') }
         expect(group_by_queries).to be <= 2
       end
+
+      it 'subject が preload され、コース数を増やしても subjects への SELECT が 1 本に保たれる' do
+        # 各 course に異なる subject を割り当てて preload の効果を確実に検証
+        4.times do
+          extra_subject = create(:subject)
+          create(:course, subject: extra_subject)
+        end
+
+        queries = []
+        callback = lambda { |_n, _s, _f, _id, payload|
+          queries << payload[:sql] if payload[:name] != 'SCHEMA'
+        }
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
+        subjects_selects = queries.count { |sql| sql.match?(/SELECT.*FROM `subjects`/i) }
+        expect(subjects_selects).to eq(1)
+      end
     end
 
     context '紐づく subject が DB レベルで欠損している場合' do

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -41,6 +41,50 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
         )
       end
     end
+
+    context '正常系 - 1件の講座が存在する場合' do
+      subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:subject_record) { create(:subject, name: '英語') }
+      let!(:course) do
+        create(:course, subject: subject_record, level_name: '基礎', level_number: 1)
+      end
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it '必要なフィールドが含まれる' do
+        subject
+        item = response.parsed_body['courses'].first
+        expect(item.keys).to include('id', 'name', 'subject', 'level_number',
+                                     'units_count', 'questions_count', 'created_at')
+      end
+
+      it 'name は level_name を返す' do
+        subject
+        expect(response.parsed_body['courses'].first['name']).to eq('基礎')
+      end
+
+      it 'subject は id と name を含む' do
+        subject
+        expect(response.parsed_body['courses'].first['subject']).to eq(
+          'id' => subject_record.id, 'name' => '英語'
+        )
+      end
+
+      it 'id / level_number / units_count / questions_count が正しい' do
+        subject
+        item = response.parsed_body['courses'].first
+        expect(item['id']).to eq(course.id)
+        expect(item['level_number']).to eq(1)
+        expect(item['units_count']).to eq(0)
+        expect(item['questions_count']).to eq(0)
+      end
+
+      it 'meta.total_count が 1 になる' do
+        subject
+        expect(response.parsed_body['meta']['total_count']).to eq(1)
+      end
+    end
   end
 
   describe 'GET /api/v1/admin/courses/:id' do

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -91,12 +91,11 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
 
       let!(:admin_user) { create(:user, :admin, high_school: nil) }
       let!(:subject_record) { create(:subject) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
 
       before do
         25.times { |i| create(:course, subject: subject_record, level_name: "Lv#{i}") }
       end
-
-      let(:cookie) { login_and_get_cookie(admin_user) }
 
       context 'デフォルト per_page=20' do
         let(:query_params) { {} }
@@ -147,6 +146,28 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
           subject
           expect(response.parsed_body['meta']['per_page']).to eq(20)
         end
+      end
+    end
+
+    context 'subject_id パラメータ指定時' do
+      subject do
+        get '/api/v1/admin/courses',
+            params: { subject_id: subject_a.id },
+            headers: headers.merge('Cookie' => cookie)
+      end
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:subject_a) { create(:subject, name: '英語') }
+      let!(:subject_b) { create(:subject, name: '数学') }
+      let!(:course_a) { create(:course, subject: subject_a) }
+      let!(:course_b) { create(:course, subject: subject_b) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it '指定教科の講座のみ返す' do
+        subject
+        ids = response.parsed_body['courses'].pluck('id')
+        expect(ids).to include(course_a.id)
+        expect(ids).not_to include(course_b.id)
       end
     end
   end

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -207,6 +207,63 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
       end
     end
 
+    context 'units_count / questions_count' do
+      subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:subject_record) { create(:subject) }
+      let!(:course) { create(:course, subject: subject_record) }
+      let!(:units) { create_list(:unit, 3, course: course) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      before do
+        create_list(:question, 2, unit: units[0])
+        create_list(:question, 4, unit: units[1])
+      end
+
+      it 'units_count は course 配下の unit 数を返す' do
+        subject
+        item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
+        expect(item['units_count']).to eq(3)
+      end
+
+      it 'units_count は soft-deleted な unit を除外する' do
+        units[2].update!(deleted_at: Time.current)
+        subject
+        item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
+        expect(item['units_count']).to eq(2)
+      end
+
+      it 'questions_count はコース配下の全 unit の question 数の合計' do
+        subject
+        item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
+        expect(item['questions_count']).to eq(6)
+      end
+
+      it 'questions_count は soft-deleted な unit / question を除外する' do
+        units[1].questions.first.update!(deleted_at: Time.current)
+        subject
+        item = response.parsed_body['courses'].find { |c| c['id'] == course.id }
+        expect(item['questions_count']).to eq(5)
+      end
+
+      it 'コース件数を増やしても counts 集計クエリは 2 本に保たれる (N+1 が発生しない)' do
+        extra_subject = create(:subject)
+        2.times do
+          extra_course = create(:course, subject: extra_subject)
+          create(:unit, course: extra_course)
+        end
+
+        queries = []
+        callback = lambda { |_n, _s, _f, _id, payload|
+          queries << payload[:sql] if payload[:name] != 'SCHEMA'
+        }
+        ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
+        group_by_queries = queries.count { |sql| sql.include?('GROUP BY') }
+        expect(group_by_queries).to be <= 2
+      end
+    end
+
     context 'subject_id パラメータ指定時' do
       subject do
         get '/api/v1/admin/courses',

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -157,6 +157,16 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
           expect(response.parsed_body['meta']['per_page']).to eq(20)
         end
       end
+
+      context 'page を配列で送ってきた場合' do
+        let(:query_params) { { page: ['2'] } }
+
+        it '500 にならず 1 ページ目を返す' do
+          subject
+          expect(response).to have_http_status(:ok)
+          expect(response.parsed_body['meta']['current_page']).to eq(1)
+        end
+      end
     end
 
     context 'q パラメータ指定時' do

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -264,6 +264,24 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
       end
     end
 
+    context 'ソフト削除済みの講座' do
+      subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:subject_record) { create(:subject) }
+      let!(:alive) { create(:course, subject: subject_record) }
+      let!(:dead)  { create(:course, subject: subject_record, deleted_at: Time.current) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'レスポンスに含まれず total_count にも数えない' do
+        subject
+        ids = response.parsed_body['courses'].pluck('id')
+        expect(ids).to include(alive.id)
+        expect(ids).not_to include(dead.id)
+        expect(response.parsed_body['meta']['total_count']).to eq(1)
+      end
+    end
+
     context 'subject_id パラメータ指定時' do
       subject do
         get '/api/v1/admin/courses',

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -264,6 +264,33 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
       end
     end
 
+    context '異常系 - 未認証アクセス' do
+      it '401が返される' do
+        get '/api/v1/admin/courses', headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(student_user)
+        get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（教員）' do
+      let!(:teacher_user) { create(:user, :teacher) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(teacher_user)
+        get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
     context 'ソフト削除済みの講座' do
       subject { get '/api/v1/admin/courses', headers: headers.merge('Cookie' => cookie) }
 

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -183,6 +183,26 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
             expect(response.parsed_body['meta']['current_page']).to eq(1)
           end
         end
+
+        context 'page=0 を指定' do
+          let(:query_params) { { page: 0 } }
+
+          it '1 ページ目にフォールバックする' do
+            subject
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body['meta']['current_page']).to eq(1)
+          end
+        end
+
+        context 'page=-1 を指定' do
+          let(:query_params) { { page: -1 } }
+
+          it '1 ページ目にフォールバックする' do
+            subject
+            expect(response).to have_http_status(:ok)
+            expect(response.parsed_body['meta']['current_page']).to eq(1)
+          end
+        end
       end
 
       context 'q パラメータ指定時' do

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -149,6 +149,27 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
       end
     end
 
+    context 'q パラメータ指定時' do
+      subject do
+        get '/api/v1/admin/courses',
+            params: { q: '基礎' },
+            headers: headers.merge('Cookie' => cookie)
+      end
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:subject_record) { create(:subject) }
+      let!(:hit) { create(:course, subject: subject_record, level_name: '基礎英語') }
+      let!(:miss) { create(:course, subject: subject_record, level_name: '上級', description: '上級向け') }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'level_name に部分一致する講座のみ返す' do
+        subject
+        ids = response.parsed_body['courses'].pluck('id')
+        expect(ids).to include(hit.id)
+        expect(ids).not_to include(miss.id)
+      end
+    end
+
     context 'subject_id パラメータ指定時' do
       subject do
         get '/api/v1/admin/courses',

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -170,6 +170,43 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
       end
     end
 
+    context 'sort/order パラメータ指定時' do
+      subject { get '/api/v1/admin/courses', params: query_params, headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:subject_record) { create(:subject) }
+      let!(:c1) { create(:course, subject: subject_record, level_name: 'A', created_at: 2.days.ago) }
+      let!(:c2) { create(:course, subject: subject_record, level_name: 'B', created_at: 1.day.ago) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      context 'sort=level_name & order=asc' do
+        let(:query_params) { { sort: 'level_name', order: 'asc' } }
+
+        it '昇順で返る' do
+          subject
+          expect(response.parsed_body['courses'].pluck('id')).to eq([c1.id, c2.id])
+        end
+      end
+
+      context '不正な sort 値（order 未指定）' do
+        let(:query_params) { { sort: 'malicious' } }
+
+        it '既定 created_at desc にフォールバック' do
+          subject
+          expect(response.parsed_body['courses'].pluck('id')).to eq([c2.id, c1.id])
+        end
+      end
+
+      context '不正な order 値' do
+        let(:query_params) { { sort: 'level_name', order: 'malicious' } }
+
+        it '既定 desc にフォールバック (level_name desc)' do
+          subject
+          expect(response.parsed_body['courses'].pluck('id')).to eq([c2.id, c1.id])
+        end
+      end
+    end
+
     context 'subject_id パラメータ指定時' do
       subject do
         get '/api/v1/admin/courses',

--- a/rails/spec/requests/api/v1/admin/courses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/courses_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe 'Api::V1::Admin::Courses', type: :request do
         }
         ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') { subject }
         group_by_queries = queries.count { |sql| sql.include?('GROUP BY') }
-        expect(group_by_queries).to be <= 2
+        expect(group_by_queries).to eq(2)
       end
 
       it 'subject が preload され、コース数を増やしても subjects への SELECT が 1 本に保たれる' do


### PR DESCRIPTION
## 概要

Issue #56 「管理画面用 講座一覧API」の実装。`/admin/courses` 画面が依存するバックエンド API `GET /api/v1/admin/courses` を新規追加する。

依存する FE issue: `/admin/courses` 画面実装

### 実装範囲

- レスポンス: `id` / `level_name` / `subject{id,name}` / `level_number` / `units_count` / `questions_count` / `created_at` と `meta{current_page,total_pages,total_count,per_page}`
- クエリパラメータ: `page` / `per_page` (default 20, max 100) / `q` (level_name OR description 部分一致, MySQL LIKE) / `subject_id` / `sort` (`level_name|created_at|id`) / `order` (`asc|desc`)
- 既定ソート: `created_at desc` + `id asc` タイブレーカー
- 認可: `Api::V1::Admin::BaseController` の Devise cookie + Pundit `authorize :admin_service, :access?` を継承


## 詳細

### N+1 対策 (HighSchoolsController#index と同形)

- `Unit.where(course_id: ids, deleted_at: nil).group(:course_id).count`
- `Question.joins(:unit).where(units: {course_id: ids, deleted_at: nil}).where(deleted_at: nil).group('units.course_id').count`
- `Admin::CoursesQuery` 初期化時に `includes(:subject)` を組み込み

### 主要ファイル

- `rails/app/controllers/api/v1/admin/courses_controller.rb` — `index` 追加 (`show` 不変)
- `rails/app/controllers/api/v1/admin/base_controller.rb` — `sanitized_per_page` / `sanitized_page` を集約
- `rails/app/queries/admin/courses_query.rb` — `active` / `by_subject_id` / `search` / `order_by` チェイン
- `rails/app/serializers/admin/course_list_serializer.rb`
- `rails/spec/queries/admin/courses_query_spec.rb`
- `rails/spec/requests/api/v1/admin/courses_spec.rb`

## 動作確認

ローカル Docker compose 環境にて確認済み。

- ` docker compose run --rm rails bundle exec rubocop` → 259 files inspected, 0 offenses
- `docker compose run --rm rails bundle exec rspec` → 482 examples, 0 failures, 2 pending (本 PR と無関係)
- `docker compose run --rm rails bundle exec rails routes -c admin/courses` で `GET /api/v1/admin/courses (admin/courses#index)` が公開されていること確認

### 追加テストカバレッジ

- 正常系: 0件、1件、ページネーション (per_page/page/上限100)、`subject_id`、`q` 検索、`sort`/`order` ホワイトリスト、`units_count`/`questions_count`、ソフト削除除外
- 異常系: 401 (未認証)、403 (生徒/教員)
- 堅牢性: per_page/page/subject_id/q に Array/Hash、`subject` が DB レベル欠損
- 性能: counts 集計クエリ数 = 2、courses への SELECT = 1、subjects への SELECT = 1、空 course_ids 時に集計 SQL ゼロ

## その他

新規ライブラリ導入無し。

## 参考情報

- 親 issue: #49 (管理者用管理画面 UI 設計・実装)
- 既存 admin index endpoint との対比: `Api::V1::Admin::HighSchoolsController#index`