### PR TITLE
issue-58 講座一覧画面 /admin/courses を実装

### DIFF
--- a/frontend/app/(admin)/admin/(authenticated)/courses/page.tsx
+++ b/frontend/app/(admin)/admin/(authenticated)/courses/page.tsx
@@ -1,0 +1,5 @@
+import { AdminCourses } from "@/features/AdminCourses";
+
+export default function AdminCoursesPage() {
+  return <AdminCourses />;
+}

--- a/frontend/app/api/admin/courses/route.ts
+++ b/frontend/app/api/admin/courses/route.ts
@@ -1,0 +1,37 @@
+import { RailsUnauthorizedError } from "@/libs/server/rails/railsError";
+import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const page = searchParams.get("page") ?? "1";
+  const perPage = searchParams.get("per_page");
+  const q = searchParams.get("q");
+  const sort = searchParams.get("sort");
+  const order = searchParams.get("order");
+
+  const params = new URLSearchParams({ page });
+  if (perPage) params.set("per_page", perPage);
+  if (q) params.set("q", q);
+  if (sort) params.set("sort", sort);
+  if (order) params.set("order", order);
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/admin/courses?${params.toString()}`,
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    if (error instanceof RailsUnauthorizedError) {
+      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+    }
+
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/features/AdminCourses/Presenter.test.tsx
+++ b/frontend/features/AdminCourses/Presenter.test.tsx
@@ -126,9 +126,7 @@ describe("AdminCoursesPresenter", () => {
   });
 
   it("courses が空のとき「講座が見つかりません」が表示される", () => {
-    render(
-      <Presenter {...defaultProps} data={{ ...mockData, courses: [] }} />,
-    );
+    render(<Presenter {...defaultProps} data={{ ...mockData, courses: [] }} />);
     expect(screen.getByText("講座が見つかりません")).toBeInTheDocument();
   });
 });

--- a/frontend/features/AdminCourses/Presenter.test.tsx
+++ b/frontend/features/AdminCourses/Presenter.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Presenter } from "./Presenter";
+import type { AdminCoursesData } from "./types";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const mockData: AdminCoursesData = {
+  courses: [
+    {
+      id: 1,
+      level_name: "基礎",
+      level_number: 1,
+      subject: { id: 1, name: "英語" },
+      units_count: 5,
+      questions_count: 42,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: 2,
+      level_name: "標準",
+      level_number: 2,
+      subject: { id: 2, name: "数学" },
+      units_count: 8,
+      questions_count: 100,
+      created_at: "2026-02-01T00:00:00Z",
+    },
+  ],
+  meta: {
+    current_page: 1,
+    total_pages: 3,
+    total_count: 50,
+    per_page: 20,
+  },
+};
+
+const defaultProps = {
+  data: mockData,
+  q: "",
+  perPage: 20,
+  sort: "created_at" as const,
+  order: "desc" as const,
+  page: 1,
+  onSearchChange: vi.fn(),
+  onPerPageChange: vi.fn(),
+  onSortChange: vi.fn(),
+  onPageChange: vi.fn(),
+};
+
+describe("AdminCoursesPresenter", () => {
+  it("テーブルヘッダーに「講座名」「科目」「単元数」「問題数」が表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    const headers = screen
+      .getAllByRole("columnheader")
+      .map((h) => h.textContent);
+    expect(headers).toContain("講座名");
+    expect(headers).toContain("科目");
+    expect(headers).toContain("単元数");
+    expect(headers).toContain("問題数");
+  });
+
+  it("courses データが行として正しくレンダリングされる", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByText("基礎")).toBeInTheDocument();
+    expect(screen.getByText("英語")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("標準")).toBeInTheDocument();
+    expect(screen.getByText("数学")).toBeInTheDocument();
+    expect(screen.getByText("100")).toBeInTheDocument();
+  });
+
+  it("講座名ヘッダーをクリックすると onSortChange が呼ばれる", () => {
+    const onSortChange = vi.fn();
+    render(<Presenter {...defaultProps} onSortChange={onSortChange} />);
+    const sortButton = screen.getByRole("button", { name: /講座名/ });
+    fireEvent.click(sortButton);
+    expect(onSortChange).toHaveBeenCalledWith("level_name");
+  });
+
+  it("検索ワード入力で onSearchChange が呼ばれる", () => {
+    const onSearchChange = vi.fn();
+    render(<Presenter {...defaultProps} onSearchChange={onSearchChange} />);
+    const input = screen.getByPlaceholderText("講座名で検索");
+    fireEvent.change(input, { target: { value: "英語" } });
+    expect(onSearchChange).toHaveBeenCalledWith("英語");
+  });
+
+  it("検索ワードが入力欄に反映される", () => {
+    render(<Presenter {...defaultProps} q="基礎" />);
+    const input = screen.getByPlaceholderText<HTMLInputElement>("講座名で検索");
+    expect(input.value).toBe("基礎");
+  });
+
+  it("表示件数プルダウンに 20 / 50 / 100 が表示され、変更で onPerPageChange が呼ばれる", () => {
+    const onPerPageChange = vi.fn();
+    render(<Presenter {...defaultProps} onPerPageChange={onPerPageChange} />);
+    const select = screen.getByRole("combobox");
+    fireEvent.mouseDown(select);
+    expect(screen.getByRole("option", { name: "20件" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "50件" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "100件" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("option", { name: "50件" }));
+    expect(onPerPageChange).toHaveBeenCalledWith(50);
+  });
+
+  it("ページネーションが表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+  });
+
+  it("行が /admin/courses/[id] を指している", () => {
+    render(<Presenter {...defaultProps} />);
+    const rowLinks = screen.getAllByRole("link");
+    const hrefs = rowLinks.map((l) => l.getAttribute("href"));
+    expect(hrefs).toContain("/admin/courses/1");
+    expect(hrefs).toContain("/admin/courses/2");
+  });
+
+  it("courses が空のとき「講座が見つかりません」が表示される", () => {
+    render(
+      <Presenter {...defaultProps} data={{ ...mockData, courses: [] }} />,
+    );
+    expect(screen.getByText("講座が見つかりません")).toBeInTheDocument();
+  });
+});

--- a/frontend/features/AdminCourses/Presenter.test.tsx
+++ b/frontend/features/AdminCourses/Presenter.test.tsx
@@ -69,11 +69,11 @@ describe("AdminCoursesPresenter", () => {
 
   it("courses データが行として正しくレンダリングされる", () => {
     render(<Presenter {...defaultProps} />);
-    expect(screen.getByText("基礎")).toBeInTheDocument();
+    expect(screen.getByText("基礎レベル1")).toBeInTheDocument();
     expect(screen.getByText("英語")).toBeInTheDocument();
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByText("42")).toBeInTheDocument();
-    expect(screen.getByText("標準")).toBeInTheDocument();
+    expect(screen.getByText("標準レベル2")).toBeInTheDocument();
     expect(screen.getByText("数学")).toBeInTheDocument();
     expect(screen.getByText("100")).toBeInTheDocument();
   });

--- a/frontend/features/AdminCourses/Presenter.tsx
+++ b/frontend/features/AdminCourses/Presenter.tsx
@@ -167,7 +167,7 @@ export const Presenter = ({
                             fontWeight: 600,
                           }}
                         >
-                          {course.level_name}
+                          {course.level_name}レベル{course.level_number}
                         </Link>
                       </TableCell>
                       <TableCell>{course.subject?.name ?? "-"}</TableCell>

--- a/frontend/features/AdminCourses/Presenter.tsx
+++ b/frontend/features/AdminCourses/Presenter.tsx
@@ -133,6 +133,7 @@ export const Presenter = ({
               <Table size="small">
                 <TableHead>
                   <TableRow sx={{ bgcolor: colors.surface.light }}>
+                    <TableCell sx={{ fontWeight: 600 }}>科目</TableCell>
                     <TableCell sx={{ fontWeight: 600 }}>
                       <TableSortLabel
                         active={sort === "level_name"}
@@ -142,7 +143,6 @@ export const Presenter = ({
                         講座名
                       </TableSortLabel>
                     </TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>科目</TableCell>
                     <TableCell sx={{ fontWeight: 600 }} align="right">
                       単元数
                     </TableCell>
@@ -158,6 +158,7 @@ export const Presenter = ({
                       hover
                       sx={{ "&:last-child td": { border: 0 } }}
                     >
+                      <TableCell>{course.subject?.name ?? "-"}</TableCell>
                       <TableCell>
                         <Link
                           href={`/admin/courses/${course.id}`}
@@ -170,7 +171,6 @@ export const Presenter = ({
                           {course.level_name}レベル{course.level_number}
                         </Link>
                       </TableCell>
-                      <TableCell>{course.subject?.name ?? "-"}</TableCell>
                       <TableCell align="right">{course.units_count}</TableCell>
                       <TableCell align="right">
                         {course.questions_count}

--- a/frontend/features/AdminCourses/Presenter.tsx
+++ b/frontend/features/AdminCourses/Presenter.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { colors } from "@/app/theme/colors";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Pagination,
+  Select,
+  type SelectChangeEvent,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  TextField,
+  Typography,
+} from "@mui/material";
+import Link from "next/link";
+import {
+  PER_PAGE_OPTIONS,
+  type AdminCoursesData,
+  type CourseOrder,
+  type CourseSort,
+} from "./types";
+
+type Props = {
+  data: AdminCoursesData;
+  q: string;
+  perPage: number;
+  sort: CourseSort;
+  order: CourseOrder;
+  page: number;
+  onSearchChange: (q: string) => void;
+  onPerPageChange: (perPage: number) => void;
+  onSortChange: (sort: CourseSort) => void;
+  onPageChange: (page: number) => void;
+};
+
+export const Presenter = ({
+  data,
+  q,
+  perPage,
+  sort,
+  order,
+  page,
+  onSearchChange,
+  onPerPageChange,
+  onSortChange,
+  onPageChange,
+}: Props) => {
+  const { courses, meta } = data;
+
+  const handlePerPageChange = (e: SelectChangeEvent<string>) => {
+    onPerPageChange(Number(e.target.value));
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Box sx={{ display: "flex", alignItems: "baseline", gap: 1.5, mb: 3 }}>
+        <Typography
+          variant="h5"
+          fontWeight={700}
+          sx={{ color: colors.text.primary }}
+        >
+          講座一覧
+        </Typography>
+        <Typography variant="body2" sx={{ color: colors.text.muted }}>
+          {meta.total_count} 件
+        </Typography>
+      </Box>
+
+      {/* 検索・表示件数 */}
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        <TextField
+          size="small"
+          placeholder="講座名で検索"
+          value={q}
+          onChange={(e) => onSearchChange(e.target.value)}
+          sx={{ minWidth: 240 }}
+        />
+        <FormControl size="small" sx={{ minWidth: 120 }}>
+          <InputLabel>表示件数</InputLabel>
+          <Select
+            label="表示件数"
+            value={String(perPage)}
+            onChange={handlePerPageChange}
+          >
+            {PER_PAGE_OPTIONS.map((option) => (
+              <MenuItem key={option} value={String(option)}>
+                {option}件
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      {/* テーブル */}
+      <Card
+        elevation={0}
+        sx={{
+          border: `1px solid ${colors.border.light}`,
+          borderRadius: 2,
+          mb: 3,
+        }}
+      >
+        <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
+          {courses.length === 0 ? (
+            <Box sx={{ py: 6, textAlign: "center" }}>
+              <Typography color="text.secondary" sx={{ mb: 2 }}>
+                講座が見つかりません
+              </Typography>
+              <Button variant="outlined" size="small" disabled>
+                新規作成（準備中）
+              </Button>
+            </Box>
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow sx={{ bgcolor: colors.surface.light }}>
+                    <TableCell sx={{ fontWeight: 600 }}>
+                      <TableSortLabel
+                        active={sort === "level_name"}
+                        direction={sort === "level_name" ? order : "asc"}
+                        onClick={() => onSortChange("level_name")}
+                      >
+                        講座名
+                      </TableSortLabel>
+                    </TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>科目</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }} align="right">
+                      単元数
+                    </TableCell>
+                    <TableCell sx={{ fontWeight: 600 }} align="right">
+                      問題数
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {courses.map((course) => (
+                    <TableRow
+                      key={course.id}
+                      hover
+                      sx={{ "&:last-child td": { border: 0 } }}
+                    >
+                      <TableCell>
+                        <Link
+                          href={`/admin/courses/${course.id}`}
+                          style={{
+                            color: colors.brand.primary,
+                            textDecoration: "none",
+                            fontWeight: 600,
+                          }}
+                        >
+                          {course.level_name}
+                        </Link>
+                      </TableCell>
+                      <TableCell>{course.subject?.name ?? "-"}</TableCell>
+                      <TableCell align="right">{course.units_count}</TableCell>
+                      <TableCell align="right">
+                        {course.questions_count}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ページネーション */}
+      {meta.total_pages > 1 && (
+        <Box sx={{ display: "flex", justifyContent: "center" }}>
+          <Pagination
+            count={meta.total_pages}
+            page={page}
+            onChange={(_, value) => onPageChange(value)}
+            color="primary"
+          />
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/frontend/features/AdminCourses/hooks/useFetchCourses.ts
+++ b/frontend/features/AdminCourses/hooks/useFetchCourses.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient } from "@/libs/http/apiClient";
+import type {
+  AdminCoursesData,
+  CourseOrder,
+  CourseSort,
+} from "../types";
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+export const useFetchCourses = () => {
+  const [data, setData] = useState<AdminCoursesData | null>(null);
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(20);
+  const [q, setQ] = useState("");
+  const [debouncedQ, setDebouncedQ] = useState("");
+  const [sort, setSort] = useState<CourseSort>("created_at");
+  const [order, setOrder] = useState<CourseOrder>("desc");
+  const router = useRouter();
+
+  // 検索ワードを debounce して過剰なリクエストを抑制する
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQ(q);
+      setPage(1);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [q]);
+
+  useEffect(() => {
+    const params: Record<string, string> = {
+      page: String(page),
+      per_page: String(perPage),
+      sort,
+      order,
+    };
+    if (debouncedQ !== "") {
+      params.q = debouncedQ;
+    }
+
+    apiClient
+      .get<AdminCoursesData>("/api/admin/courses", { params })
+      .then((res) => setData(res.data))
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          router.push("/login");
+        }
+      });
+  }, [page, perPage, debouncedQ, sort, order, router]);
+
+  const handleSearchChange = (value: string) => {
+    setQ(value);
+  };
+
+  const handlePerPageChange = (value: number) => {
+    setPerPage(value);
+    setPage(1);
+  };
+
+  const handleSortChange = (nextSort: CourseSort) => {
+    if (sort === nextSort) {
+      setOrder((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSort(nextSort);
+      setOrder("asc");
+    }
+    setPage(1);
+  };
+
+  return {
+    data,
+    q,
+    perPage,
+    sort,
+    order,
+    page,
+    onSearchChange: handleSearchChange,
+    onPerPageChange: handlePerPageChange,
+    onSortChange: handleSortChange,
+    onPageChange: setPage,
+  };
+};

--- a/frontend/features/AdminCourses/hooks/useFetchCourses.ts
+++ b/frontend/features/AdminCourses/hooks/useFetchCourses.ts
@@ -3,11 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { apiClient } from "@/libs/http/apiClient";
-import type {
-  AdminCoursesData,
-  CourseOrder,
-  CourseSort,
-} from "../types";
+import type { AdminCoursesData, CourseOrder, CourseSort } from "../types";
 
 const SEARCH_DEBOUNCE_MS = 300;
 

--- a/frontend/features/AdminCourses/index.tsx
+++ b/frontend/features/AdminCourses/index.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Box, CircularProgress } from "@mui/material";
+import { Presenter } from "./Presenter";
+import { useFetchCourses } from "./hooks/useFetchCourses";
+
+export const AdminCourses = () => {
+  const { data, ...handlers } = useFetchCourses();
+
+  if (!data) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return <Presenter data={data} {...handlers} />;
+};

--- a/frontend/features/AdminCourses/types.ts
+++ b/frontend/features/AdminCourses/types.ts
@@ -1,0 +1,32 @@
+export type Subject = {
+  id: number;
+  name: string;
+};
+
+export type AdminCourse = {
+  id: number;
+  level_name: string;
+  level_number: number;
+  subject: Subject | null;
+  units_count: number;
+  questions_count: number;
+  created_at: string;
+};
+
+export type AdminCourseMeta = {
+  current_page: number;
+  total_pages: number;
+  total_count: number;
+  per_page: number;
+};
+
+export type AdminCoursesData = {
+  courses: AdminCourse[];
+  meta: AdminCourseMeta;
+};
+
+export type CourseSort = "level_name" | "created_at" | "id";
+
+export type CourseOrder = "asc" | "desc";
+
+export const PER_PAGE_OPTIONS = [20, 50, 100] as const;


### PR DESCRIPTION
## 概要

管理者向け講座管理機能の一画面として、講座一覧画面 `/admin/courses` を実装しました。

- 対応issue: #58【Next.js】講座一覧画面

講座一覧API（`GET /api/v1/admin/courses`）は実装済みのため、フロントエンドで返却値を表示します。

## 詳細

**機能**
- フィルタ: 検索ワード（`q`）。300ms debounce で過剰リクエストを抑制
- ソート: 講座名ヘッダー（`TableSortLabel`）で昇降トグル。サーバーソート対応列のみ
- ページネーション + 表示件数切替（20/50/100）
- 空状態: メッセージ + 新規作成CTA（別issueのため `disabled`「準備中」表記）
- 行クリック: 講座名を `/admin/courses/{id}` へのリンク化

**スコープ外（別issue / 明記して残置）**
- 講座詳細ページ `/admin/courses/[courseId]`（遷移リンクのみ設置）
- 科目フィルタUI（科目一覧APIがフロント・Railsともに未実装のため見送り）
- 対象学年・割当高校数・ステータス列、新規作成機能


## 動作確認

- 一覧表示・検索・ソート・ページネーション・表示件数切替・空状態・行クリック遷移を確認済み
- `npm run test` — 37 passed（AdminCourses Presenter 9件含む）
- `npm run typecheck` — green
- `npm run lint` — green
- `npm run format:check` — green

## その他

新規ライブラリの導入はありません。

## 参考情報

特になし
