### PR TITLE
issue-64 管理者詳細・編集画面

### DIFF
--- a/frontend/app/(admin)/admin/(authenticated)/admins/[adminId]/page.tsx
+++ b/frontend/app/(admin)/admin/(authenticated)/admins/[adminId]/page.tsx
@@ -1,0 +1,28 @@
+import { cookies } from "next/headers";
+import { getMeFromRails } from "@/libs/server/me";
+import { AdminAdminDetail } from "@/features/AdminAdminDetail";
+
+type Props = {
+  params: Promise<{ adminId: string }>;
+};
+
+const AdminAdminDetailPage = async ({ params }: Props) => {
+  const { adminId } = await params;
+
+  // 自己削除ガードのため、ログイン中の管理者 ID を取得して渡す
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join("; ");
+  const me = await getMeFromRails(cookieHeader);
+
+  return (
+    <AdminAdminDetail
+      adminId={Number(adminId)}
+      currentAdminId={me?.id ?? null}
+    />
+  );
+};
+
+export default AdminAdminDetailPage;

--- a/frontend/app/(admin)/admin/(authenticated)/admins/[adminId]/page.tsx
+++ b/frontend/app/(admin)/admin/(authenticated)/admins/[adminId]/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { getMeFromRails } from "@/libs/server/me";
+import { getPrefectures } from "@/libs/server/prefectures";
 import { AdminAdminDetail } from "@/features/AdminAdminDetail";
 
 type Props = {
@@ -17,10 +18,14 @@ const AdminAdminDetailPage = async ({ params }: Props) => {
     .join("; ");
   const me = await getMeFromRails(cookieHeader);
 
+  // 住所カスケードの都道府県プルダウン用
+  const prefectures = await getPrefectures(cookieHeader);
+
   return (
     <AdminAdminDetail
       adminId={Number(adminId)}
       currentAdminId={me?.id ?? null}
+      prefectures={prefectures}
     />
   );
 };

--- a/frontend/app/api/admin/addresses/route.ts
+++ b/frontend/app/api/admin/addresses/route.ts
@@ -1,0 +1,33 @@
+import { RailsUnauthorizedError } from "@/libs/server/rails/railsError";
+import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+
+    const query = searchParams.toString();
+
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/admin/addresses?${query}`,
+      {
+        method: "GET",
+      },
+    );
+
+    const nextResponse = NextResponse.json(data, { status });
+
+    if (setCookie) nextResponse.headers.set("set-cookie", setCookie);
+
+    return nextResponse;
+  } catch (error) {
+    if (error instanceof RailsUnauthorizedError) {
+      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+    }
+
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/app/api/admin/admins/[adminId]/password-reset/route.ts
+++ b/frontend/app/api/admin/admins/[adminId]/password-reset/route.ts
@@ -1,0 +1,46 @@
+import {
+  RailsFetchError,
+  RailsUnauthorizedError,
+} from "@/libs/server/rails/railsError";
+import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { type NextRequest, NextResponse } from "next/server";
+
+// 対象管理者にパスワード再設定メールを送信する。
+// body の email を Rails のパスワードリセット要求エンドポイントへ転送する。
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      "/api/v1/password/reset/request",
+      { method: "POST", body },
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    if (error instanceof RailsUnauthorizedError) {
+      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+    }
+
+    if (error instanceof RailsFetchError) {
+      let data: unknown = {
+        errors: ["パスワード再設定メールの送信に失敗しました"],
+      };
+      if (error.bodyText) {
+        try {
+          data = JSON.parse(error.bodyText);
+        } catch {
+          // パース失敗時はデフォルトのエラーメッセージを使う
+        }
+      }
+      return NextResponse.json(data, { status: error.status });
+    }
+
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/app/api/admin/admins/[adminId]/password-reset/route.ts
+++ b/frontend/app/api/admin/admins/[adminId]/password-reset/route.ts
@@ -1,8 +1,5 @@
-import {
-  RailsFetchError,
-  RailsUnauthorizedError,
-} from "@/libs/server/rails/railsError";
 import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { handleRailsRouteError } from "@/libs/server/rails/handleRailsRouteError";
 import { type NextRequest, NextResponse } from "next/server";
 
 // 対象管理者にパスワード再設定メールを送信する。
@@ -20,27 +17,9 @@ export async function POST(request: NextRequest) {
     if (setCookie) res.headers.set("set-cookie", setCookie);
     return res;
   } catch (error) {
-    if (error instanceof RailsUnauthorizedError) {
-      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
-    }
-
-    if (error instanceof RailsFetchError) {
-      let data: unknown = {
-        errors: ["パスワード再設定メールの送信に失敗しました"],
-      };
-      if (error.bodyText) {
-        try {
-          data = JSON.parse(error.bodyText);
-        } catch {
-          // パース失敗時はデフォルトのエラーメッセージを使う
-        }
-      }
-      return NextResponse.json(data, { status: error.status });
-    }
-
-    return NextResponse.json(
-      { message: "INTERNAL_SERVER_ERROR" },
-      { status: 500 },
+    return handleRailsRouteError(
+      error,
+      "パスワード再設定メールの送信に失敗しました",
     );
   }
 }

--- a/frontend/app/api/admin/admins/[adminId]/route.ts
+++ b/frontend/app/api/admin/admins/[adminId]/route.ts
@@ -1,0 +1,94 @@
+import {
+  RailsFetchError,
+  RailsUnauthorizedError,
+} from "@/libs/server/rails/railsError";
+import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { type NextRequest, NextResponse } from "next/server";
+
+type Params = { params: Promise<{ adminId: string }> };
+
+// 管理者詳細の取得
+export async function GET(_: NextRequest, { params }: Params) {
+  const { adminId } = await params;
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/admin/admins/${adminId}`,
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    if (error instanceof RailsUnauthorizedError) {
+      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+    }
+
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+}
+
+// 管理者の更新（name / email を Rails へ送る）
+export async function PATCH(request: NextRequest, { params }: Params) {
+  const { adminId } = await params;
+  const body = await request.json();
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/admin/admins/${adminId}`,
+      { method: "PATCH", body },
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    return handleMutationError(error, "管理者の更新に失敗しました");
+  }
+}
+
+// 管理者の削除（ソフトデリート）。自己削除・最後の管理者は Rails が 422 を返す。
+export async function DELETE(_: NextRequest, { params }: Params) {
+  const { adminId } = await params;
+
+  try {
+    const { status, setCookie } = await railsFetch(
+      `/api/v1/admin/admins/${adminId}`,
+      { method: "DELETE" },
+    );
+
+    const res = new NextResponse(null, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    return handleMutationError(error, "管理者の削除に失敗しました");
+  }
+}
+
+// 更新・削除の共通エラーハンドリング。
+// 401 は専用、422 などは Rails のエラー内容（{ errors: [...] }）をそのまま返す。
+function handleMutationError(error: unknown, fallbackMessage: string) {
+  if (error instanceof RailsUnauthorizedError) {
+    return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  if (error instanceof RailsFetchError) {
+    let data: unknown = { errors: [fallbackMessage] };
+    if (error.bodyText) {
+      try {
+        data = JSON.parse(error.bodyText);
+      } catch {
+        // パース失敗時はデフォルトのエラーメッセージを使う
+      }
+    }
+    return NextResponse.json(data, { status: error.status });
+  }
+
+  return NextResponse.json(
+    { message: "INTERNAL_SERVER_ERROR" },
+    { status: 500 },
+  );
+}

--- a/frontend/app/api/admin/admins/[adminId]/route.ts
+++ b/frontend/app/api/admin/admins/[adminId]/route.ts
@@ -1,8 +1,5 @@
-import {
-  RailsFetchError,
-  RailsUnauthorizedError,
-} from "@/libs/server/rails/railsError";
 import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { handleRailsRouteError } from "@/libs/server/rails/handleRailsRouteError";
 import { type NextRequest, NextResponse } from "next/server";
 
 type Params = { params: Promise<{ adminId: string }> };
@@ -20,14 +17,8 @@ export async function GET(_: NextRequest, { params }: Params) {
     if (setCookie) res.headers.set("set-cookie", setCookie);
     return res;
   } catch (error) {
-    if (error instanceof RailsUnauthorizedError) {
-      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
-    }
-
-    return NextResponse.json(
-      { message: "INTERNAL_SERVER_ERROR" },
-      { status: 500 },
-    );
+    // 404（存在しない・削除済み）などは Rails のステータス・内容をそのまま返す
+    return handleRailsRouteError(error, "管理者の取得に失敗しました");
   }
 }
 
@@ -46,7 +37,7 @@ export async function PATCH(request: NextRequest, { params }: Params) {
     if (setCookie) res.headers.set("set-cookie", setCookie);
     return res;
   } catch (error) {
-    return handleMutationError(error, "管理者の更新に失敗しました");
+    return handleRailsRouteError(error, "管理者の更新に失敗しました");
   }
 }
 
@@ -64,31 +55,6 @@ export async function DELETE(_: NextRequest, { params }: Params) {
     if (setCookie) res.headers.set("set-cookie", setCookie);
     return res;
   } catch (error) {
-    return handleMutationError(error, "管理者の削除に失敗しました");
+    return handleRailsRouteError(error, "管理者の削除に失敗しました");
   }
-}
-
-// 更新・削除の共通エラーハンドリング。
-// 401 は専用、422 などは Rails のエラー内容（{ errors: [...] }）をそのまま返す。
-function handleMutationError(error: unknown, fallbackMessage: string) {
-  if (error instanceof RailsUnauthorizedError) {
-    return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
-  }
-
-  if (error instanceof RailsFetchError) {
-    let data: unknown = { errors: [fallbackMessage] };
-    if (error.bodyText) {
-      try {
-        data = JSON.parse(error.bodyText);
-      } catch {
-        // パース失敗時はデフォルトのエラーメッセージを使う
-      }
-    }
-    return NextResponse.json(data, { status: error.status });
-  }
-
-  return NextResponse.json(
-    { message: "INTERNAL_SERVER_ERROR" },
-    { status: 500 },
-  );
 }

--- a/frontend/constants/gender.ts
+++ b/frontend/constants/gender.ts
@@ -1,0 +1,7 @@
+import { GenderType } from "@/types/common/gender";
+
+export const GenderLabel: Record<GenderType, string> = {
+  male: "男",
+  female: "女",
+  other: "その他",
+};

--- a/frontend/features/AdminAdminDetail/Presenter.test.tsx
+++ b/frontend/features/AdminAdminDetail/Presenter.test.tsx
@@ -15,7 +15,7 @@ const mockAdmin: AdminDetail = {
 const defaultProps = {
   admin: mockAdmin,
   isSelf: false,
-  onUpdate: vi.fn(),
+  onUpdate: vi.fn(async () => true),
   updating: false,
   updateErrors: [] as string[],
   onPasswordReset: vi.fn(),
@@ -56,7 +56,7 @@ describe("AdminAdminDetailPresenter", () => {
   });
 
   it("編集して保存すると onUpdate が編集値で呼ばれる", async () => {
-    const onUpdate = vi.fn();
+    const onUpdate = vi.fn(async () => true);
     render(<Presenter {...defaultProps} onUpdate={onUpdate} />);
     fireEvent.click(screen.getByRole("button", { name: "編集" }));
 
@@ -71,6 +71,32 @@ describe("AdminAdminDetailPresenter", () => {
         email: "tanaka@example.com",
       });
     });
+  });
+
+  it("保存が成功すると編集モードを抜けて読み取り表示に戻る", async () => {
+    const onUpdate = vi.fn(async () => true);
+    render(<Presenter {...defaultProps} onUpdate={onUpdate} />);
+    fireEvent.click(screen.getByRole("button", { name: "編集" }));
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "編集" })).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("textbox", { name: "名前" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("保存が失敗すると編集モードのままになる", async () => {
+    const onUpdate = vi.fn(async () => false);
+    render(<Presenter {...defaultProps} onUpdate={onUpdate} />);
+    fireEvent.click(screen.getByRole("button", { name: "編集" }));
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalled();
+    });
+    expect(screen.getByRole("textbox", { name: "名前" })).toBeInTheDocument();
   });
 
   it("「キャンセル」で編集モードが解除され読み取り表示に戻る", () => {

--- a/frontend/features/AdminAdminDetail/Presenter.test.tsx
+++ b/frontend/features/AdminAdminDetail/Presenter.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Presenter } from "./Presenter";
+import type { AdminDetail } from "./types";
+
+const mockAdmin: AdminDetail = {
+  id: 1,
+  name: "田中管理者",
+  email: "tanaka@example.com",
+  created_at: "2025-06-04T10:30:00.000Z",
+  updated_at: "2025-06-05T10:30:00.000Z",
+  activity_log: [],
+};
+
+const defaultProps = {
+  admin: mockAdmin,
+  isSelf: false,
+  onUpdate: vi.fn(),
+  updating: false,
+  updateErrors: [] as string[],
+  onPasswordReset: vi.fn(),
+  resettingPassword: false,
+  deleteDialogOpen: false,
+  onDeleteClick: vi.fn(),
+  onDeleteDialogClose: vi.fn(),
+  onDeleteConfirm: vi.fn(),
+  deleting: false,
+  deleteErrors: [] as string[],
+  snackbar: { open: false, message: "", severity: "success" as const },
+  onSnackbarClose: vi.fn(),
+};
+
+describe("AdminAdminDetailPresenter", () => {
+  it("名前・メール・登録日が読み取り表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    // 名前はパンくず・見出しにも出るため、複数存在することだけ確認する
+    expect(screen.getAllByText("田中管理者").length).toBeGreaterThan(0);
+    expect(screen.getByText("tanaka@example.com")).toBeInTheDocument();
+    expect(screen.getByText("2025/06/04")).toBeInTheDocument();
+  });
+
+  it("「編集」ボタンで入力フィールドと「保存」「キャンセル」が現れる", () => {
+    render(<Presenter {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "編集" }));
+
+    expect(screen.getByRole("textbox", { name: "名前" })).toHaveValue(
+      "田中管理者",
+    );
+    expect(screen.getByRole("textbox", { name: "メールアドレス" })).toHaveValue(
+      "tanaka@example.com",
+    );
+    expect(screen.getByRole("button", { name: "保存" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "キャンセル" }),
+    ).toBeInTheDocument();
+  });
+
+  it("編集して保存すると onUpdate が編集値で呼ばれる", async () => {
+    const onUpdate = vi.fn();
+    render(<Presenter {...defaultProps} onUpdate={onUpdate} />);
+    fireEvent.click(screen.getByRole("button", { name: "編集" }));
+
+    fireEvent.change(screen.getByRole("textbox", { name: "名前" }), {
+      target: { value: "鈴木管理者" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "保存" }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith({
+        name: "鈴木管理者",
+        email: "tanaka@example.com",
+      });
+    });
+  });
+
+  it("「キャンセル」で編集モードが解除され読み取り表示に戻る", () => {
+    render(<Presenter {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "編集" }));
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(
+      screen.queryByRole("textbox", { name: "名前" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "編集" })).toBeInTheDocument();
+  });
+
+  it("updateErrors が Alert で表示される", () => {
+    render(
+      <Presenter
+        {...defaultProps}
+        updateErrors={["メールアドレスは既に使用されています"]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "編集" }));
+    expect(
+      screen.getByText("メールアドレスは既に使用されています"),
+    ).toBeInTheDocument();
+  });
+
+  it("パスワードリセットボタンで onPasswordReset が呼ばれる", () => {
+    const onPasswordReset = vi.fn();
+    render(<Presenter {...defaultProps} onPasswordReset={onPasswordReset} />);
+    fireEvent.click(screen.getByRole("button", { name: "パスワードリセット" }));
+    expect(onPasswordReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("resettingPassword 中はパスワードリセットボタンが無効", () => {
+    render(<Presenter {...defaultProps} resettingPassword />);
+    expect(
+      screen.getByRole("button", { name: "パスワードリセット" }),
+    ).toBeDisabled();
+  });
+
+  it("アクティビティログの空状態が表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(
+      screen.getByText("アクティビティはまだありません"),
+    ).toBeInTheDocument();
+  });
+
+  it("危険操作カードの削除ボタンで onDeleteClick が呼ばれる", () => {
+    const onDeleteClick = vi.fn();
+    render(<Presenter {...defaultProps} onDeleteClick={onDeleteClick} />);
+    fireEvent.click(screen.getByRole("button", { name: "この管理者を削除" }));
+    expect(onDeleteClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("deleteDialogOpen のとき確認ダイアログが表示され、確認ボタンは初期 disabled", () => {
+    render(<Presenter {...defaultProps} deleteDialogOpen />);
+    expect(screen.getByRole("button", { name: "削除する" })).toBeDisabled();
+  });
+
+  it("正確なメールを入力すると確認ボタンが有効化され onDeleteConfirm が呼ばれる", () => {
+    const onDeleteConfirm = vi.fn();
+    render(
+      <Presenter
+        {...defaultProps}
+        deleteDialogOpen
+        onDeleteConfirm={onDeleteConfirm}
+      />,
+    );
+    const confirmButton = screen.getByRole("button", { name: "削除する" });
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "メールアドレスを入力" }),
+      {
+        target: { value: "wrong@example.com" },
+      },
+    );
+    expect(confirmButton).toBeDisabled();
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "メールアドレスを入力" }),
+      {
+        target: { value: "tanaka@example.com" },
+      },
+    );
+    expect(confirmButton).toBeEnabled();
+
+    fireEvent.click(confirmButton);
+    expect(onDeleteConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("isSelf のとき削除ボタンが無効で説明文が表示される", () => {
+    render(<Presenter {...defaultProps} isSelf />);
+    expect(
+      screen.getByRole("button", { name: "この管理者を削除" }),
+    ).toBeDisabled();
+    expect(screen.getByText("自分自身は削除できません")).toBeInTheDocument();
+  });
+
+  it("snackbar.open のときメッセージが表示される", () => {
+    render(
+      <Presenter
+        {...defaultProps}
+        snackbar={{
+          open: true,
+          message: "管理者を更新しました",
+          severity: "success",
+        }}
+      />,
+    );
+    expect(screen.getByText("管理者を更新しました")).toBeInTheDocument();
+  });
+
+  it("updating 中は保存ボタンが無効", () => {
+    render(<Presenter {...defaultProps} updating />);
+    fireEvent.click(screen.getByRole("button", { name: "編集" }));
+    expect(screen.getByRole("button", { name: "保存" })).toBeDisabled();
+  });
+});

--- a/frontend/features/AdminAdminDetail/Presenter.test.tsx
+++ b/frontend/features/AdminAdminDetail/Presenter.test.tsx
@@ -10,10 +10,24 @@ const mockAdmin: AdminDetail = {
   created_at: "2025-06-04T10:30:00.000Z",
   updated_at: "2025-06-05T10:30:00.000Z",
   activity_log: [],
+  user_personal_info: {
+    id: 10,
+    phone_number: "08012345678",
+    birthday: "1999-01-01",
+    gender: "male",
+  },
+  address: {
+    id: 5,
+    postal_code: "1000001",
+    city: "千代田区",
+    town: "千代田",
+    prefecture: { id: 13, name: "東京都" },
+  },
 };
 
 const defaultProps = {
   admin: mockAdmin,
+  prefectures: [{ id: 13, name: "東京都" }],
   isSelf: false,
   onUpdate: vi.fn(async () => true),
   updating: false,
@@ -37,6 +51,29 @@ describe("AdminAdminDetailPresenter", () => {
     expect(screen.getAllByText("田中管理者").length).toBeGreaterThan(0);
     expect(screen.getByText("tanaka@example.com")).toBeInTheDocument();
     expect(screen.getByText("2025/06/04")).toBeInTheDocument();
+  });
+
+  it("電話番号・生年月日・性別・住所が読み取り表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByText("08012345678")).toBeInTheDocument();
+    expect(screen.getByText("1999-01-01")).toBeInTheDocument();
+    expect(screen.getByText("男")).toBeInTheDocument();
+    expect(screen.getByText("東京都 千代田区 千代田")).toBeInTheDocument();
+  });
+
+  it("個人情報・住所が未設定なら「未設定」と表示される", () => {
+    render(
+      <Presenter
+        {...defaultProps}
+        admin={{
+          ...mockAdmin,
+          user_personal_info: null,
+          address: null,
+        }}
+      />,
+    );
+    // 電話番号・生年月日・性別・住所の 4 項目が未設定表示になる
+    expect(screen.getAllByText("未設定").length).toBeGreaterThanOrEqual(4);
   });
 
   it("「編集」ボタンで入力フィールドと「保存」「キャンセル」が現れる", () => {
@@ -66,10 +103,16 @@ describe("AdminAdminDetailPresenter", () => {
     fireEvent.click(screen.getByRole("button", { name: "保存" }));
 
     await waitFor(() => {
-      expect(onUpdate).toHaveBeenCalledWith({
-        name: "鈴木管理者",
-        email: "tanaka@example.com",
-      });
+      expect(onUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "鈴木管理者",
+          email: "tanaka@example.com",
+          phone_number: "08012345678",
+          birthday: "1999-01-01",
+          gender: "male",
+          address_id: 5,
+        }),
+      );
     });
   });
 

--- a/frontend/features/AdminAdminDetail/Presenter.test.tsx
+++ b/frontend/features/AdminAdminDetail/Presenter.test.tsx
@@ -3,9 +3,18 @@ import { describe, it, expect, vi } from "vitest";
 import { Presenter } from "./Presenter";
 import type { AdminDetail } from "./types";
 
+// 編集モードに入ると住所カスケードが /api/admin/addresses を叩くため、
+// 実 HTTP を発生させないようにモックする。
+vi.mock("@/libs/http/apiClient", () => ({
+  apiClient: {
+    get: vi.fn(async () => ({ data: [] })),
+  },
+}));
+
 const mockAdmin: AdminDetail = {
   id: 1,
   name: "田中管理者",
+  name_kana: "タナカカンリシャ",
   email: "tanaka@example.com",
   created_at: "2025-06-04T10:30:00.000Z",
   updated_at: "2025-06-05T10:30:00.000Z",
@@ -49,6 +58,7 @@ describe("AdminAdminDetailPresenter", () => {
     render(<Presenter {...defaultProps} />);
     // 名前はパンくず・見出しにも出るため、複数存在することだけ確認する
     expect(screen.getAllByText("田中管理者").length).toBeGreaterThan(0);
+    expect(screen.getByText("タナカカンリシャ")).toBeInTheDocument();
     expect(screen.getByText("tanaka@example.com")).toBeInTheDocument();
     expect(screen.getByText("2025/06/04")).toBeInTheDocument();
   });
@@ -106,6 +116,7 @@ describe("AdminAdminDetailPresenter", () => {
       expect(onUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "鈴木管理者",
+          name_kana: "タナカカンリシャ",
           email: "tanaka@example.com",
           phone_number: "08012345678",
           birthday: "1999-01-01",

--- a/frontend/features/AdminAdminDetail/Presenter.tsx
+++ b/frontend/features/AdminAdminDetail/Presenter.tsx
@@ -29,8 +29,8 @@ type Props = {
   // 表示中の管理者がログイン中の本人かどうか（自己削除ガード用）
   isSelf: boolean;
 
-  // 編集（更新）
-  onUpdate: (input: UpdateAdminInput) => void;
+  // 編集（更新）。成功すると true を返し、編集モードを抜ける。
+  onUpdate: (input: UpdateAdminInput) => Promise<boolean>;
   updating: boolean;
   updateErrors: string[];
 
@@ -88,8 +88,11 @@ export const Presenter = ({
     setEditing(false);
   };
 
-  const handleSave = (input: UpdateAdminInput) => {
-    onUpdate(input);
+  const handleSave = async (input: UpdateAdminInput) => {
+    const success = await onUpdate(input);
+    if (success) {
+      setEditing(false);
+    }
   };
 
   return (

--- a/frontend/features/AdminAdminDetail/Presenter.tsx
+++ b/frontend/features/AdminAdminDetail/Presenter.tsx
@@ -1,0 +1,393 @@
+"use client";
+
+import {
+  Alert,
+  Box,
+  Breadcrumbs,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Divider,
+  Grid,
+  Snackbar,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import HistoryIcon from "@mui/icons-material/History";
+import Link from "next/link";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { format } from "date-fns";
+import { colors } from "@/app/theme/colors";
+import { DeleteConfirmDialog } from "./components/DeleteConfirmDialog";
+import type { AdminDetail, SnackbarState, UpdateAdminInput } from "./types";
+
+type Props = {
+  admin: AdminDetail;
+  // 表示中の管理者がログイン中の本人かどうか（自己削除ガード用）
+  isSelf: boolean;
+
+  // 編集（更新）
+  onUpdate: (input: UpdateAdminInput) => void;
+  updating: boolean;
+  updateErrors: string[];
+
+  // パスワードリセット
+  onPasswordReset: () => void;
+  resettingPassword: boolean;
+
+  // 削除フロー
+  deleteDialogOpen: boolean;
+  onDeleteClick: () => void;
+  onDeleteDialogClose: () => void;
+  onDeleteConfirm: () => void;
+  deleting: boolean;
+  deleteErrors: string[];
+
+  // 完了スナックバー
+  snackbar: SnackbarState;
+  onSnackbarClose: () => void;
+};
+
+export const Presenter = ({
+  admin,
+  isSelf,
+  onUpdate,
+  updating,
+  updateErrors,
+  onPasswordReset,
+  resettingPassword,
+  deleteDialogOpen,
+  onDeleteClick,
+  onDeleteDialogClose,
+  onDeleteConfirm,
+  deleting,
+  deleteErrors,
+  snackbar,
+  onSnackbarClose,
+}: Props) => {
+  const [editing, setEditing] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<UpdateAdminInput>({
+    defaultValues: { name: admin.name, email: admin.email },
+  });
+
+  const handleEditClick = () => {
+    reset({ name: admin.name, email: admin.email });
+    setEditing(true);
+  };
+
+  const handleCancel = () => {
+    setEditing(false);
+  };
+
+  const handleSave = (input: UpdateAdminInput) => {
+    onUpdate(input);
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      {/* パンくずナビ */}
+      <Breadcrumbs sx={{ mb: 2 }}>
+        <Link
+          href="/admin/admins"
+          style={{ color: colors.brand.primary, textDecoration: "none" }}
+        >
+          管理者一覧
+        </Link>
+        <Typography color="text.primary">{admin.name}</Typography>
+      </Breadcrumbs>
+
+      <Typography
+        variant="h5"
+        component="h1"
+        fontWeight={700}
+        sx={{ color: colors.text.primary, mb: 3 }}
+      >
+        {admin.name}
+      </Typography>
+
+      <Grid container spacing={3}>
+        {/* 左カラム（65%）：プロフィール・編集 */}
+        <Grid size={{ xs: 12, md: 8 }}>
+          <Card
+            elevation={0}
+            sx={{ border: `1px solid ${colors.border.light}`, borderRadius: 2 }}
+          >
+            <CardContent sx={{ p: 3 }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  mb: 2,
+                }}
+              >
+                <Typography variant="h6" fontWeight={700}>
+                  プロフィール
+                </Typography>
+                {!editing && (
+                  <Button variant="outlined" onClick={handleEditClick}>
+                    編集
+                  </Button>
+                )}
+              </Box>
+
+              <Divider sx={{ mb: 3 }} />
+
+              {editing ? (
+                <Box component="form" onSubmit={handleSubmit(handleSave)}>
+                  {updateErrors.length > 0 && (
+                    <Alert severity="error" sx={{ mb: 2 }}>
+                      <Stack component="ul" sx={{ m: 0, pl: 2 }} spacing={0.5}>
+                        {updateErrors.map((message, index) => (
+                          <li key={index}>{message}</li>
+                        ))}
+                      </Stack>
+                    </Alert>
+                  )}
+
+                  <Stack spacing={3}>
+                    <TextField
+                      label="名前"
+                      fullWidth
+                      required
+                      {...register("name", {
+                        required: "名前を入力してください",
+                      })}
+                      error={!!errors.name}
+                      helperText={errors.name?.message}
+                    />
+                    <TextField
+                      label="メールアドレス"
+                      type="email"
+                      fullWidth
+                      required
+                      {...register("email", {
+                        required: "メールアドレスを入力してください",
+                        pattern: {
+                          value: /^[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}$/,
+                          message: "メールアドレスの形式が正しくありません",
+                        },
+                      })}
+                      error={!!errors.email}
+                      helperText={errors.email?.message}
+                    />
+                  </Stack>
+
+                  <Box
+                    sx={{
+                      mt: 3,
+                      display: "flex",
+                      justifyContent: "flex-end",
+                      gap: 1.5,
+                    }}
+                  >
+                    <Button
+                      onClick={handleCancel}
+                      disabled={updating}
+                      color="inherit"
+                    >
+                      キャンセル
+                    </Button>
+                    <Button
+                      type="submit"
+                      variant="contained"
+                      disabled={updating}
+                      startIcon={
+                        updating ? (
+                          <CircularProgress size={16} color="inherit" />
+                        ) : null
+                      }
+                    >
+                      保存
+                    </Button>
+                  </Box>
+                </Box>
+              ) : (
+                <Stack spacing={3}>
+                  <Box>
+                    <Typography
+                      variant="body2"
+                      sx={{ color: colors.text.muted, mb: 0.5 }}
+                    >
+                      名前
+                    </Typography>
+                    <Typography variant="body1">{admin.name}</Typography>
+                  </Box>
+                  <Box>
+                    <Typography
+                      variant="body2"
+                      sx={{ color: colors.text.muted, mb: 0.5 }}
+                    >
+                      メールアドレス
+                    </Typography>
+                    <Typography variant="body1">{admin.email}</Typography>
+                  </Box>
+                  <Box>
+                    <Typography
+                      variant="body2"
+                      sx={{ color: colors.text.muted, mb: 0.5 }}
+                    >
+                      登録日
+                    </Typography>
+                    <Typography variant="body1">
+                      {format(new Date(admin.created_at), "yyyy/MM/dd")}
+                    </Typography>
+                  </Box>
+                </Stack>
+              )}
+
+              {!editing && (
+                <>
+                  <Divider sx={{ my: 3 }} />
+                  <Box>
+                    <Typography
+                      variant="body2"
+                      sx={{ color: colors.text.muted, mb: 1 }}
+                    >
+                      パスワード
+                    </Typography>
+                    <Button
+                      variant="outlined"
+                      onClick={onPasswordReset}
+                      disabled={resettingPassword}
+                      startIcon={
+                        resettingPassword ? (
+                          <CircularProgress size={16} color="inherit" />
+                        ) : null
+                      }
+                    >
+                      パスワードリセット
+                    </Button>
+                    <Typography
+                      variant="caption"
+                      sx={{ display: "block", color: colors.text.muted, mt: 1 }}
+                    >
+                      パスワード再設定メールを送信します。
+                    </Typography>
+                  </Box>
+                </>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        {/* 右カラム（35%）：アクティビティログ・危険操作 */}
+        <Grid size={{ xs: 12, md: 4 }}>
+          <Stack spacing={3}>
+            {/* アクティビティログ（空状態のみ） */}
+            <Card
+              elevation={0}
+              sx={{
+                border: `1px solid ${colors.border.light}`,
+                borderRadius: 2,
+              }}
+            >
+              <CardContent sx={{ p: 3 }}>
+                <Typography variant="h6" fontWeight={700} sx={{ mb: 2 }}>
+                  アクティビティログ
+                </Typography>
+                <Box
+                  sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    gap: 1,
+                    py: 4,
+                  }}
+                >
+                  <HistoryIcon
+                    sx={{ fontSize: 40, color: colors.text.muted }}
+                  />
+                  <Typography
+                    variant="body2"
+                    sx={{ color: colors.text.secondary }}
+                  >
+                    アクティビティはまだありません
+                  </Typography>
+                </Box>
+              </CardContent>
+            </Card>
+
+            {/* 危険操作 */}
+            <Card
+              elevation={0}
+              sx={{
+                border: `1px solid ${colors.status.error}`,
+                borderRadius: 2,
+              }}
+            >
+              <CardContent sx={{ p: 3 }}>
+                <Typography
+                  variant="h6"
+                  fontWeight={700}
+                  sx={{ color: colors.status.error, mb: 1 }}
+                >
+                  危険操作
+                </Typography>
+                <Typography
+                  variant="body2"
+                  sx={{ color: colors.text.secondary, mb: 2 }}
+                >
+                  この管理者を削除します。この操作は取り消せません。
+                </Typography>
+                <Button
+                  variant="outlined"
+                  color="error"
+                  onClick={onDeleteClick}
+                  disabled={isSelf}
+                >
+                  この管理者を削除
+                </Button>
+                {isSelf && (
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      display: "block",
+                      color: colors.text.muted,
+                      mt: 1,
+                    }}
+                  >
+                    自分自身は削除できません
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
+          </Stack>
+        </Grid>
+      </Grid>
+
+      <DeleteConfirmDialog
+        open={deleteDialogOpen}
+        expectedEmail={admin.email}
+        onClose={onDeleteDialogClose}
+        onConfirm={onDeleteConfirm}
+        deleting={deleting}
+        deleteErrors={deleteErrors}
+      />
+
+      <Snackbar
+        open={snackbar.open}
+        autoHideDuration={3000}
+        onClose={onSnackbarClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      >
+        <Alert
+          onClose={onSnackbarClose}
+          severity={snackbar.severity}
+          sx={{ width: "100%" }}
+        >
+          {snackbar.message}
+        </Alert>
+      </Snackbar>
+    </Box>
+  );
+};

--- a/frontend/features/AdminAdminDetail/Presenter.tsx
+++ b/frontend/features/AdminAdminDetail/Presenter.tsx
@@ -180,6 +180,10 @@ export const Presenter = ({
               ) : (
                 <Stack spacing={3}>
                   <ReadOnlyField label="名前" value={admin.name} />
+                  <ReadOnlyField
+                    label="氏名カナ"
+                    value={admin.name_kana ?? ""}
+                  />
                   <ReadOnlyField label="メールアドレス" value={admin.email} />
                   <ReadOnlyField
                     label="電話番号"

--- a/frontend/features/AdminAdminDetail/Presenter.tsx
+++ b/frontend/features/AdminAdminDetail/Presenter.tsx
@@ -12,20 +12,38 @@ import {
   Grid,
   Snackbar,
   Stack,
-  TextField,
   Typography,
 } from "@mui/material";
 import HistoryIcon from "@mui/icons-material/History";
 import Link from "next/link";
 import { useState } from "react";
-import { useForm } from "react-hook-form";
 import { format } from "date-fns";
+import type { Prefecture } from "@/types/common/prefecture";
 import { colors } from "@/app/theme/colors";
 import { DeleteConfirmDialog } from "./components/DeleteConfirmDialog";
+import { ProfileEditForm } from "./components/ProfileEditForm";
 import type { AdminDetail, SnackbarState, UpdateAdminInput } from "./types";
+
+const GENDER_LABELS: Record<string, string> = {
+  male: "男",
+  female: "女",
+  other: "その他",
+};
+
+// 読み取り表示の 1 項目。未設定は「未設定」と表示する。
+const ReadOnlyField = ({ label, value }: { label: string; value: string }) => (
+  <Box>
+    <Typography variant="body2" sx={{ color: colors.text.muted, mb: 0.5 }}>
+      {label}
+    </Typography>
+    <Typography variant="body1">{value || "未設定"}</Typography>
+  </Box>
+);
 
 type Props = {
   admin: AdminDetail;
+  // 住所カスケード（都道府県プルダウン）用の都道府県一覧
+  prefectures: Prefecture[];
   // 表示中の管理者がログイン中の本人かどうか（自己削除ガード用）
   isSelf: boolean;
 
@@ -53,6 +71,7 @@ type Props = {
 
 export const Presenter = ({
   admin,
+  prefectures,
   isSelf,
   onUpdate,
   updating,
@@ -70,17 +89,7 @@ export const Presenter = ({
 }: Props) => {
   const [editing, setEditing] = useState(false);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors },
-  } = useForm<UpdateAdminInput>({
-    defaultValues: { name: admin.name, email: admin.email },
-  });
-
   const handleEditClick = () => {
-    reset({ name: admin.name, email: admin.email });
     setEditing(true);
   };
 
@@ -88,12 +97,26 @@ export const Presenter = ({
     setEditing(false);
   };
 
-  const handleSave = async (input: UpdateAdminInput) => {
+  // 編集フォームから呼ばれる。成功したら編集モードを抜ける。
+  const handleUpdate = async (input: UpdateAdminInput) => {
     const success = await onUpdate(input);
     if (success) {
       setEditing(false);
     }
+    return success;
   };
+
+  const personalInfo = admin.user_personal_info;
+  const address = admin.address;
+  const addressText = address
+    ? [
+        address.prefecture?.name ?? "",
+        address.city,
+        address.town,
+      ]
+        .filter(Boolean)
+        .join(" ")
+    : "";
 
   return (
     <Box sx={{ p: 3 }}>
@@ -146,105 +169,40 @@ export const Presenter = ({
               <Divider sx={{ mb: 3 }} />
 
               {editing ? (
-                <Box component="form" onSubmit={handleSubmit(handleSave)}>
-                  {updateErrors.length > 0 && (
-                    <Alert severity="error" sx={{ mb: 2 }}>
-                      <Stack component="ul" sx={{ m: 0, pl: 2 }} spacing={0.5}>
-                        {updateErrors.map((message, index) => (
-                          <li key={index}>{message}</li>
-                        ))}
-                      </Stack>
-                    </Alert>
-                  )}
-
-                  <Stack spacing={3}>
-                    <TextField
-                      label="名前"
-                      fullWidth
-                      required
-                      {...register("name", {
-                        required: "名前を入力してください",
-                      })}
-                      error={!!errors.name}
-                      helperText={errors.name?.message}
-                    />
-                    <TextField
-                      label="メールアドレス"
-                      type="email"
-                      fullWidth
-                      required
-                      {...register("email", {
-                        required: "メールアドレスを入力してください",
-                        pattern: {
-                          value: /^[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}$/,
-                          message: "メールアドレスの形式が正しくありません",
-                        },
-                      })}
-                      error={!!errors.email}
-                      helperText={errors.email?.message}
-                    />
-                  </Stack>
-
-                  <Box
-                    sx={{
-                      mt: 3,
-                      display: "flex",
-                      justifyContent: "flex-end",
-                      gap: 1.5,
-                    }}
-                  >
-                    <Button
-                      onClick={handleCancel}
-                      disabled={updating}
-                      color="inherit"
-                    >
-                      キャンセル
-                    </Button>
-                    <Button
-                      type="submit"
-                      variant="contained"
-                      disabled={updating}
-                      startIcon={
-                        updating ? (
-                          <CircularProgress size={16} color="inherit" />
-                        ) : null
-                      }
-                    >
-                      保存
-                    </Button>
-                  </Box>
-                </Box>
+                <ProfileEditForm
+                  admin={admin}
+                  prefectures={prefectures}
+                  onUpdate={handleUpdate}
+                  onCancel={handleCancel}
+                  updating={updating}
+                  updateErrors={updateErrors}
+                />
               ) : (
                 <Stack spacing={3}>
-                  <Box>
-                    <Typography
-                      variant="body2"
-                      sx={{ color: colors.text.muted, mb: 0.5 }}
-                    >
-                      名前
-                    </Typography>
-                    <Typography variant="body1">{admin.name}</Typography>
-                  </Box>
-                  <Box>
-                    <Typography
-                      variant="body2"
-                      sx={{ color: colors.text.muted, mb: 0.5 }}
-                    >
-                      メールアドレス
-                    </Typography>
-                    <Typography variant="body1">{admin.email}</Typography>
-                  </Box>
-                  <Box>
-                    <Typography
-                      variant="body2"
-                      sx={{ color: colors.text.muted, mb: 0.5 }}
-                    >
-                      登録日
-                    </Typography>
-                    <Typography variant="body1">
-                      {format(new Date(admin.created_at), "yyyy/MM/dd")}
-                    </Typography>
-                  </Box>
+                  <ReadOnlyField label="名前" value={admin.name} />
+                  <ReadOnlyField label="メールアドレス" value={admin.email} />
+                  <ReadOnlyField
+                    label="電話番号"
+                    value={personalInfo?.phone_number ?? ""}
+                  />
+                  <ReadOnlyField
+                    label="生年月日"
+                    value={personalInfo?.birthday ?? ""}
+                  />
+                  <ReadOnlyField
+                    label="性別"
+                    value={
+                      personalInfo?.gender
+                        ? (GENDER_LABELS[personalInfo.gender] ??
+                          personalInfo.gender)
+                        : ""
+                    }
+                  />
+                  <ReadOnlyField label="住所" value={addressText} />
+                  <ReadOnlyField
+                    label="登録日"
+                    value={format(new Date(admin.created_at), "yyyy/MM/dd")}
+                  />
                 </Stack>
               )}
 

--- a/frontend/features/AdminAdminDetail/Presenter.tsx
+++ b/frontend/features/AdminAdminDetail/Presenter.tsx
@@ -109,11 +109,7 @@ export const Presenter = ({
   const personalInfo = admin.user_personal_info;
   const address = admin.address;
   const addressText = address
-    ? [
-        address.prefecture?.name ?? "",
-        address.city,
-        address.town,
-      ]
+    ? [address.prefecture?.name ?? "", address.city, address.town]
         .filter(Boolean)
         .join(" ")
     : "";

--- a/frontend/features/AdminAdminDetail/Presenter.tsx
+++ b/frontend/features/AdminAdminDetail/Presenter.tsx
@@ -23,12 +23,8 @@ import { colors } from "@/app/theme/colors";
 import { DeleteConfirmDialog } from "./components/DeleteConfirmDialog";
 import { ProfileEditForm } from "./components/ProfileEditForm";
 import type { AdminDetail, SnackbarState, UpdateAdminInput } from "./types";
-
-const GENDER_LABELS: Record<string, string> = {
-  male: "男",
-  female: "女",
-  other: "その他",
-};
+import { GenderLabel } from "@/constants/gender";
+import type { GenderType } from "@/types/common/gender";
 
 // 読み取り表示の 1 項目。未設定は「未設定」と表示する。
 const ReadOnlyField = ({ label, value }: { label: string; value: string }) => (
@@ -193,7 +189,7 @@ export const Presenter = ({
                     label="性別"
                     value={
                       personalInfo?.gender
-                        ? (GENDER_LABELS[personalInfo.gender] ??
+                        ? (GenderLabel[personalInfo.gender as GenderType] ??
                           personalInfo.gender)
                         : ""
                     }

--- a/frontend/features/AdminAdminDetail/components/DeleteConfirmDialog.tsx
+++ b/frontend/features/AdminAdminDetail/components/DeleteConfirmDialog.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import {
+  Alert,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { useEffect, useState } from "react";
+import { colors } from "@/app/theme/colors";
+
+type Props = {
+  open: boolean;
+  // 確認のために入力させる対象管理者のメールアドレス
+  expectedEmail: string;
+  onClose: () => void;
+  onConfirm: () => void;
+  deleting: boolean;
+  // API（Rails）から返るエラー文言の配列
+  deleteErrors: string[];
+};
+
+// 管理者削除の確認ダイアログ。
+// 対象のメールアドレスを正確に入力するまで「削除する」ボタンを無効化する。
+export const DeleteConfirmDialog = ({
+  open,
+  expectedEmail,
+  onClose,
+  onConfirm,
+  deleting,
+  deleteErrors,
+}: Props) => {
+  const [input, setInput] = useState("");
+
+  // 開閉のたびに入力をリセットする
+  useEffect(() => {
+    if (!open) {
+      setInput("");
+    }
+  }, [open]);
+
+  const canDelete = input === expectedEmail && !deleting;
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="xs">
+      <DialogTitle sx={{ color: colors.status.error, fontWeight: 700 }}>
+        管理者を削除
+      </DialogTitle>
+      <DialogContent>
+        {deleteErrors.length > 0 && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            <Stack component="ul" sx={{ m: 0, pl: 2 }} spacing={0.5}>
+              {deleteErrors.map((message, index) => (
+                <li key={index}>{message}</li>
+              ))}
+            </Stack>
+          </Alert>
+        )}
+
+        <DialogContentText sx={{ mb: 2 }}>
+          この操作は取り消せません。削除するには対象のメールアドレス
+          <Typography component="span" fontWeight={700}>
+            {` ${expectedEmail} `}
+          </Typography>
+          を入力してください。
+        </DialogContentText>
+
+        <TextField
+          label="メールアドレスを入力"
+          fullWidth
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          autoComplete="off"
+        />
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={onClose} disabled={deleting} color="inherit">
+          キャンセル
+        </Button>
+        <Button
+          onClick={onConfirm}
+          variant="contained"
+          color="error"
+          disabled={!canDelete}
+          startIcon={
+            deleting ? <CircularProgress size={16} color="inherit" /> : null
+          }
+        >
+          削除する
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/frontend/features/AdminAdminDetail/components/ProfileEditForm.tsx
+++ b/frontend/features/AdminAdminDetail/components/ProfileEditForm.tsx
@@ -1,0 +1,328 @@
+"use client";
+
+import {
+  Alert,
+  Autocomplete,
+  Box,
+  Button,
+  CircularProgress,
+  FormControlLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Stack,
+  TextField,
+} from "@mui/material";
+import { Controller, useForm } from "react-hook-form";
+import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { ja } from "date-fns/locale";
+import { format } from "date-fns";
+import { useEffect, useMemo } from "react";
+import type { Prefecture } from "@/types/common/prefecture";
+import { useFetchAddresses } from "../hooks/useFetchAddresses";
+import type { AdminDetail, AdminEditForm, UpdateAdminInput } from "../types";
+
+// 未設定時に DatePicker のカレンダーが開く基準日（1999年ごろ）。
+const BIRTHDAY_REFERENCE_DATE = new Date(1999, 0, 1);
+
+type Props = {
+  admin: AdminDetail;
+  prefectures: Prefecture[];
+  onUpdate: (input: UpdateAdminInput) => Promise<boolean>;
+  onCancel: () => void;
+  updating: boolean;
+  updateErrors: string[];
+};
+
+const buildDefaultValues = (admin: AdminDetail): AdminEditForm => ({
+  name: admin.name,
+  email: admin.email,
+  phone_number: admin.user_personal_info?.phone_number ?? "",
+  birthday: admin.user_personal_info?.birthday ?? "",
+  gender: admin.user_personal_info?.gender ?? "",
+  prefecture_id: admin.address?.prefecture?.id ?? null,
+  city: admin.address?.city ?? "",
+  town: admin.address?.town ?? "",
+  address_id: admin.address?.id ?? null,
+});
+
+export const ProfileEditForm = ({
+  admin,
+  prefectures,
+  onUpdate,
+  onCancel,
+  updating,
+  updateErrors,
+}: Props) => {
+  const {
+    control,
+    register,
+    watch,
+    setValue,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<AdminEditForm>({
+    defaultValues: buildDefaultValues(admin),
+  });
+
+  const prefectureId = watch("prefecture_id");
+  const city = watch("city");
+  const town = watch("town");
+
+  const {
+    cityOptions,
+    townOptions,
+    fetchCities,
+    fetchTowns,
+    setCityOptions,
+    setTownOptions,
+  } = useFetchAddresses();
+
+  // 初期表示時に既存住所の候補を表示しておく（API 取得前のフォールバック）。
+  const initialCityOptions = useMemo(
+    () => (admin.address ? [admin.address.city] : []),
+    [admin.address],
+  );
+  const initialTownOptions = useMemo(
+    () =>
+      admin.address
+        ? [
+            {
+              id: admin.address.id,
+              city: admin.address.city,
+              town: admin.address.town,
+            },
+          ]
+        : [],
+    [admin.address],
+  );
+
+  useEffect(() => {
+    if (!prefectureId) {
+      setCityOptions([]);
+      setTownOptions([]);
+      return;
+    }
+    fetchCities(prefectureId);
+  }, [prefectureId, fetchCities, setCityOptions, setTownOptions]);
+
+  useEffect(() => {
+    if (!prefectureId || !city) {
+      setTownOptions([]);
+      return;
+    }
+    fetchTowns(prefectureId, city);
+  }, [prefectureId, city, fetchTowns, setTownOptions]);
+
+  const mergedCityOptions =
+    cityOptions.length > 0 ? cityOptions : initialCityOptions;
+  const mergedTownOptions =
+    townOptions.length > 0 ? townOptions : initialTownOptions;
+
+  // town に対応する address_id を同期する。
+  useEffect(() => {
+    if (!town) {
+      setValue("address_id", null);
+      return;
+    }
+    const selected = mergedTownOptions.find((item) => item.town === town);
+    setValue("address_id", selected ? selected.id : null);
+  }, [town, mergedTownOptions, setValue]);
+
+  const handleSave = (data: AdminEditForm) => {
+    return onUpdate({
+      name: data.name,
+      email: data.email,
+      phone_number: data.phone_number,
+      birthday: data.birthday,
+      gender: data.gender,
+      address_id: data.address_id,
+    });
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit(handleSave)}>
+      <input type="hidden" {...register("address_id")} />
+
+      {updateErrors.length > 0 && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          <Stack component="ul" sx={{ m: 0, pl: 2 }} spacing={0.5}>
+            {updateErrors.map((message, index) => (
+              <li key={index}>{message}</li>
+            ))}
+          </Stack>
+        </Alert>
+      )}
+
+      <Stack spacing={3}>
+        <TextField
+          label="名前"
+          fullWidth
+          required
+          {...register("name", { required: "名前を入力してください" })}
+          error={!!errors.name}
+          helperText={errors.name?.message}
+        />
+        <TextField
+          label="メールアドレス"
+          type="email"
+          fullWidth
+          required
+          {...register("email", {
+            required: "メールアドレスを入力してください",
+            pattern: {
+              value: /^[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}$/,
+              message: "メールアドレスの形式が正しくありません",
+            },
+          })}
+          error={!!errors.email}
+          helperText={errors.email?.message}
+        />
+        <TextField
+          label="電話番号"
+          fullWidth
+          placeholder="ハイフンなし"
+          {...register("phone_number", {
+            pattern: {
+              value: /^\d{10,11}$/,
+              message: "電話番号は数字10〜11桁で入力してください",
+            },
+          })}
+          error={!!errors.phone_number}
+          helperText={errors.phone_number?.message}
+        />
+
+        <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={ja}>
+          <Controller
+            name="birthday"
+            control={control}
+            render={({ field }) => (
+              <DatePicker
+                label="生年月日"
+                format="yyyy-MM-dd"
+                maxDate={new Date()}
+                referenceDate={
+                  field.value ? new Date(field.value) : BIRTHDAY_REFERENCE_DATE
+                }
+                value={field.value ? new Date(field.value) : null}
+                onChange={(date) =>
+                  field.onChange(date ? format(date, "yyyy-MM-dd") : "")
+                }
+                slotProps={{ textField: { fullWidth: true } }}
+              />
+            )}
+          />
+        </LocalizationProvider>
+
+        <Controller
+          name="gender"
+          control={control}
+          render={({ field }) => (
+            <RadioGroup row {...field}>
+              <FormControlLabel value="male" control={<Radio />} label="男" />
+              <FormControlLabel value="female" control={<Radio />} label="女" />
+              <FormControlLabel
+                value="other"
+                control={<Radio />}
+                label="その他"
+              />
+            </RadioGroup>
+          )}
+        />
+
+        <Controller
+          name="prefecture_id"
+          control={control}
+          render={({ field }) => (
+            <TextField
+              select
+              label="都道府県"
+              fullWidth
+              value={field.value ?? ""}
+              onChange={(e) => {
+                const value = e.target.value ? Number(e.target.value) : null;
+                field.onChange(value);
+                setValue("city", "");
+                setValue("town", "");
+                setValue("address_id", null);
+                setCityOptions([]);
+                setTownOptions([]);
+              }}
+            >
+              <MenuItem value="">選択してください</MenuItem>
+              {prefectures.map((prefecture) => (
+                <MenuItem key={prefecture.id} value={prefecture.id}>
+                  {prefecture.name}
+                </MenuItem>
+              ))}
+            </TextField>
+          )}
+        />
+
+        <Controller
+          name="city"
+          control={control}
+          render={({ field }) => (
+            <Autocomplete
+              disabled={!prefectureId}
+              options={mergedCityOptions}
+              value={field.value || null}
+              isOptionEqualToValue={(option, value) => option === value}
+              getOptionLabel={(option) => option}
+              onChange={(_, value) => {
+                field.onChange(value || "");
+                setValue("town", "");
+                setValue("address_id", null);
+                setTownOptions([]);
+              }}
+              renderInput={(params) => (
+                <TextField {...params} fullWidth label="市区町村" />
+              )}
+            />
+          )}
+        />
+
+        <Controller
+          name="town"
+          control={control}
+          render={({ field }) => (
+            <Autocomplete
+              disabled={!city}
+              options={mergedTownOptions}
+              value={
+                mergedTownOptions.find(
+                  (option) => option.town === field.value,
+                ) || null
+              }
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+              getOptionLabel={(option) => option.town}
+              onChange={(_, value) => field.onChange(value?.town || "")}
+              renderInput={(params) => (
+                <TextField {...params} fullWidth label="町名・丁目" />
+              )}
+            />
+          )}
+        />
+      </Stack>
+
+      <Box
+        sx={{ mt: 3, display: "flex", justifyContent: "flex-end", gap: 1.5 }}
+      >
+        <Button onClick={onCancel} disabled={updating} color="inherit">
+          キャンセル
+        </Button>
+        <Button
+          type="submit"
+          variant="contained"
+          disabled={updating}
+          startIcon={
+            updating ? <CircularProgress size={16} color="inherit" /> : null
+          }
+        >
+          保存
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/features/AdminAdminDetail/components/ProfileEditForm.tsx
+++ b/frontend/features/AdminAdminDetail/components/ProfileEditForm.tsx
@@ -192,6 +192,17 @@ export const ProfileEditForm = ({
           label="電話番号"
           fullWidth
           placeholder="ハイフンなし"
+          // フォーカス時にブラウザのオートフィル候補で入力欄がグレーに
+          // 塗られるのを抑止する（autofill 背景を box-shadow で打ち消す）
+          autoComplete="off"
+          sx={{
+            "& input:-webkit-autofill, & input:-webkit-autofill:focus, & input:-webkit-autofill:hover":
+              {
+                WebkitBoxShadow: "0 0 0 1000px #fff inset",
+                WebkitTextFillColor: "inherit",
+                transition: "background-color 9999s ease-in-out 0s",
+              },
+          }}
           {...register("phone_number", {
             pattern: {
               value: /^\d{10,11}$/,

--- a/frontend/features/AdminAdminDetail/components/ProfileEditForm.tsx
+++ b/frontend/features/AdminAdminDetail/components/ProfileEditForm.tsx
@@ -37,6 +37,7 @@ type Props = {
 
 const buildDefaultValues = (admin: AdminDetail): AdminEditForm => ({
   name: admin.name,
+  name_kana: admin.name_kana ?? "",
   email: admin.email,
   phone_number: admin.user_personal_info?.phone_number ?? "",
   birthday: admin.user_personal_info?.birthday ?? "",
@@ -133,6 +134,7 @@ export const ProfileEditForm = ({
   const handleSave = (data: AdminEditForm) => {
     return onUpdate({
       name: data.name,
+      name_kana: data.name_kana,
       email: data.email,
       phone_number: data.phone_number,
       birthday: data.birthday,
@@ -163,6 +165,13 @@ export const ProfileEditForm = ({
           {...register("name", { required: "名前を入力してください" })}
           error={!!errors.name}
           helperText={errors.name?.message}
+        />
+        <TextField
+          label="氏名カナ"
+          fullWidth
+          {...register("name_kana")}
+          error={!!errors.name_kana}
+          helperText={errors.name_kana?.message}
         />
         <TextField
           label="メールアドレス"

--- a/frontend/features/AdminAdminDetail/hooks/useDeleteAdmin.ts
+++ b/frontend/features/AdminAdminDetail/hooks/useDeleteAdmin.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { apiClient } from "@/libs/http/apiClient";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type UseDeleteAdminParams = {
+  adminId: number;
+};
+
+// 管理者の削除を行うフック。
+// 確認ダイアログの開閉・削除中状態・エラー（自己削除/最後の管理者など）を管理する。
+// 削除成功後は一覧（/admin/admins）へ遷移する。
+export const useDeleteAdmin = ({ adminId }: UseDeleteAdminParams) => {
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteErrors, setDeleteErrors] = useState<string[]>([]);
+  const router = useRouter();
+
+  const handleDeleteClick = () => {
+    setDeleteErrors([]);
+    setDeleteDialogOpen(true);
+  };
+
+  const handleDeleteDialogClose = () => {
+    setDeleteDialogOpen(false);
+    setDeleteErrors([]);
+  };
+
+  const handleDeleteConfirm = async () => {
+    setDeleting(true);
+    setDeleteErrors([]);
+
+    try {
+      await apiClient.delete(`/api/admin/admins/${adminId}`);
+      router.push("/admin/admins");
+    } catch (err) {
+      const response =
+        err && typeof err === "object" && "response" in err
+          ? (
+              err as {
+                response?: { status?: number; data?: { errors?: string[] } };
+              }
+            ).response
+          : undefined;
+
+      if (response?.status === 401) {
+        router.push("/login");
+        return;
+      }
+
+      const errors = response?.data?.errors;
+      setDeleteErrors(
+        Array.isArray(errors) && errors.length > 0
+          ? errors
+          : ["管理者の削除に失敗しました"],
+      );
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return {
+    deleteDialogOpen,
+    deleting,
+    deleteErrors,
+    handleDeleteClick,
+    handleDeleteDialogClose,
+    handleDeleteConfirm,
+  };
+};

--- a/frontend/features/AdminAdminDetail/hooks/useDeleteAdmin.ts
+++ b/frontend/features/AdminAdminDetail/hooks/useDeleteAdmin.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { apiClient } from "@/libs/http/apiClient";
+import { extractApiError } from "@/libs/http/extractApiError";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -35,26 +36,14 @@ export const useDeleteAdmin = ({ adminId }: UseDeleteAdminParams) => {
       await apiClient.delete(`/api/admin/admins/${adminId}`);
       router.push("/admin/admins");
     } catch (err) {
-      const response =
-        err && typeof err === "object" && "response" in err
-          ? (
-              err as {
-                response?: { status?: number; data?: { errors?: string[] } };
-              }
-            ).response
-          : undefined;
+      const { status, errors } = extractApiError(err);
 
-      if (response?.status === 401) {
+      if (status === 401) {
         router.push("/login");
         return;
       }
 
-      const errors = response?.data?.errors;
-      setDeleteErrors(
-        Array.isArray(errors) && errors.length > 0
-          ? errors
-          : ["管理者の削除に失敗しました"],
-      );
+      setDeleteErrors(errors ?? ["管理者の削除に失敗しました"]);
     } finally {
       setDeleting(false);
     }

--- a/frontend/features/AdminAdminDetail/hooks/useFetchAddresses.ts
+++ b/frontend/features/AdminAdminDetail/hooks/useFetchAddresses.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+import debounce from "lodash/debounce";
+import { apiClient } from "@/libs/http/apiClient";
+import type { Address } from "../types";
+
+// 住所カスケード（都道府県→市区町村→町名）の候補取得。
+// admin 画面用に /api/admin/addresses を参照する。
+export const useFetchAddresses = () => {
+  const [cityOptions, setCityOptions] = useState<string[]>([]);
+  const [townOptions, setTownOptions] = useState<Address[]>([]);
+
+  const fetchCities = useMemo(() => {
+    return debounce(async (prefectureId: number) => {
+      const res = await apiClient.get<Address[]>("/api/admin/addresses", {
+        params: { prefecture_id: prefectureId },
+      });
+
+      const cities = [...new Set(res.data.map((a) => a.city))];
+
+      setCityOptions(cities);
+    }, 300);
+  }, []);
+
+  const fetchTowns = useMemo(() => {
+    return debounce(async (prefectureId: number, city: string) => {
+      const res = await apiClient.get<Address[]>("/api/admin/addresses", {
+        params: { prefecture_id: prefectureId, city },
+      });
+
+      setTownOptions(res.data);
+    }, 300);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      fetchCities.cancel();
+      fetchTowns.cancel();
+    };
+  }, [fetchCities, fetchTowns]);
+
+  return {
+    cityOptions,
+    townOptions,
+    fetchCities,
+    fetchTowns,
+    setCityOptions,
+    setTownOptions,
+  };
+};

--- a/frontend/features/AdminAdminDetail/hooks/useFetchAdminDetail.ts
+++ b/frontend/features/AdminAdminDetail/hooks/useFetchAdminDetail.ts
@@ -1,24 +1,39 @@
 "use client";
 
 import { apiClient } from "@/libs/http/apiClient";
+import { extractApiError } from "@/libs/http/extractApiError";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 import type { AdminDetail } from "../types";
 
 // 管理者詳細を取得するフック。
 // adminId の変更で自動再取得し、更新後などに使う refetch も返す。
+// 取得状態は admin（成功）/ fetchError（失敗）で区別する。
 export const useFetchAdminDetail = (adminId: number) => {
   const [admin, setAdmin] = useState<AdminDetail | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const router = useRouter();
 
   const fetchAdmin = useCallback(() => {
+    setFetchError(null);
+
     apiClient
       .get<{ admin: AdminDetail }>(`/api/admin/admins/${adminId}`)
       .then((res) => setAdmin(res.data.admin))
       .catch((err) => {
-        if (err.response?.status === 401) {
+        const { status } = extractApiError(err);
+
+        if (status === 401) {
           router.push("/login");
+          return;
         }
+
+        // 404（存在しない・削除済み）やその他のエラーはエラー状態として表示する
+        setFetchError(
+          status === 404
+            ? "管理者が見つかりませんでした"
+            : "管理者の取得に失敗しました",
+        );
       });
   }, [adminId, router]);
 
@@ -26,5 +41,6 @@ export const useFetchAdminDetail = (adminId: number) => {
     fetchAdmin();
   }, [fetchAdmin]);
 
-  return { admin, refetch: fetchAdmin };
+  // PATCH レスポンスなどで取得済みデータを更新するための setter も返す
+  return { admin, setAdmin, fetchError, refetch: fetchAdmin };
 };

--- a/frontend/features/AdminAdminDetail/hooks/useFetchAdminDetail.ts
+++ b/frontend/features/AdminAdminDetail/hooks/useFetchAdminDetail.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { apiClient } from "@/libs/http/apiClient";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import type { AdminDetail } from "../types";
+
+// 管理者詳細を取得するフック。
+// adminId の変更で自動再取得し、更新後などに使う refetch も返す。
+export const useFetchAdminDetail = (adminId: number) => {
+  const [admin, setAdmin] = useState<AdminDetail | null>(null);
+  const router = useRouter();
+
+  const fetchAdmin = useCallback(() => {
+    apiClient
+      .get<{ admin: AdminDetail }>(`/api/admin/admins/${adminId}`)
+      .then((res) => setAdmin(res.data.admin))
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          router.push("/login");
+        }
+      });
+  }, [adminId, router]);
+
+  useEffect(() => {
+    fetchAdmin();
+  }, [fetchAdmin]);
+
+  return { admin, refetch: fetchAdmin };
+};

--- a/frontend/features/AdminAdminDetail/hooks/usePasswordReset.ts
+++ b/frontend/features/AdminAdminDetail/hooks/usePasswordReset.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { apiClient } from "@/libs/http/apiClient";
+import { extractApiError } from "@/libs/http/extractApiError";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -32,10 +33,7 @@ export const usePasswordReset = ({
       });
       onSuccess();
     } catch (err) {
-      const status =
-        err && typeof err === "object" && "response" in err
-          ? (err as { response?: { status?: number } }).response?.status
-          : undefined;
+      const { status } = extractApiError(err);
 
       if (status === 401) {
         router.push("/login");

--- a/frontend/features/AdminAdminDetail/hooks/usePasswordReset.ts
+++ b/frontend/features/AdminAdminDetail/hooks/usePasswordReset.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { apiClient } from "@/libs/http/apiClient";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type UsePasswordResetParams = {
+  adminId: number;
+  email: string;
+  // 送信成功時に呼ばれる（スナックバー表示など）
+  onSuccess: () => void;
+  // 送信失敗時に呼ばれる（スナックバー表示など）
+  onError: () => void;
+};
+
+// 対象管理者にパスワード再設定メールを送信するフック。
+export const usePasswordReset = ({
+  adminId,
+  email,
+  onSuccess,
+  onError,
+}: UsePasswordResetParams) => {
+  const [resettingPassword, setResettingPassword] = useState(false);
+  const router = useRouter();
+
+  const handlePasswordReset = async () => {
+    setResettingPassword(true);
+
+    try {
+      await apiClient.post(`/api/admin/admins/${adminId}/password-reset`, {
+        email,
+      });
+      onSuccess();
+    } catch (err) {
+      const status =
+        err && typeof err === "object" && "response" in err
+          ? (err as { response?: { status?: number } }).response?.status
+          : undefined;
+
+      if (status === 401) {
+        router.push("/login");
+        return;
+      }
+
+      onError();
+    } finally {
+      setResettingPassword(false);
+    }
+  };
+
+  return { resettingPassword, handlePasswordReset };
+};

--- a/frontend/features/AdminAdminDetail/hooks/useUpdateAdmin.ts
+++ b/frontend/features/AdminAdminDetail/hooks/useUpdateAdmin.ts
@@ -1,14 +1,15 @@
 "use client";
 
 import { apiClient } from "@/libs/http/apiClient";
+import { extractApiError } from "@/libs/http/extractApiError";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import type { UpdateAdminInput } from "../types";
+import type { AdminDetail, UpdateAdminInput } from "../types";
 
 type UseUpdateAdminParams = {
   adminId: number;
-  // 更新成功後に呼ばれる（詳細の再取得・スナックバー表示など）
-  onUpdated: () => void;
+  // 更新成功後に呼ばれる。PATCH レスポンスの最新 admin を渡す。
+  onUpdated: (admin: AdminDetail) => void;
 };
 
 // 管理者の更新を行うフック。422 はエラーを表示し、401 はログインへ遷移する。
@@ -20,34 +21,29 @@ export const useUpdateAdmin = ({
   const [updateErrors, setUpdateErrors] = useState<string[]>([]);
   const router = useRouter();
 
-  const handleUpdate = async (input: UpdateAdminInput) => {
+  // 更新に成功したら true を返す（呼び出し側が編集モードを抜けるのに使う）。
+  const handleUpdate = async (input: UpdateAdminInput): Promise<boolean> => {
     setUpdating(true);
     setUpdateErrors([]);
 
     try {
-      await apiClient.patch(`/api/admin/admins/${adminId}`, input);
-      onUpdated();
+      // PATCH は更新後の admin を返すので、再取得せずそれを使う
+      const res = await apiClient.patch<{ admin: AdminDetail }>(
+        `/api/admin/admins/${adminId}`,
+        input,
+      );
+      onUpdated(res.data.admin);
+      return true;
     } catch (err) {
-      const response =
-        err && typeof err === "object" && "response" in err
-          ? (
-              err as {
-                response?: { status?: number; data?: { errors?: string[] } };
-              }
-            ).response
-          : undefined;
+      const { status, errors } = extractApiError(err);
 
-      if (response?.status === 401) {
+      if (status === 401) {
         router.push("/login");
-        return;
+        return false;
       }
 
-      const errors = response?.data?.errors;
-      setUpdateErrors(
-        Array.isArray(errors) && errors.length > 0
-          ? errors
-          : ["管理者の更新に失敗しました"],
-      );
+      setUpdateErrors(errors ?? ["管理者の更新に失敗しました"]);
+      return false;
     } finally {
       setUpdating(false);
     }

--- a/frontend/features/AdminAdminDetail/hooks/useUpdateAdmin.ts
+++ b/frontend/features/AdminAdminDetail/hooks/useUpdateAdmin.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { apiClient } from "@/libs/http/apiClient";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import type { UpdateAdminInput } from "../types";
+
+type UseUpdateAdminParams = {
+  adminId: number;
+  // 更新成功後に呼ばれる（詳細の再取得・スナックバー表示など）
+  onUpdated: () => void;
+};
+
+// 管理者の更新を行うフック。422 はエラーを表示し、401 はログインへ遷移する。
+export const useUpdateAdmin = ({
+  adminId,
+  onUpdated,
+}: UseUpdateAdminParams) => {
+  const [updating, setUpdating] = useState(false);
+  const [updateErrors, setUpdateErrors] = useState<string[]>([]);
+  const router = useRouter();
+
+  const handleUpdate = async (input: UpdateAdminInput) => {
+    setUpdating(true);
+    setUpdateErrors([]);
+
+    try {
+      await apiClient.patch(`/api/admin/admins/${adminId}`, input);
+      onUpdated();
+    } catch (err) {
+      const response =
+        err && typeof err === "object" && "response" in err
+          ? (
+              err as {
+                response?: { status?: number; data?: { errors?: string[] } };
+              }
+            ).response
+          : undefined;
+
+      if (response?.status === 401) {
+        router.push("/login");
+        return;
+      }
+
+      const errors = response?.data?.errors;
+      setUpdateErrors(
+        Array.isArray(errors) && errors.length > 0
+          ? errors
+          : ["管理者の更新に失敗しました"],
+      );
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  return { updating, updateErrors, handleUpdate };
+};

--- a/frontend/features/AdminAdminDetail/index.tsx
+++ b/frontend/features/AdminAdminDetail/index.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Box, CircularProgress } from "@mui/material";
+import { useState } from "react";
+import { Presenter } from "./Presenter";
+import { useFetchAdminDetail } from "./hooks/useFetchAdminDetail";
+import { useUpdateAdmin } from "./hooks/useUpdateAdmin";
+import { useDeleteAdmin } from "./hooks/useDeleteAdmin";
+import { usePasswordReset } from "./hooks/usePasswordReset";
+import type { SnackbarState } from "./types";
+
+type Props = {
+  adminId: number;
+  // ログイン中の管理者 ID（自己削除ガード用）。未取得時は null。
+  currentAdminId: number | null;
+};
+
+const initialSnackbar: SnackbarState = {
+  open: false,
+  message: "",
+  severity: "success",
+};
+
+export const AdminAdminDetail = ({ adminId, currentAdminId }: Props) => {
+  const [snackbar, setSnackbar] = useState<SnackbarState>(initialSnackbar);
+
+  const { admin, refetch } = useFetchAdminDetail(adminId);
+
+  const { updating, updateErrors, handleUpdate } = useUpdateAdmin({
+    adminId,
+    onUpdated: () => {
+      setSnackbar({
+        open: true,
+        message: "管理者を更新しました",
+        severity: "success",
+      });
+      refetch();
+    },
+  });
+
+  const {
+    deleteDialogOpen,
+    deleting,
+    deleteErrors,
+    handleDeleteClick,
+    handleDeleteDialogClose,
+    handleDeleteConfirm,
+  } = useDeleteAdmin({ adminId });
+
+  const { resettingPassword, handlePasswordReset } = usePasswordReset({
+    adminId,
+    email: admin?.email ?? "",
+    onSuccess: () =>
+      setSnackbar({
+        open: true,
+        message: "パスワード再設定メールを送信しました",
+        severity: "success",
+      }),
+    onError: () =>
+      setSnackbar({
+        open: true,
+        message: "パスワード再設定メールの送信に失敗しました",
+        severity: "error",
+      }),
+  });
+
+  const handleSnackbarClose = () => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  };
+
+  if (!admin) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Presenter
+      admin={admin}
+      isSelf={currentAdminId === admin.id}
+      onUpdate={handleUpdate}
+      updating={updating}
+      updateErrors={updateErrors}
+      onPasswordReset={handlePasswordReset}
+      resettingPassword={resettingPassword}
+      deleteDialogOpen={deleteDialogOpen}
+      onDeleteClick={handleDeleteClick}
+      onDeleteDialogClose={handleDeleteDialogClose}
+      onDeleteConfirm={handleDeleteConfirm}
+      deleting={deleting}
+      deleteErrors={deleteErrors}
+      snackbar={snackbar}
+      onSnackbarClose={handleSnackbarClose}
+    />
+  );
+};

--- a/frontend/features/AdminAdminDetail/index.tsx
+++ b/frontend/features/AdminAdminDetail/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, CircularProgress } from "@mui/material";
+import { Alert, Box, Button, CircularProgress } from "@mui/material";
 import { useState } from "react";
 import { Presenter } from "./Presenter";
 import { useFetchAdminDetail } from "./hooks/useFetchAdminDetail";
@@ -11,7 +11,9 @@ import type { SnackbarState } from "./types";
 
 type Props = {
   adminId: number;
-  // ログイン中の管理者 ID（自己削除ガード用）。未取得時は null。
+  // ログイン中の管理者 ID（自己削除ガード用）。/me 取得失敗時は null。
+  // null の場合は本人判定ができないため UI ガードは無効になるが、
+  // 自己削除・最後の管理者の削除は Rails 側でも 422 で防がれる。
   currentAdminId: number | null;
 };
 
@@ -24,17 +26,18 @@ const initialSnackbar: SnackbarState = {
 export const AdminAdminDetail = ({ adminId, currentAdminId }: Props) => {
   const [snackbar, setSnackbar] = useState<SnackbarState>(initialSnackbar);
 
-  const { admin, refetch } = useFetchAdminDetail(adminId);
+  const { admin, setAdmin, fetchError, refetch } = useFetchAdminDetail(adminId);
 
   const { updating, updateErrors, handleUpdate } = useUpdateAdmin({
     adminId,
-    onUpdated: () => {
+    onUpdated: (updated) => {
+      // PATCH レスポンスの最新 admin で表示を更新する（再取得しない）
+      setAdmin(updated);
       setSnackbar({
         open: true,
         message: "管理者を更新しました",
         severity: "success",
       });
-      refetch();
     },
   });
 
@@ -67,6 +70,23 @@ export const AdminAdminDetail = ({ adminId, currentAdminId }: Props) => {
   const handleSnackbarClose = () => {
     setSnackbar((prev) => ({ ...prev, open: false }));
   };
+
+  if (fetchError) {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert
+          severity="error"
+          action={
+            <Button color="inherit" size="small" onClick={refetch}>
+              再試行
+            </Button>
+          }
+        >
+          {fetchError}
+        </Alert>
+      </Box>
+    );
+  }
 
   if (!admin) {
     return (

--- a/frontend/features/AdminAdminDetail/index.tsx
+++ b/frontend/features/AdminAdminDetail/index.tsx
@@ -8,6 +8,7 @@ import { useUpdateAdmin } from "./hooks/useUpdateAdmin";
 import { useDeleteAdmin } from "./hooks/useDeleteAdmin";
 import { usePasswordReset } from "./hooks/usePasswordReset";
 import type { SnackbarState } from "./types";
+import type { Prefecture } from "@/types/common/prefecture";
 
 type Props = {
   adminId: number;
@@ -15,6 +16,8 @@ type Props = {
   // null の場合は本人判定ができないため UI ガードは無効になるが、
   // 自己削除・最後の管理者の削除は Rails 側でも 422 で防がれる。
   currentAdminId: number | null;
+  // 住所カスケード（都道府県プルダウン）用の都道府県一覧
+  prefectures: Prefecture[];
 };
 
 const initialSnackbar: SnackbarState = {
@@ -23,7 +26,11 @@ const initialSnackbar: SnackbarState = {
   severity: "success",
 };
 
-export const AdminAdminDetail = ({ adminId, currentAdminId }: Props) => {
+export const AdminAdminDetail = ({
+  adminId,
+  currentAdminId,
+  prefectures,
+}: Props) => {
   const [snackbar, setSnackbar] = useState<SnackbarState>(initialSnackbar);
 
   const { admin, setAdmin, fetchError, refetch } = useFetchAdminDetail(adminId);
@@ -106,6 +113,7 @@ export const AdminAdminDetail = ({ adminId, currentAdminId }: Props) => {
   return (
     <Presenter
       admin={admin}
+      prefectures={prefectures}
       isSelf={currentAdminId === admin.id}
       onUpdate={handleUpdate}
       updating={updating}

--- a/frontend/features/AdminAdminDetail/types.ts
+++ b/frontend/features/AdminAdminDetail/types.ts
@@ -1,0 +1,22 @@
+// 管理者詳細 API（GET /api/admin/admins/:id）のレスポンス。
+// activity_log は現状 [] を返すプレースホルダー。
+export type AdminDetail = {
+  id: number;
+  name: string;
+  email: string;
+  created_at: string;
+  updated_at: string;
+  activity_log: unknown[];
+};
+
+// 管理者の更新（PATCH）で送る入力。
+export type UpdateAdminInput = {
+  name: string;
+  email: string;
+};
+
+export type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: "success" | "error";
+};

--- a/frontend/features/AdminAdminDetail/types.ts
+++ b/frontend/features/AdminAdminDetail/types.ts
@@ -7,12 +7,53 @@ export type AdminDetail = {
   created_at: string;
   updated_at: string;
   activity_log: unknown[];
+  user_personal_info?: {
+    id: number;
+    phone_number: string | null;
+    birthday: string | null;
+    gender: string | null;
+  } | null;
+  address?: {
+    id: number;
+    postal_code: string;
+    city: string;
+    town: string;
+    prefecture: {
+      id: number;
+      name: string;
+    } | null;
+  } | null;
 };
 
 // 管理者の更新（PATCH）で送る入力。
+// 個人情報・住所は任意（未設定の admin を弾かない）。
 export type UpdateAdminInput = {
   name: string;
   email: string;
+  phone_number?: string;
+  birthday?: string;
+  gender?: string;
+  address_id?: number | null;
+};
+
+// 編集フォームの内部値（住所カスケード用に都道府県/市区町村/町名を持つ）。
+export type AdminEditForm = {
+  name: string;
+  email: string;
+  phone_number: string;
+  birthday: string;
+  gender: string;
+  prefecture_id: number | null;
+  city: string;
+  town: string;
+  address_id: number | null;
+};
+
+// 住所カスケードの町名候補。
+export type Address = {
+  id: number;
+  city: string;
+  town: string;
 };
 
 export type SnackbarState = {

--- a/frontend/features/AdminAdminDetail/types.ts
+++ b/frontend/features/AdminAdminDetail/types.ts
@@ -3,6 +3,7 @@
 export type AdminDetail = {
   id: number;
   name: string;
+  name_kana: string | null;
   email: string;
   created_at: string;
   updated_at: string;
@@ -29,6 +30,7 @@ export type AdminDetail = {
 // 個人情報・住所は任意（未設定の admin を弾かない）。
 export type UpdateAdminInput = {
   name: string;
+  name_kana?: string;
   email: string;
   phone_number?: string;
   birthday?: string;
@@ -39,6 +41,7 @@ export type UpdateAdminInput = {
 // 編集フォームの内部値（住所カスケード用に都道府県/市区町村/町名を持つ）。
 export type AdminEditForm = {
   name: string;
+  name_kana: string;
   email: string;
   phone_number: string;
   birthday: string;

--- a/frontend/features/AdminAdmins/Presenter.test.tsx
+++ b/frontend/features/AdminAdmins/Presenter.test.tsx
@@ -7,10 +7,15 @@ vi.mock("next/link", () => ({
   default: ({
     children,
     href,
+    ...props
   }: {
     children: React.ReactNode;
     href: string;
-  }) => <a href={href}>{children}</a>,
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
 }));
 
 const mockData: AdminsData = {
@@ -64,11 +69,14 @@ describe("AdminAdminsPresenter", () => {
     expect(headers).toContain("詳細");
   });
 
-  it("「詳細」リンクが /admin/admins/[id] を指している", () => {
+  it("詳細リンクが /admin/admins/[id] を指している", () => {
     render(<Presenter {...defaultProps} />);
-    const detailLinks = screen.getAllByRole("link", { name: "詳細" });
-    expect(detailLinks[0]).toHaveAttribute("href", "/admin/admins/1");
-    expect(detailLinks[1]).toHaveAttribute("href", "/admin/admins/2");
+    expect(
+      screen.getByRole("link", { name: "田中管理者の詳細" }),
+    ).toHaveAttribute("href", "/admin/admins/1");
+    expect(
+      screen.getByRole("link", { name: "佐藤管理者の詳細" }),
+    ).toHaveAttribute("href", "/admin/admins/2");
   });
 
   it("admins データが行として正しくレンダリングされる", () => {

--- a/frontend/features/AdminAdmins/Presenter.test.tsx
+++ b/frontend/features/AdminAdmins/Presenter.test.tsx
@@ -3,16 +3,19 @@ import { describe, it, expect, vi } from "vitest";
 import { Presenter } from "./Presenter";
 import type { AdminsData } from "./types";
 
+// next/link のモック。アクセシブルネーム検証のため aria-label のみ透過し、
+// MUI が注入する内部 props を <a> に流して不正な DOM 属性を隠さないようにする。
 vi.mock("next/link", () => ({
   default: ({
     children,
     href,
-    ...props
+    "aria-label": ariaLabel,
   }: {
     children: React.ReactNode;
     href: string;
+    "aria-label"?: string;
   }) => (
-    <a href={href} {...props}>
+    <a href={href} aria-label={ariaLabel}>
       {children}
     </a>
   ),

--- a/frontend/features/AdminAdmins/Presenter.test.tsx
+++ b/frontend/features/AdminAdmins/Presenter.test.tsx
@@ -3,6 +3,16 @@ import { describe, it, expect, vi } from "vitest";
 import { Presenter } from "./Presenter";
 import type { AdminsData } from "./types";
 
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
 const mockData: AdminsData = {
   admins: [
     {
@@ -43,7 +53,7 @@ const defaultProps = {
 };
 
 describe("AdminAdminsPresenter", () => {
-  it("テーブルヘッダーに「名前」「メールアドレス」「登録日」が表示される", () => {
+  it("テーブルヘッダーに「名前」「メールアドレス」「登録日」「詳細」が表示される", () => {
     render(<Presenter {...defaultProps} />);
     const headers = screen
       .getAllByRole("columnheader")
@@ -51,6 +61,14 @@ describe("AdminAdminsPresenter", () => {
     expect(headers).toContain("名前");
     expect(headers).toContain("メールアドレス");
     expect(headers).toContain("登録日");
+    expect(headers).toContain("詳細");
+  });
+
+  it("「詳細」リンクが /admin/admins/[id] を指している", () => {
+    render(<Presenter {...defaultProps} />);
+    const detailLinks = screen.getAllByRole("link", { name: "詳細" });
+    expect(detailLinks[0]).toHaveAttribute("href", "/admin/admins/1");
+    expect(detailLinks[1]).toHaveAttribute("href", "/admin/admins/2");
   });
 
   it("admins データが行として正しくレンダリングされる", () => {

--- a/frontend/features/AdminAdmins/Presenter.tsx
+++ b/frontend/features/AdminAdmins/Presenter.tsx
@@ -2,6 +2,7 @@
 
 import { colors } from "@/app/theme/colors";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import {
   Alert,
   Avatar,
@@ -9,6 +10,7 @@ import {
   Button,
   Card,
   CardContent,
+  IconButton,
   Pagination,
   Snackbar,
   Stack,
@@ -135,7 +137,9 @@ export const Presenter = ({
                       メールアドレス
                     </TableCell>
                     <TableCell sx={{ fontWeight: 600 }}>登録日</TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>詳細</TableCell>
+                    <TableCell align="right" sx={{ fontWeight: 600 }}>
+                      詳細
+                    </TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -168,16 +172,15 @@ export const Presenter = ({
                       <TableCell>
                         {format(new Date(admin.created_at), "yyyy/MM/dd")}
                       </TableCell>
-                      <TableCell>
-                        <Button
+                      <TableCell align="right">
+                        <IconButton
                           component={Link}
                           href={`/admin/admins/${admin.id}`}
                           size="small"
-                          variant="outlined"
-                          sx={{ fontSize: "0.75rem" }}
+                          aria-label={`${admin.name}の詳細`}
                         >
-                          詳細
-                        </Button>
+                          <ChevronRightIcon fontSize="small" />
+                        </IconButton>
                       </TableCell>
                     </TableRow>
                   ))}

--- a/frontend/features/AdminAdmins/Presenter.tsx
+++ b/frontend/features/AdminAdmins/Presenter.tsx
@@ -22,6 +22,7 @@ import {
   Typography,
 } from "@mui/material";
 import { format } from "date-fns";
+import Link from "next/link";
 import { AdminCreateDrawer } from "./components/AdminCreateDrawer";
 import type { AdminsData, CreateAdminInput, SnackbarState } from "./types";
 
@@ -134,6 +135,7 @@ export const Presenter = ({
                       メールアドレス
                     </TableCell>
                     <TableCell sx={{ fontWeight: 600 }}>登録日</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>詳細</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
@@ -165,6 +167,17 @@ export const Presenter = ({
                       <TableCell>{admin.email}</TableCell>
                       <TableCell>
                         {format(new Date(admin.created_at), "yyyy/MM/dd")}
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          component={Link}
+                          href={`/admin/admins/${admin.id}`}
+                          size="small"
+                          variant="outlined"
+                          sx={{ fontSize: "0.75rem" }}
+                        >
+                          詳細
+                        </Button>
                       </TableCell>
                     </TableRow>
                   ))}

--- a/frontend/features/AdminAdmins/Presenter.tsx
+++ b/frontend/features/AdminAdmins/Presenter.tsx
@@ -21,6 +21,7 @@ import {
   TableHead,
   TableRow,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { format } from "date-fns";
@@ -173,14 +174,16 @@ export const Presenter = ({
                         {format(new Date(admin.created_at), "yyyy/MM/dd")}
                       </TableCell>
                       <TableCell align="right">
-                        <IconButton
-                          component={Link}
-                          href={`/admin/admins/${admin.id}`}
-                          size="small"
-                          aria-label={`${admin.name}の詳細`}
-                        >
-                          <ChevronRightIcon fontSize="small" />
-                        </IconButton>
+                        <Tooltip title="詳細">
+                          <IconButton
+                            component={Link}
+                            href={`/admin/admins/${admin.id}`}
+                            size="small"
+                            aria-label={`${admin.name}の詳細`}
+                          >
+                            <ChevronRightIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
                       </TableCell>
                     </TableRow>
                   ))}

--- a/frontend/features/AdminAdmins/hooks/useCreateAdmin.ts
+++ b/frontend/features/AdminAdmins/hooks/useCreateAdmin.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { apiClient } from "@/libs/http/apiClient";
+import { extractApiError } from "@/libs/http/extractApiError";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import type { CreateAdminInput, SnackbarState } from "../types";
@@ -49,26 +50,14 @@ export const useCreateAdmin = ({ onCreated }: UseCreateAdminParams) => {
       });
       onCreated();
     } catch (err) {
-      const status =
-        err && typeof err === "object" && "response" in err
-          ? (
-              err as {
-                response?: { status?: number; data?: { errors?: string[] } };
-              }
-            ).response
-          : undefined;
+      const { status, errors } = extractApiError(err);
 
-      if (status?.status === 401) {
+      if (status === 401) {
         router.push("/login");
         return;
       }
 
-      const errors = status?.data?.errors;
-      setCreateErrors(
-        Array.isArray(errors) && errors.length > 0
-          ? errors
-          : ["管理者の追加に失敗しました"],
-      );
+      setCreateErrors(errors ?? ["管理者の追加に失敗しました"]);
     } finally {
       setCreating(false);
     }

--- a/frontend/features/ColleagueDetail/Presenter.tsx
+++ b/frontend/features/ColleagueDetail/Presenter.tsx
@@ -12,7 +12,8 @@ import {
   Typography,
 } from "@mui/material";
 import Link from "next/link";
-import { formatAddress, GenderLabel } from "./constants";
+import { GenderLabel } from "@/constants/gender";
+import { formatAddress } from "./constants";
 import { Teacher } from "./types";
 
 type Props = {

--- a/frontend/features/ColleagueDetail/constants.ts
+++ b/frontend/features/ColleagueDetail/constants.ts
@@ -1,11 +1,4 @@
 import { Address } from "@/types/common/address";
-import { GenderType } from "@/types/common/gender";
-
-export const GenderLabel: Record<GenderType, string> = {
-  male: "男",
-  female: "女",
-  other: "その他",
-};
 
 export const formatAddress = (address: Address) => {
   const label = address.prefecture.name + address.city + address.town;

--- a/frontend/libs/http/extractApiError.ts
+++ b/frontend/libs/http/extractApiError.ts
@@ -1,0 +1,25 @@
+// apiClient（axios）が投げたエラーから、レスポンスの status と
+// バリデーションエラー配列（{ errors: [...] }）を安全に取り出す共通ヘルパ。
+// 各フックでエラーの形を毎回ナローイングするのを避ける。
+export type ApiError = {
+  status?: number;
+  errors?: string[];
+};
+
+export const extractApiError = (err: unknown): ApiError => {
+  const response =
+    err && typeof err === "object" && "response" in err
+      ? (
+          err as {
+            response?: { status?: number; data?: { errors?: string[] } };
+          }
+        ).response
+      : undefined;
+
+  const errors = response?.data?.errors;
+
+  return {
+    status: response?.status,
+    errors: Array.isArray(errors) && errors.length > 0 ? errors : undefined,
+  };
+};

--- a/frontend/libs/server/rails/handleRailsRouteError.ts
+++ b/frontend/libs/server/rails/handleRailsRouteError.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { RailsFetchError, RailsUnauthorizedError } from "./railsError";
+
+// Rails への fetch で発生した例外を Next.js の Response に変換する共通ハンドラ。
+// - RailsUnauthorizedError は 401 に統一
+// - RailsFetchError（422 など）は Rails のエラー内容（{ errors: [...] }）をそのまま返す
+// - それ以外は 500
+export function handleRailsRouteError(error: unknown, fallbackMessage: string) {
+  if (error instanceof RailsUnauthorizedError) {
+    return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  if (error instanceof RailsFetchError) {
+    let data: unknown = { errors: [fallbackMessage] };
+    if (error.bodyText) {
+      try {
+        data = JSON.parse(error.bodyText);
+      } catch {
+        // パース失敗時はデフォルトのエラーメッセージを使う
+      }
+    }
+    return NextResponse.json(data, { status: error.status });
+  }
+
+  return NextResponse.json(
+    { message: "INTERNAL_SERVER_ERROR" },
+    { status: 500 },
+  );
+}

--- a/rails/app/controllers/api/v1/admin/addresses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/addresses_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class AddressesController < BaseController
+        def index
+          if params[:prefecture_id].blank?
+            render json: { error: '都道府県は必須です。' }, status: :bad_request
+            return
+          end
+
+          addresses = AddressesQuery.new(
+            prefecture_id: params[:prefecture_id],
+            city: params[:city],
+            town: params[:town]
+          ).call
+
+          render json: addresses, each_serializer: AddressSerializer, status: :ok
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/admin/addresses_controller.rb
+++ b/rails/app/controllers/api/v1/admin/addresses_controller.rb
@@ -5,10 +5,7 @@ module Api
     module Admin
       class AddressesController < BaseController
         def index
-          if params[:prefecture_id].blank?
-            render json: { error: '都道府県は必須です。' }, status: :bad_request
-            return
-          end
+          return render json: { error: '都道府県は必須です。' }, status: :bad_request if params[:prefecture_id].blank?
 
           addresses = AddressesQuery.new(
             prefecture_id: params[:prefecture_id],

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -64,7 +64,11 @@ module Api
                           status: :unprocessable_content
           end
 
-          target.update!(deleted_at: Time.current)
+          # 論理削除は内部的な状態変更のため、name_kana など on: :update の
+          # presence バリデーション（プロフィール未設定の招待直後 admin で失敗する）を
+          # 走らせずに deleted_at だけ更新する。
+          now = Time.current
+          target.update_columns(deleted_at: now, updated_at: now)
           head :no_content
         end
 

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -54,15 +54,8 @@ module Api
         def destroy
           target = User.admins.active.find(params[:id])
 
-          if last_active_admin?(target)
-            return render json: { errors: ['最後の管理者は削除できません'] },
-                          status: :unprocessable_content
-          end
-
-          if target == current_user
-            return render json: { errors: ['自分自身は削除できません'] },
-                          status: :unprocessable_content
-          end
+          return render_delete_error('最後の管理者は削除できません') if last_active_admin?(target)
+          return render_delete_error('自分自身は削除できません') if target == current_user
 
           # 論理削除は内部的な状態変更のため、name_kana など on: :update の
           # presence バリデーション（プロフィール未設定の招待直後 admin で失敗する）を
@@ -89,6 +82,10 @@ module Api
 
         def last_active_admin?(target)
           !User.admins.active.where.not(id: target.id).exists?
+        end
+
+        def render_delete_error(message)
+          render json: { errors: [message] }, status: :unprocessable_content
         end
 
         def sanitized_per_page

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -84,7 +84,7 @@ module Api
         end
 
         def update_params
-          params.permit(:name, :email, :address_id, :phone_number, :birthday, :gender)
+          params.permit(:name, :name_kana, :email, :address_id, :phone_number, :birthday, :gender)
         end
 
         def last_active_admin?(target)

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -25,7 +25,7 @@ module Api
         end
 
         def show
-          admin = User.admins.where(deleted_at: nil).find(params[:id])
+          admin = admin_scope.find(params[:id])
 
           render json: { admin: ::Admin::AdminDetailSerializer.new(admin) }
         end
@@ -41,7 +41,7 @@ module Api
         end
 
         def update
-          admin = User.admins.where(deleted_at: nil).find(params[:id])
+          admin = admin_scope.find(params[:id])
           form = ::Admin::AdminForm.new(update_params.merge(user: admin))
 
           if form.save
@@ -74,12 +74,17 @@ module Api
 
         private
 
+        # show / update で個人情報・住所まで返すため eager load して N+1 を避ける
+        def admin_scope
+          User.admins.where(deleted_at: nil).includes(:user_personal_info, address: :prefecture)
+        end
+
         def create_params
           params.permit(:name, :email)
         end
 
         def update_params
-          params.permit(:name, :email)
+          params.permit(:name, :email, :address_id, :phone_number, :birthday, :gender)
         end
 
         def last_active_admin?(target)

--- a/rails/app/controllers/api/v1/admin/admins_controller.rb
+++ b/rails/app/controllers/api/v1/admin/admins_controller.rb
@@ -52,7 +52,7 @@ module Api
         end
 
         def destroy
-          target = User.admins.where(deleted_at: nil).find(params[:id])
+          target = User.admins.active.find(params[:id])
 
           if last_active_admin?(target)
             return render json: { errors: ['最後の管理者は削除できません'] },
@@ -76,7 +76,7 @@ module Api
 
         # show / update で個人情報・住所まで返すため eager load して N+1 を避ける
         def admin_scope
-          User.admins.where(deleted_at: nil).includes(:user_personal_info, address: :prefecture)
+          User.admins.active.includes(:user_personal_info, address: :prefecture)
         end
 
         def create_params
@@ -88,7 +88,7 @@ module Api
         end
 
         def last_active_admin?(target)
-          !User.admins.where(deleted_at: nil).where.not(id: target.id).exists?
+          !User.admins.active.where.not(id: target.id).exists?
         end
 
         def sanitized_per_page

--- a/rails/app/forms/admin/admin_form.rb
+++ b/rails/app/forms/admin/admin_form.rb
@@ -6,6 +6,7 @@ module Admin
     include ActiveModel::Attributes
 
     attribute :name, :string
+    attribute :name_kana, :string
     attribute :email, :string
     attribute :address_id, :integer
     attribute :phone_number, :string
@@ -48,7 +49,7 @@ module Admin
 
     def update_admin
       ActiveRecord::Base.transaction do
-        @user.update!({ name: name, email: email, address_id: address_id }.compact)
+        @user.update!({ name: name, name_kana: name_kana, email: email, address_id: address_id }.compact)
         update_user_personal_info!
       end
       @user

--- a/rails/app/forms/admin/admin_form.rb
+++ b/rails/app/forms/admin/admin_form.rb
@@ -7,11 +7,21 @@ module Admin
 
     attribute :name, :string
     attribute :email, :string
+    attribute :address_id, :integer
+    attribute :phone_number, :string
+    attribute :birthday, :date
+    attribute :gender, :string
 
     attr_accessor :user
 
     validates :email, presence: true, unless: :updating?
     validates :name, presence: true, on: :update
+    # 個人情報・住所は招待直後でプロフィール未設定の admin を弾かないよう全て任意。
+    # 入力された場合のみ形式・整合性を検証する。
+    validates :phone_number, format: { with: /\A\d{10,11}\z/ }, allow_blank: true, on: :update
+    validates :gender, inclusion: { in: UserPersonalInfo.genders.keys }, allow_blank: true, on: :update
+    validate :address_must_exist, on: :update
+    validate :birthday_cannot_be_future, on: :update
 
     def save
       validation_context = updating? ? :update : nil
@@ -37,8 +47,41 @@ module Admin
     end
 
     def update_admin
-      @user.update!({ name: name, email: email }.compact)
+      ActiveRecord::Base.transaction do
+        @user.update!({ name: name, email: email, address_id: address_id }.compact)
+        update_user_personal_info!
+      end
       @user
+    end
+
+    def update_user_personal_info!
+      info = @user.user_personal_info
+      # 既存 info が無く個人情報も未入力なら、空レコードは作らない（name/email のみ更新時）
+      return if info.nil? && personal_info_blank?
+
+      info ||= @user.build_user_personal_info
+      info.assign_attributes(
+        phone_number: phone_number,
+        birthday: birthday,
+        gender: gender
+      )
+      info.save!
+    end
+
+    def personal_info_blank?
+      phone_number.blank? && birthday.blank? && gender.blank?
+    end
+
+    def address_must_exist
+      return if address_id.blank?
+
+      errors.add(:address_id, 'が不正です。') unless Address.exists?(address_id)
+    end
+
+    def birthday_cannot_be_future
+      return if birthday.blank?
+
+      errors.add(:birthday, 'は未来日付にできません。') if birthday > Time.zone.today
     end
   end
 end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -55,7 +55,9 @@ class User < ApplicationRecord
                                             inverse_of: :receiver_user, dependent: :destroy
 
   validates :name, presence: true, on: :update
-  validates :name_kana, presence: true, on: :update
+  # 管理者は氏名カナを持たない運用（作成時も未設定）。student/teacher の
+  # カナ必須は各プロフィールフォーム側で担保しているため、ここでは admin を除外する。
+  validates :name_kana, presence: true, on: :update, unless: :admin?
   validates :user_role, presence: true
   validates :high_school, presence: true, if: :requires_high_school?
   validates :grade, presence: true, if: :student?

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -104,6 +104,7 @@ class User < ApplicationRecord
   scope :by_high_school, ->(high_school_ids) { where(high_school_id: high_school_ids) }
   scope :high_school_current, -> { joins(:grade).where(grades: { year: 1..3 }) }
   scope :invitation_pending, -> { where(password_reset_required: true) }
+  scope :active, -> { where(deleted_at: nil) }
 
   private
 

--- a/rails/app/queries/admins_query.rb
+++ b/rails/app/queries/admins_query.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class AdminsQuery
-  def initialize(scope = User.admins.where(deleted_at: nil))
+  def initialize(scope = User.admins.active)
     @scope = scope
   end
 

--- a/rails/app/serializers/admin/admin_detail_serializer.rb
+++ b/rails/app/serializers/admin/admin_detail_serializer.rb
@@ -4,6 +4,9 @@ module Admin
   class AdminDetailSerializer < ActiveModel::Serializer
     attributes :id, :name, :email, :created_at, :updated_at, :activity_log
 
+    has_one :user_personal_info, serializer: UserPersonalInfoSerializer
+    belongs_to :address, serializer: AddressSerializer
+
     def activity_log
       []
     end

--- a/rails/app/serializers/admin/admin_detail_serializer.rb
+++ b/rails/app/serializers/admin/admin_detail_serializer.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class AdminDetailSerializer < ActiveModel::Serializer
-    attributes :id, :name, :email, :created_at, :updated_at, :activity_log
+    attributes :id, :name, :name_kana, :email, :created_at, :updated_at, :activity_log
 
     has_one :user_personal_info, serializer: UserPersonalInfoSerializer
     belongs_to :address, serializer: AddressSerializer

--- a/rails/config/locales/ja.yml
+++ b/rails/config/locales/ja.yml
@@ -7,6 +7,17 @@ ja:
     models:
       goal: 目標
       task: タスク
+    attributes:
+      user:
+        name: 名前
+        name_kana: 氏名カナ
+        email: メールアドレス
+        address: 住所
+        address_id: 住所
+      user_personal_info:
+        phone_number: 電話番号
+        birthday: 生年月日
+        gender: 性別
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました"
@@ -19,3 +30,13 @@ ja:
           attributes:
             user:
               not_teacher: "教職員アカウントのみ設定可能です"
+  activemodel:
+    attributes:
+      admin/admin_form:
+        name: 名前
+        name_kana: 氏名カナ
+        email: メールアドレス
+        address_id: 住所
+        phone_number: 電話番号
+        birthday: 生年月日
+        gender: 性別

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
       namespace :admin do
         resource :dashboard, only: :show
         resources :admins, only: [:index, :show, :create, :update, :destroy]
+        resources :addresses, only: :index
         resources :high_schools, only: [:index, :show] do
           resources :teachers, only: [:index, :create, :update]
         end

--- a/rails/spec/forms/admin/admin_form_spec.rb
+++ b/rails/spec/forms/admin/admin_form_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::AdminForm, type: :model do
+  describe '#save（新規作成）' do
+    it 'email があれば admin を作成する' do
+      form = described_class.new(name: '新規', email: 'new@example.com')
+      expect(form.save).to be(true)
+      expect(form.result).to be_a(User)
+      expect(form.result.email).to eq('new@example.com')
+    end
+
+    it 'email が空だと作成に失敗する' do
+      form = described_class.new(name: '新規', email: '')
+      expect(form.save).to be(false)
+      expect(form.errors[:email]).to be_present
+    end
+  end
+
+  describe '#save（更新）' do
+    let(:address) { create(:address) }
+    let!(:user) { create(:user, :admin, high_school: nil, name: '更新前', email: 'before@example.com') }
+
+    it 'name / email / 住所 / 個人情報をまとめて更新する' do
+      form = described_class.new(
+        user: user,
+        name: '更新後',
+        email: 'after@example.com',
+        address_id: address.id,
+        phone_number: '08012345678',
+        birthday: Date.new(1999, 1, 1),
+        gender: 'male'
+      )
+
+      expect(form.save).to be(true)
+
+      user.reload
+      expect(user.name).to eq('更新後')
+      expect(user.email).to eq('after@example.com')
+      expect(user.address_id).to eq(address.id)
+
+      info = user.user_personal_info
+      expect(info.phone_number).to eq('08012345678')
+      expect(info.birthday).to eq(Date.new(1999, 1, 1))
+      expect(info.gender).to eq('male')
+    end
+
+    it '個人情報が未入力でも更新できる（招待直後 admin を弾かない）' do
+      form = described_class.new(user: user, name: '更新後', email: 'after@example.com')
+      expect(form.save).to be(true)
+      expect(user.reload.user_personal_info).to be_nil
+    end
+
+    it '個人情報が全て未入力なら空の user_personal_info を作らない' do
+      expect do
+        described_class.new(user: user, name: '更新後', email: 'after@example.com').save
+      end.not_to change(UserPersonalInfo, :count)
+    end
+
+    it '既存の user_personal_info がある場合は更新する' do
+      user.create_user_personal_info!(phone_number: '08000000000', gender: 'female')
+
+      form = described_class.new(
+        user: user, name: '更新後', email: 'after@example.com',
+        phone_number: '09011112222', gender: 'male'
+      )
+      expect(form.save).to be(true)
+
+      info = user.reload.user_personal_info
+      expect(info.phone_number).to eq('09011112222')
+      expect(info.gender).to eq('male')
+    end
+
+    context 'バリデーション' do
+      it 'phone_number が桁数不正だと失敗する' do
+        form = described_class.new(user: user, name: '更新後', email: 'after@example.com', phone_number: '123')
+        expect(form.save).to be(false)
+        expect(form.errors[:phone_number]).to be_present
+      end
+
+      it 'gender が enum 外だと失敗する' do
+        form = described_class.new(user: user, name: '更新後', email: 'after@example.com', gender: 'unknown')
+        expect(form.save).to be(false)
+        expect(form.errors[:gender]).to be_present
+      end
+
+      it '存在しない address_id だと失敗する' do
+        form = described_class.new(user: user, name: '更新後', email: 'after@example.com', address_id: 0)
+        expect(form.save).to be(false)
+        expect(form.errors[:address_id]).to be_present
+      end
+
+      it 'birthday が未来日付だと失敗する' do
+        form = described_class.new(
+          user: user, name: '更新後', email: 'after@example.com', birthday: Date.tomorrow
+        )
+        expect(form.save).to be(false)
+        expect(form.errors[:birthday]).to be_present
+      end
+    end
+  end
+end

--- a/rails/spec/forms/admin/admin_form_spec.rb
+++ b/rails/spec/forms/admin/admin_form_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe Admin::AdminForm, type: :model do
       expect(user.reload.user_personal_info).to be_nil
     end
 
+    it 'name_kana が未設定の admin でも更新できる（admin はカナ不要）' do
+      user.update_columns(name_kana: nil)
+      form = described_class.new(user: user, name: '更新後', email: 'after@example.com')
+      expect(form.save).to be(true)
+      expect(user.reload.name).to eq('更新後')
+    end
+
     it '個人情報が全て未入力なら空の user_personal_info を作らない' do
       expect do
         described_class.new(user: user, name: '更新後', email: 'after@example.com').save

--- a/rails/spec/forms/admin/admin_form_spec.rb
+++ b/rails/spec/forms/admin/admin_form_spec.rb
@@ -22,10 +22,11 @@ RSpec.describe Admin::AdminForm, type: :model do
     let(:address) { create(:address) }
     let!(:user) { create(:user, :admin, high_school: nil, name: '更新前', email: 'before@example.com') }
 
-    it 'name / email / 住所 / 個人情報をまとめて更新する' do
+    it 'name / name_kana / email / 住所 / 個人情報をまとめて更新する' do
       form = described_class.new(
         user: user,
         name: '更新後',
+        name_kana: 'コウシンゴ',
         email: 'after@example.com',
         address_id: address.id,
         phone_number: '08012345678',
@@ -37,6 +38,7 @@ RSpec.describe Admin::AdminForm, type: :model do
 
       user.reload
       expect(user.name).to eq('更新後')
+      expect(user.name_kana).to eq('コウシンゴ')
       expect(user.email).to eq('after@example.com')
       expect(user.address_id).to eq(address.id)
 

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -51,6 +51,14 @@ RSpec.describe User, type: :model do
         expect(user.errors[:name]).to include('を入力してください')
         expect(user.errors[:name_kana]).to include('を入力してください')
       end
+
+      it 'admin は更新時も name_kana が必須ではない（name は必須）' do
+        user = create(:user, email: 'admin@example.com', password: 'password', user_role: admin_role,
+                             high_school: nil, name_kana: nil)
+        user.name_kana = nil
+
+        expect(user.valid?(:update)).to be true
+      end
     end
 
     describe 'user_role' do

--- a/rails/spec/requests/api/v1/admin/addresses_spec.rb
+++ b/rails/spec/requests/api/v1/admin/addresses_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Addresses', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  let!(:admin_user) { create(:user, :admin, high_school: nil) }
+  let(:cookie)      { login_and_get_cookie(admin_user) }
+  let(:prefecture)  { create(:prefecture) }
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe '認可' do
+    it '未認証は401' do
+      get '/api/v1/admin/addresses', params: { prefecture_id: 1 }, headers: headers
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it '非admin (student) は403' do
+      student = create(:user)
+      student_cookie = login_and_get_cookie(student)
+      get '/api/v1/admin/addresses',
+          params: { prefecture_id: 1 }, headers: headers.merge('Cookie' => student_cookie)
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'GET /api/v1/admin/addresses' do
+    it 'prefecture_id が無いと 400' do
+      get '/api/v1/admin/addresses', headers: headers.merge('Cookie' => cookie)
+      expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'prefecture_id で住所一覧を返す' do
+      address = create(:address, prefecture: prefecture)
+      get '/api/v1/admin/addresses',
+          params: { prefecture_id: prefecture.id },
+          headers: headers.merge('Cookie' => cookie)
+
+      expect(response).to have_http_status(:ok)
+      ids = response.parsed_body.pluck('id')
+      expect(ids).to include(address.id)
+    end
+
+    it 'city で絞り込める' do
+      create(:address, prefecture: prefecture, city: '千代田区')
+      create(:address, prefecture: prefecture, city: '港区')
+      get '/api/v1/admin/addresses',
+          params: { prefecture_id: prefecture.id, city: '港区' },
+          headers: headers.merge('Cookie' => cookie)
+
+      cities = response.parsed_body.pluck('city').uniq
+      expect(cities).to contain_exactly('港区')
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -343,6 +343,17 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
         ids = response.parsed_body['admins'].pluck('id')
         expect(ids).not_to include(target.id)
       end
+
+      it 'プロフィール未設定（name_kana が空）の招待直後 admin も論理削除できる' do
+        # 招待直後でプロフィール未入力の admin は name_kana が空。
+        # 論理削除が on: :update の presence バリデーションに引っかからないことを担保する。
+        invited = create(:user, :admin, high_school: nil, name_kana: nil)
+
+        delete "/api/v1/admin/admins/#{invited.id}", headers: headers.merge('Cookie' => cookie)
+
+        expect(response).to have_http_status(:no_content)
+        expect(invited.reload.deleted_at).to be_present
+      end
     end
 
     context '異常系' do

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -177,10 +177,12 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
         expect(response).to have_http_status(:ok)
       end
 
-      it '詳細レスポンスに id/name/email/created_at/updated_at/activity_log を含む' do
+      it '詳細レスポンスに id/name/name_kana/email/created_at/updated_at/activity_log を含む' do
         get "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
         admin_data = response.parsed_body['admin']
-        expect(admin_data.keys).to include('id', 'name', 'email', 'created_at', 'updated_at', 'activity_log')
+        expect(admin_data.keys).to include(
+          'id', 'name', 'name_kana', 'email', 'created_at', 'updated_at', 'activity_log'
+        )
       end
 
       it 'activity_log は空配列で返される' do
@@ -318,11 +320,12 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
         expect(target.email).to eq('after-admin@example.com')
       end
 
-      it '住所・個人情報も更新される' do
+      it 'name_kana・住所・個人情報も更新される' do
         address = create(:address)
         patch "/api/v1/admin/admins/#{target.id}",
               params: {
-                name: '更新後太郎', email: 'after-admin@example.com',
+                name: '更新後太郎', name_kana: 'コウシンゴタロウ',
+                email: 'after-admin@example.com',
                 address_id: address.id, phone_number: '08012345678',
                 birthday: '1999-01-01', gender: 'male'
               }.to_json,
@@ -330,6 +333,7 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
 
         expect(response).to have_http_status(:ok)
         target.reload
+        expect(target.name_kana).to eq('コウシンゴタロウ')
         expect(target.address_id).to eq(address.id)
         expect(target.user_personal_info.phone_number).to eq('08012345678')
         expect(target.user_personal_info.gender).to eq('male')

--- a/rails/spec/requests/api/v1/admin/admins_spec.rb
+++ b/rails/spec/requests/api/v1/admin/admins_spec.rb
@@ -187,6 +187,24 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
         get "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
         expect(response.parsed_body['admin']['activity_log']).to eq([])
       end
+
+      it 'user_personal_info / address フィールドを含む' do
+        get "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
+        expect(response.parsed_body['admin'].keys).to include('user_personal_info', 'address')
+      end
+
+      it '個人情報・住所が設定済みなら値が返される' do
+        address = create(:address)
+        target.update_columns(address_id: address.id)
+        target.create_user_personal_info!(phone_number: '08012345678', birthday: Date.new(1999, 1, 1), gender: 'male')
+
+        get "/api/v1/admin/admins/#{target.id}", headers: headers.merge('Cookie' => cookie)
+        admin_data = response.parsed_body['admin']
+        expect(admin_data['user_personal_info']).to include(
+          'phone_number' => '08012345678', 'gender' => 'male'
+        )
+        expect(admin_data['address']['id']).to eq(address.id)
+      end
     end
 
     context '異常系' do
@@ -298,6 +316,30 @@ RSpec.describe 'Api::V1::Admin::Admins', type: :request do
         target.reload
         expect(target.name).to eq('更新後太郎')
         expect(target.email).to eq('after-admin@example.com')
+      end
+
+      it '住所・個人情報も更新される' do
+        address = create(:address)
+        patch "/api/v1/admin/admins/#{target.id}",
+              params: {
+                name: '更新後太郎', email: 'after-admin@example.com',
+                address_id: address.id, phone_number: '08012345678',
+                birthday: '1999-01-01', gender: 'male'
+              }.to_json,
+              headers: headers.merge('Cookie' => cookie)
+
+        expect(response).to have_http_status(:ok)
+        target.reload
+        expect(target.address_id).to eq(address.id)
+        expect(target.user_personal_info.phone_number).to eq('08012345678')
+        expect(target.user_personal_info.gender).to eq('male')
+      end
+
+      it 'birthday が未来日付の場合 422 が返される' do
+        patch "/api/v1/admin/admins/#{target.id}",
+              params: { name: '更新後太郎', birthday: (Date.current + 1).iso8601 }.to_json,
+              headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 


### PR DESCRIPTION
## 概要

<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

管理者用管理画面の一部として、管理者詳細・編集画面 `/admin/admins/:id` を実装します。

- 対象issue: #64【Next.js】管理者詳細・編集画面

2カラム構成（左65% プロフィール・編集、右35% アクティビティログ・危険操作）で、編集・パスワードリセット・削除（自己削除不可ガード付き）を行えるようにしています。

## 詳細

<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

### UI/UX 方針

- 編集フォームは **表示→編集トグル**（誤操作防止）
- 成否フィードバックは **Snackbar 統一**（バリデーション/サーバーエラーはフォーム・ダイアログ内 Alert も併用）
- 危険操作カードは **赤枠・警告色で強調**、削除確認は **対象メールアドレスを正確に入力するまで「削除」disabled**
- 自己削除時は **削除ボタン disabled + 「自分自身は削除できません」** を表示

### レビューで見てほしい点 / 補足

- **自己削除ガード**: `currentAdminId === admin.id` で判定。`me.id`・`admin.id` はともに `users.id`（管理者は `User.admins`）で同一名前空間です。`/me` 取得失敗時は判定不能になり UI ガードは無効化されますが、Rails 側でも 422 で防いでいます（多層防御）。
- **アクティビティログ**: バックエンドの `activity_log` が現状 `[]` のプレースホルダーのため、空状態 UI のみ表示しています。
- **Rails の不具合修正（追加対応）**: プロフィール未設定（`name_kana` が空）の招待直後の管理者を削除すると、論理削除の `update!` が `on: :update` の presence バリデーションに失敗して 422 になっていました。論理削除は `update_columns` で `deleted_at` のみ更新しバリデーションをスキップするよう修正し、回帰テストを追加しています。

## 動作確認
<img width="1686" height="476" alt="スクリーンショット 2026-06-09 14 06 10" src="https://github.com/user-attachments/assets/b1b2e06b-0193-4af0-97e0-4f25205598e3" />
<img width="1684" height="646" alt="スクリーンショット 2026-06-09 14 06 24" src="https://github.com/user-attachments/assets/62f0539e-d62a-44bf-b82d-b6affd88d7b6" />
<img width="549" height="404" alt="スクリーンショット 2026-06-09 14 06 58" src="https://github.com/user-attachments/assets/7f2fcfca-6a79-4737-8a0b-1fafacf0d8dc" />

<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

ローカルで一通り動作確認済みです（スクリーンショットは後ほど添付します）。

- [x] 一覧 → 詳細遷移
- [x] プロフィール編集（表示→編集トグル、保存で更新・Snackbar 表示・読み取り表示に復帰）
- [x] パスワードリセットメール送信
- [x] 削除（メールアドレス入力で「削除」有効化 → 削除 → 一覧へ遷移）
- [x] 自己削除不可の UI ガード（削除ボタン disabled + 説明文）
- [x] プロフィール未設定の管理者も削除できること

### 自動テスト

- フロント: Vitest 55 件 green、ESLint / Prettier / typecheck green
- バックエンド: `admins_spec` 47 件 green、RuboCop offenses なし

（スクリーンショットは後ほど追記）

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

新規ライブラリの追加はありません（MUI / react-hook-form など既存スタックを踏襲）。

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
