### PR TITLE
issue-53 講座詳細画面（単元一覧）を追加

### DIFF
--- a/frontend/app/(admin)/admin/(authenticated)/courses/[courseId]/page.tsx
+++ b/frontend/app/(admin)/admin/(authenticated)/courses/[courseId]/page.tsx
@@ -1,0 +1,11 @@
+import { AdminCourseDetail } from "@/features/AdminCourseDetail";
+
+type Props = {
+  params: Promise<{ courseId: string }>;
+};
+
+export default async function AdminCourseDetailPage({ params }: Props) {
+  const { courseId } = await params;
+
+  return <AdminCourseDetail courseId={Number(courseId)} />;
+}

--- a/frontend/app/api/admin/courses/[courseId]/route.ts
+++ b/frontend/app/api/admin/courses/[courseId]/route.ts
@@ -8,6 +8,11 @@ export async function GET(
 ) {
   const { courseId } = await params;
 
+  // courseId は数値IDのみ許容。不正値は Rails へ問い合わせる前に弾く
+  if (!/^\d+$/.test(courseId)) {
+    return NextResponse.json({ message: "BAD_REQUEST" }, { status: 400 });
+  }
+
   try {
     const { status, data, setCookie } = await railsFetch(
       `/api/v1/admin/courses/${courseId}`,

--- a/frontend/app/api/admin/courses/[courseId]/route.ts
+++ b/frontend/app/api/admin/courses/[courseId]/route.ts
@@ -1,0 +1,29 @@
+import { RailsUnauthorizedError } from "@/libs/server/rails/railsError";
+import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  _: NextRequest,
+  { params }: { params: Promise<{ courseId: string }> },
+) {
+  const { courseId } = await params;
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/admin/courses/${courseId}`,
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    if (error instanceof RailsUnauthorizedError) {
+      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+    }
+
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/features/AdminCourseDetail/Presenter.test.tsx
+++ b/frontend/features/AdminCourseDetail/Presenter.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Presenter } from "./Presenter";
+import type { AdminCourseDetail } from "./types";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const mockCourse: AdminCourseDetail = {
+  id: 7,
+  subject: { id: 1, name: "数学" },
+  level_number: 2,
+  level_name: "標準",
+  description: "標準レベルのコースです",
+  units: [
+    { id: 11, unit_name: "二次関数", questions_count: 5 },
+    { id: 12, unit_name: "三角比", questions_count: 0 },
+  ],
+};
+
+describe("AdminCourseDetailPresenter", () => {
+  it("科目名・レベル・説明が表示される", () => {
+    render(<Presenter course={mockCourse} />);
+    expect(screen.getByText("数学")).toBeInTheDocument();
+    expect(screen.getAllByText("標準レベル2").length).toBeGreaterThan(0);
+    expect(screen.getByText("標準レベルのコースです")).toBeInTheDocument();
+  });
+
+  it("説明が空の場合はプレースホルダーが表示される", () => {
+    render(<Presenter course={{ ...mockCourse, description: null }} />);
+    expect(screen.getByText("説明はありません")).toBeInTheDocument();
+  });
+
+  it("単元名と問題数が行として表示される", () => {
+    render(<Presenter course={mockCourse} />);
+    expect(screen.getByText("二次関数")).toBeInTheDocument();
+    expect(screen.getByText("三角比")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("問題数0の単元に「CSVで問題を追加」ヒントが表示される", () => {
+    render(<Presenter course={mockCourse} />);
+    const row = screen.getByText("三角比").closest("tr");
+    expect(row).not.toBeNull();
+    expect(
+      within(row as HTMLElement).getByText(/CSVで問題を追加/),
+    ).toBeInTheDocument();
+  });
+
+  it("問題数がある単元にはヒントが表示されない", () => {
+    render(<Presenter course={mockCourse} />);
+    const row = screen.getByText("二次関数").closest("tr");
+    expect(
+      within(row as HTMLElement).queryByText(/CSVで問題を追加/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("各単元行のCSVボタンが正しい href を持つ", () => {
+    render(<Presenter course={mockCourse} />);
+    const row = screen.getByText("二次関数").closest("tr");
+    const link = within(row as HTMLElement).getByRole("link", {
+      name: /CSV/,
+    });
+    expect(link).toHaveAttribute("href", "/admin/courses/7/units/11/import");
+  });
+
+  it("単元が0件のとき空状態メッセージが表示される", () => {
+    render(<Presenter course={{ ...mockCourse, units: [] }} />);
+    expect(screen.getByText("単元がまだありません")).toBeInTheDocument();
+  });
+
+  it("パンくずに講座一覧リンクがある", () => {
+    render(<Presenter course={mockCourse} />);
+    const link = screen.getByRole("link", { name: "講座一覧" });
+    expect(link).toHaveAttribute("href", "/admin/courses");
+  });
+});

--- a/frontend/features/AdminCourseDetail/Presenter.tsx
+++ b/frontend/features/AdminCourseDetail/Presenter.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { colors } from "@/app/theme/colors";
+import {
+  Box,
+  Breadcrumbs,
+  Button,
+  Card,
+  CardContent,
+  Grid,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import UploadFileOutlinedIcon from "@mui/icons-material/UploadFileOutlined";
+import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
+import Link from "next/link";
+import type { AdminCourseDetail } from "./types";
+
+type Props = {
+  course: AdminCourseDetail;
+};
+
+export const Presenter = ({ course }: Props) => {
+  const courseLabel = `${course.level_name}レベル${course.level_number}`;
+
+  return (
+    <Box sx={{ p: 3 }}>
+      {/* パンくずナビ */}
+      <Breadcrumbs sx={{ mb: 2 }}>
+        <Link
+          href="/admin/courses"
+          style={{ color: colors.brand.primary, textDecoration: "none" }}
+        >
+          講座一覧
+        </Link>
+        <Typography color="text.primary">{courseLabel}</Typography>
+      </Breadcrumbs>
+
+      {/* ページタイトル */}
+      <Typography
+        variant="h5"
+        component="h1"
+        fontWeight={700}
+        sx={{ color: colors.text.primary, mb: 3 }}
+      >
+        {courseLabel}
+      </Typography>
+
+      {/* 講座情報カード */}
+      <Card
+        elevation={0}
+        sx={{
+          border: `1px solid ${colors.border.light}`,
+          borderRadius: 2,
+          mb: 3,
+        }}
+      >
+        <CardContent sx={{ p: 3 }}>
+          <Grid container spacing={3}>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <Typography
+                variant="body2"
+                sx={{ color: colors.text.muted, mb: 0.5 }}
+              >
+                科目
+              </Typography>
+              <Typography variant="h6" fontWeight={700}>
+                {course.subject.name}
+              </Typography>
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <Typography
+                variant="body2"
+                sx={{ color: colors.text.muted, mb: 0.5 }}
+              >
+                レベル
+              </Typography>
+              <Typography variant="h6" fontWeight={700}>
+                {courseLabel}
+              </Typography>
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              <Typography
+                variant="body2"
+                sx={{ color: colors.text.muted, mb: 0.5 }}
+              >
+                説明
+              </Typography>
+              {course.description ? (
+                <Typography variant="body1">{course.description}</Typography>
+              ) : (
+                <Typography variant="body1" sx={{ color: colors.text.muted }}>
+                  説明はありません
+                </Typography>
+              )}
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+
+      {/* 単元一覧 */}
+      <Typography
+        variant="h6"
+        fontWeight={700}
+        sx={{ color: colors.text.primary, mb: 1.5 }}
+      >
+        単元一覧
+      </Typography>
+      <Card
+        elevation={0}
+        sx={{ border: `1px solid ${colors.border.light}`, borderRadius: 2 }}
+      >
+        <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
+          {course.units.length === 0 ? (
+            <Box sx={{ py: 6, textAlign: "center" }}>
+              <Typography color="text.secondary">
+                単元がまだありません
+              </Typography>
+            </Box>
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow sx={{ bgcolor: colors.surface.light }}>
+                    <TableCell sx={{ fontWeight: 600 }}>単元名</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }} align="right">
+                      問題数
+                    </TableCell>
+                    <TableCell sx={{ fontWeight: 600 }} align="right">
+                      操作
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {course.units.map((unit) => (
+                    <TableRow
+                      key={unit.id}
+                      hover
+                      sx={{ "&:last-child td": { border: 0 } }}
+                    >
+                      <TableCell>
+                        <Box
+                          sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 1,
+                            flexWrap: "wrap",
+                          }}
+                        >
+                          <Typography variant="body2">
+                            {unit.unit_name}
+                          </Typography>
+                          {/* 問題数0の単元は、何をすべきか管理者に明示する */}
+                          {unit.questions_count === 0 && (
+                            <Box
+                              sx={{
+                                display: "inline-flex",
+                                alignItems: "center",
+                                gap: 0.5,
+                                color: colors.status.warning,
+                              }}
+                            >
+                              <WarningAmberOutlinedIcon fontSize="inherit" />
+                              <Typography variant="caption">
+                                CSVで問題を追加
+                              </Typography>
+                            </Box>
+                          )}
+                        </Box>
+                      </TableCell>
+                      <TableCell align="right">
+                        {unit.questions_count}
+                      </TableCell>
+                      <TableCell align="right">
+                        {/*
+                          CSVインポートウィザード(#P0-6)の想定遷移先。
+                          単元プリセット込みのURL。ウィザード本体は別issueで実装予定。
+                        */}
+                        <Button
+                          component={Link}
+                          href={`/admin/courses/${course.id}/units/${unit.id}/import`}
+                          size="small"
+                          variant="outlined"
+                          startIcon={<UploadFileOutlinedIcon />}
+                        >
+                          CSV取込
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
+  );
+};

--- a/frontend/features/AdminCourseDetail/Presenter.tsx
+++ b/frontend/features/AdminCourseDetail/Presenter.tsx
@@ -78,7 +78,7 @@ export const Presenter = ({ course }: Props) => {
                 variant="body2"
                 sx={{ color: colors.text.muted, mb: 0.5 }}
               >
-                レベル
+                難易度
               </Typography>
               <Typography variant="h6" fontWeight={700}>
                 {courseLabel}

--- a/frontend/features/AdminCourseDetail/hooks/useFetchCourseDetail.ts
+++ b/frontend/features/AdminCourseDetail/hooks/useFetchCourseDetail.ts
@@ -7,18 +7,27 @@ import type { AdminCourseDetail } from "../types";
 
 export const useFetchCourseDetail = (courseId: number) => {
   const [course, setCourse] = useState<AdminCourseDetail | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<boolean>(false);
   const router = useRouter();
 
   useEffect(() => {
+    setLoading(true);
+    setError(false);
+
     apiClient
       .get<AdminCourseDetail>(`/api/admin/courses/${courseId}`)
       .then((res) => setCourse(res.data))
       .catch((err) => {
         if (err.response?.status === 401) {
           router.push("/login");
+          return;
         }
-      });
+        setError(true);
+        setCourse(null);
+      })
+      .finally(() => setLoading(false));
   }, [courseId, router]);
 
-  return { course };
+  return { course, loading, error };
 };

--- a/frontend/features/AdminCourseDetail/hooks/useFetchCourseDetail.ts
+++ b/frontend/features/AdminCourseDetail/hooks/useFetchCourseDetail.ts
@@ -12,13 +12,20 @@ export const useFetchCourseDetail = (courseId: number) => {
   const router = useRouter();
 
   useEffect(() => {
+    // courseId が変わった際、古いリクエストの応答で新しい表示を上書きしないようにする
+    let ignore = false;
+
     setLoading(true);
     setError(false);
 
     apiClient
       .get<AdminCourseDetail>(`/api/admin/courses/${courseId}`)
-      .then((res) => setCourse(res.data))
+      .then((res) => {
+        if (ignore) return;
+        setCourse(res.data);
+      })
       .catch((err) => {
+        if (ignore) return;
         if (err.response?.status === 401) {
           router.push("/login");
           return;
@@ -26,7 +33,14 @@ export const useFetchCourseDetail = (courseId: number) => {
         setError(true);
         setCourse(null);
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (ignore) return;
+        setLoading(false);
+      });
+
+    return () => {
+      ignore = true;
+    };
   }, [courseId, router]);
 
   return { course, loading, error };

--- a/frontend/features/AdminCourseDetail/hooks/useFetchCourseDetail.ts
+++ b/frontend/features/AdminCourseDetail/hooks/useFetchCourseDetail.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient } from "@/libs/http/apiClient";
+import type { AdminCourseDetail } from "../types";
+
+export const useFetchCourseDetail = (courseId: number) => {
+  const [course, setCourse] = useState<AdminCourseDetail | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    apiClient
+      .get<AdminCourseDetail>(`/api/admin/courses/${courseId}`)
+      .then((res) => setCourse(res.data))
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          router.push("/login");
+        }
+      });
+  }, [courseId, router]);
+
+  return { course };
+};

--- a/frontend/features/AdminCourseDetail/hooks/useFetchCourseDetail.ts
+++ b/frontend/features/AdminCourseDetail/hooks/useFetchCourseDetail.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import axios from "axios";
 import { apiClient } from "@/libs/http/apiClient";
 import type { AdminCourseDetail } from "../types";
 
@@ -12,20 +13,22 @@ export const useFetchCourseDetail = (courseId: number) => {
   const router = useRouter();
 
   useEffect(() => {
-    // courseId が変わった際、古いリクエストの応答で新しい表示を上書きしないようにする
-    let ignore = false;
+    // courseId が変わった際、古いリクエストをキャンセルして
+    // 古い応答で新しい表示を上書きしないようにする
+    const controller = new AbortController();
 
     setLoading(true);
     setError(false);
 
     apiClient
-      .get<AdminCourseDetail>(`/api/admin/courses/${courseId}`)
+      .get<AdminCourseDetail>(`/api/admin/courses/${courseId}`, {
+        signal: controller.signal,
+      })
       .then((res) => {
-        if (ignore) return;
         setCourse(res.data);
       })
       .catch((err) => {
-        if (ignore) return;
+        if (axios.isCancel(err)) return;
         if (err.response?.status === 401) {
           router.push("/login");
           return;
@@ -34,12 +37,12 @@ export const useFetchCourseDetail = (courseId: number) => {
         setCourse(null);
       })
       .finally(() => {
-        if (ignore) return;
+        if (controller.signal.aborted) return;
         setLoading(false);
       });
 
     return () => {
-      ignore = true;
+      controller.abort();
     };
   }, [courseId, router]);
 

--- a/frontend/features/AdminCourseDetail/index.tsx
+++ b/frontend/features/AdminCourseDetail/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, CircularProgress } from "@mui/material";
+import { Box, CircularProgress, Typography } from "@mui/material";
 import { Presenter } from "./Presenter";
 import { useFetchCourseDetail } from "./hooks/useFetchCourseDetail";
 
@@ -9,9 +9,9 @@ type Props = {
 };
 
 export const AdminCourseDetail = ({ courseId }: Props) => {
-  const { course } = useFetchCourseDetail(courseId);
+  const { course, loading, error } = useFetchCourseDetail(courseId);
 
-  if (!course) {
+  if (loading) {
     return (
       <Box
         sx={{
@@ -22,6 +22,25 @@ export const AdminCourseDetail = ({ courseId }: Props) => {
         }}
       >
         <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error || !course) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+          flexDirection: "column",
+          gap: 1,
+        }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          データの取得に失敗しました
+        </Typography>
       </Box>
     );
   }

--- a/frontend/features/AdminCourseDetail/index.tsx
+++ b/frontend/features/AdminCourseDetail/index.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Box, CircularProgress } from "@mui/material";
+import { Presenter } from "./Presenter";
+import { useFetchCourseDetail } from "./hooks/useFetchCourseDetail";
+
+type Props = {
+  courseId: number;
+};
+
+export const AdminCourseDetail = ({ courseId }: Props) => {
+  const { course } = useFetchCourseDetail(courseId);
+
+  if (!course) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return <Presenter course={course} />;
+};

--- a/frontend/features/AdminCourseDetail/types.ts
+++ b/frontend/features/AdminCourseDetail/types.ts
@@ -1,0 +1,19 @@
+export type Subject = {
+  id: number;
+  name: string;
+};
+
+export type CourseUnit = {
+  id: number;
+  unit_name: string;
+  questions_count: number;
+};
+
+export type AdminCourseDetail = {
+  id: number;
+  subject: Subject;
+  level_number: number;
+  level_name: string;
+  description: string | null;
+  units: CourseUnit[];
+};


### PR DESCRIPTION
## 概要

issue #53 【Next.js】講座詳細画面（単元一覧）。

管理者向け講座詳細画面 `/admin/courses/:id` を新規実装。講座一覧の各行リンクの遷移先が未実装で404になっていたため、その遷移先を用意する。

## 詳細

- **BFF パターン踏襲**: `app/api/admin/courses/[courseId]/route.ts` から `railsFetch` 経由で Rails (`GET /api/v1/admin/courses/:id`) を呼ぶ。既存 `schools/[schoolId]` ルートと同形。
- **Container / Presenter / hook 分離**: 既存 `AdminCourses` / `AdminSchoolDetail` の慣習に準拠。
- **UX配慮（webに不慣れな管理者向け）**: 問題数0の単元に「⚠️ CSVで問題を追加」を警告色で表示。CSV取込ボタンはアイコン+日本語ラベルで操作を明示（遷移先は #P0-6 ウィザードの想定URL）。
- **TDD**: Presenter テストを red 先行で追加 → 実装。


## 動作確認
<img width="1677" height="596" alt="スクリーンショット 2026-06-10 13 25 35" src="https://github.com/user-attachments/assets/9522592e-3833-4c7d-9699-068b00953d8a" />
<img width="1676" height="707" alt="スクリーンショット 2026-06-10 13 26 02" src="https://github.com/user-attachments/assets/463207f8-e50d-4a8e-9be1-f3baae03c551" />


- [x] `/admin/courses` の講座名リンク → `/admin/courses/:id` に遷移、講座情報・単元一覧が表示される
- [x] 問題数0の単元に警告ヒントが表示される
- [x] CSV取込ボタンのリンク先URLが想定どおり（ウィザード本体は #P0-6 で実装予定）
- [x] 初期ロード中に CircularProgress、取得失敗時にエラーメッセージ表示
- [x] Vitest 8件 pass / ESLint clean / Prettier clean / typecheck（本変更にエラーなし）

## その他

- 新規ライブラリの導入なし（既存の MUI v7 / axios のみ使用）。

## 参考情報

