### PR TITLE
[Rails]生徒用お知らせ一覧・詳細取得API作成

### DIFF
--- a/rails/app/controllers/api/v1/student/announcements_controller.rb
+++ b/rails/app/controllers/api/v1/student/announcements_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Student
+      class AnnouncementsController < Api::V1::Student::BaseController
+        def index
+          announcements = announcement_scope
+                          .order(published_at: :desc, id: :desc)
+                          .page(params[:page])
+                          .per(20)
+
+          render json: {
+            announcements: ActiveModelSerializers::SerializableResource.new(
+              announcements, each_serializer: AnnouncementSerializer
+            ),
+            meta: {
+              current_page: announcements.current_page,
+              total_pages: announcements.total_pages,
+              total_count: announcements.total_count,
+              per_page: 20
+            }
+          }
+        end
+
+        private
+
+        def announcement_scope
+          Announcement.for_user(current_user).includes(:publisher).published
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/student/announcements_controller.rb
+++ b/rails/app/controllers/api/v1/student/announcements_controller.rb
@@ -23,6 +23,12 @@ module Api
           }
         end
 
+        def show
+          announcement = announcement_scope.find(params[:id])
+
+          render json: announcement, serializer: AnnouncementSerializer, status: :ok
+        end
+
         private
 
         def announcement_scope

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
           end
         end
         resources :courses, only: :index
-        resources :announcements, only: :index
+        resources :announcements, only: [:index, :show]
       end
 
       namespace :teacher do

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
           end
         end
         resources :courses, only: :index
+        resources :announcements, only: :index
       end
 
       namespace :teacher do

--- a/rails/spec/requests/api/v1/student/announcements_spec.rb
+++ b/rails/spec/requests/api/v1/student/announcements_spec.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Student::Announcements', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: {
+           email: user.email,
+           password: 'password'
+         }.to_json,
+         headers: headers
+
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/student/announcements' do
+    context '正常系' do
+      let!(:high_school) { create(:high_school) }
+
+      let!(:student) { create(:user, :student, high_school: high_school) }
+      let(:cookie) { login_and_get_cookie(student) }
+
+      let!(:teacher) { create(:user, :teacher, high_school: high_school) }
+      let!(:other_student) { create(:user, :student) }
+
+      let!(:announcements) do
+        create_list(:announcement, 3, :published, publisher: teacher).map do |a|
+          create(:announcement_target, :all_users, announcement: a)
+          a
+        end
+      end
+
+      let!(:draft_announcements) do
+        create_list(:announcement, 3, :draft, publisher: teacher).map do |a|
+          create(:announcement_target, :all_users, announcement: a)
+          a
+        end
+      end
+
+      let!(:teacher_announcements) do
+        create_list(:announcement, 2, :published, publisher: teacher).map do |a|
+          create(
+            :announcement_target,
+            :by_role,
+            announcement: a,
+            user_role_id: teacher.user_role_id
+          )
+          a
+        end
+      end
+
+      let!(:other_school_announcements) do
+        other_school = create(:high_school)
+
+        create_list(:announcement, 2, :published, publisher: teacher).map do |a|
+          create(
+            :announcement_target,
+            :by_school,
+            announcement: a,
+            high_school_id: other_school.id
+          )
+          a
+        end
+      end
+
+      let!(:other_user_announcements) do
+        create_list(:announcement, 2, :published, publisher: teacher).map do |a|
+          create(
+            :announcement_target,
+            :by_user,
+            announcement: a,
+            user_id: other_student.id
+          )
+          a
+        end
+      end
+
+      it '200が返る' do
+        get '/api/v1/student/announcements',
+            headers: headers.merge('Cookie' => cookie)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '最大20件取得できる' do
+        get '/api/v1/student/announcements',
+            headers: headers.merge('Cookie' => cookie)
+
+        json = response.parsed_body
+
+        expect(json['announcements'].size).to eq(3)
+      end
+
+      it 'for_userの対象データが返る' do
+        get '/api/v1/student/announcements',
+            headers: headers.merge('Cookie' => cookie)
+
+        json = response.parsed_body
+
+        returned_ids = json['announcements'].pluck('id')
+
+        expect(returned_ids).to match_array(announcements.map(&:id))
+      end
+
+      it 'draftは返らない' do
+        get '/api/v1/student/announcements',
+            headers: headers.merge('Cookie' => cookie)
+
+        json = response.parsed_body
+
+        returned_ids = json['announcements'].pluck('id')
+
+        expect(returned_ids).not_to include(*draft_announcements.map(&:id))
+      end
+
+      it '教師向けのお知らせは返らない' do
+        get '/api/v1/student/announcements',
+            headers: headers.merge('Cookie' => cookie)
+
+        json = response.parsed_body
+
+        returned_ids = json['announcements'].pluck('id')
+
+        expect(returned_ids).not_to include(*teacher_announcements.map(&:id))
+      end
+
+      it '別高校向けのお知らせは返らない' do
+        get '/api/v1/student/announcements',
+            headers: headers.merge('Cookie' => cookie)
+
+        json = response.parsed_body
+
+        returned_ids = json['announcements'].pluck('id')
+
+        expect(returned_ids).not_to include(*other_school_announcements.map(&:id))
+      end
+
+      it '別ユーザー向けのお知らせは返らない' do
+        get '/api/v1/student/announcements',
+            headers: headers.merge('Cookie' => cookie)
+
+        json = response.parsed_body
+
+        returned_ids = json['announcements'].pluck('id')
+
+        expect(returned_ids).not_to include(*other_user_announcements.map(&:id))
+      end
+
+      it 'meta情報が返る' do
+        get '/api/v1/student/announcements',
+            headers: headers.merge('Cookie' => cookie)
+
+        json = response.parsed_body
+
+        expect(json['meta']['current_page']).to eq(1)
+        expect(json['meta']['total_pages']).to eq(1)
+        expect(json['meta']['total_count']).to eq(3)
+        expect(json['meta']['per_page']).to eq(20)
+      end
+    end
+  end
+
+  describe 'GET /api/v1/student/announcements/:id' do
+    context '正常系' do
+      let!(:high_school) { create(:high_school) }
+
+      let!(:student) { create(:user, :student, high_school: high_school) }
+      let(:cookie) { login_and_get_cookie(student) }
+
+      let!(:teacher) { create(:user, :teacher, high_school: high_school) }
+      let!(:other_student) { create(:user, :student) }
+
+      let!(:announcement) do
+        create(:announcement, :published, publisher: teacher).tap do |a|
+          create(:announcement_target, :all_users, announcement: a)
+        end
+      end
+
+      it '200が返る' do
+        get "/api/v1/student/announcements/#{announcement.id}",
+            headers: headers.merge('Cookie' => cookie)
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '対象のお知らせが取得できる' do
+        get "/api/v1/student/announcements/#{announcement.id}",
+            headers: headers.merge('Cookie' => cookie)
+
+        json = response.parsed_body
+
+        expect(json['id']).to eq(announcement.id)
+        expect(json['title']).to eq(announcement.title)
+        expect(json['content']).to eq(announcement.content)
+      end
+    end
+
+    context '異常系' do
+      let!(:high_school) { create(:high_school) }
+
+      let!(:student) { create(:user, :student, high_school: high_school) }
+      let(:cookie) { login_and_get_cookie(student) }
+
+      let!(:teacher) { create(:user, :teacher, high_school: high_school) }
+
+      it '教師向けのお知らせは404になる' do
+        announcement = create(:announcement, :published, publisher: teacher)
+
+        create(
+          :announcement_target,
+          :by_role,
+          announcement: announcement,
+          user_role_id: teacher.user_role_id
+        )
+
+        get "/api/v1/student/announcements/#{announcement.id}",
+            headers: headers.merge('Cookie' => cookie)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it '別高校向けのお知らせは404になる' do
+        other_school = create(:high_school)
+
+        announcement = create(:announcement, :published, publisher: teacher)
+
+        create(
+          :announcement_target,
+          :by_school,
+          announcement: announcement,
+          high_school_id: other_school.id
+        )
+
+        get "/api/v1/student/announcements/#{announcement.id}",
+            headers: headers.merge('Cookie' => cookie)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it '別ユーザー向けのお知らせは404になる' do
+        other_student = create(:user, :student)
+
+        announcement = create(:announcement, :published, publisher: teacher)
+
+        create(
+          :announcement_target,
+          :by_user,
+          announcement: announcement,
+          user_id: other_student.id
+        )
+
+        get "/api/v1/student/announcements/#{announcement.id}",
+            headers: headers.merge('Cookie' => cookie)
+
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it 'draftは404になる' do
+        announcement = create(:announcement, :draft, publisher: teacher)
+
+        create(
+          :announcement_target,
+          :all_users,
+          announcement: announcement
+        )
+
+        get "/api/v1/student/announcements/#{announcement.id}",
+            headers: headers.merge('Cookie' => cookie)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
https://app.notion.com/p/Rails-API-3652946467fd802796d3c1032e2446d6
<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細

- 生徒向けお知らせ一覧取得APIを実装
- 生徒向けお知らせ詳細取得APIを実装
- Announcement.for_user(current_user) を利用し、対象ユーザーのみがお知らせを取得できるように実装
- 公開済み（published）のお知らせのみ取得するよう実装
- 一覧・詳細APIのRequest Specを追加
- <!--

レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

## 動作確認
対象1spec: 14 examples, 0 failures

- 生徒ユーザーで一覧・詳細APIを実行し、対象のお知らせのみ取得できることを確認
- 対象外（別高校・別ユーザー・教師向け・draft）のお知らせが取得できないことをRequest Specで確認
- ページネーション情報（meta）が返却されることを確認

<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
