### PR TITLE
【Rails】高校詳細タブ用API（学年一覧・お知らせ一覧）

### DIFF
--- a/rails/app/controllers/api/v1/admin/announcements_controller.rb
+++ b/rails/app/controllers/api/v1/admin/announcements_controller.rb
@@ -6,19 +6,27 @@ module Api
       class AnnouncementsController < BaseController
         def index
           school = HighSchool.find(params[:high_school_id])
+          per_page = sanitized_per_page
           announcements = Announcement
                           .joins(:announcement_targets)
                           .where(announcement_targets: { high_school_id: school.id })
                           .includes(:publisher, :announcement_targets)
                           .distinct
                           .order(created_at: :desc, id: :desc)
+                          .page(sanitized_page).per(per_page)
 
           render json: {
             announcements: ActiveModelSerializers::SerializableResource.new(
               announcements,
               each_serializer: ::Admin::AnnouncementSerializer,
               high_school_id: school.id
-            )
+            ),
+            meta: {
+              current_page: announcements.current_page,
+              total_pages: announcements.total_pages,
+              total_count: announcements.total_count,
+              per_page: per_page
+            }
           }
         end
       end

--- a/rails/app/controllers/api/v1/admin/announcements_controller.rb
+++ b/rails/app/controllers/api/v1/admin/announcements_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class AnnouncementsController < BaseController
+        def index
+          school = HighSchool.find(params[:high_school_id])
+          announcements = Announcement
+                          .joins(:announcement_targets)
+                          .where(announcement_targets: { high_school_id: school.id })
+                          .includes(:publisher, :announcement_targets)
+                          .distinct
+                          .order(created_at: :desc)
+
+          render json: {
+            announcements: ActiveModelSerializers::SerializableResource.new(
+              announcements,
+              each_serializer: ::Admin::AnnouncementSerializer
+            )
+          }
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/admin/announcements_controller.rb
+++ b/rails/app/controllers/api/v1/admin/announcements_controller.rb
@@ -16,7 +16,8 @@ module Api
           render json: {
             announcements: ActiveModelSerializers::SerializableResource.new(
               announcements,
-              each_serializer: ::Admin::AnnouncementSerializer
+              each_serializer: ::Admin::AnnouncementSerializer,
+              high_school_id: school.id
             )
           }
         end

--- a/rails/app/controllers/api/v1/admin/announcements_controller.rb
+++ b/rails/app/controllers/api/v1/admin/announcements_controller.rb
@@ -11,7 +11,7 @@ module Api
                           .where(announcement_targets: { high_school_id: school.id })
                           .includes(:publisher, :announcement_targets)
                           .distinct
-                          .order(created_at: :desc)
+                          .order(created_at: :desc, id: :desc)
 
           render json: {
             announcements: ActiveModelSerializers::SerializableResource.new(

--- a/rails/app/controllers/api/v1/admin/grades_controller.rb
+++ b/rails/app/controllers/api/v1/admin/grades_controller.rb
@@ -6,13 +6,20 @@ module Api
       class GradesController < BaseController
         def index
           school = HighSchool.find(params[:high_school_id])
-          grades = school.grades.order(:year)
+          per_page = sanitized_per_page
+          grades = school.grades.order(:year).page(sanitized_page).per(per_page)
 
           render json: {
             grades: ActiveModelSerializers::SerializableResource.new(
               grades,
               each_serializer: ::Admin::GradeSerializer
-            )
+            ),
+            meta: {
+              current_page: grades.current_page,
+              total_pages: grades.total_pages,
+              total_count: grades.total_count,
+              per_page: per_page
+            }
           }
         end
       end

--- a/rails/app/controllers/api/v1/admin/grades_controller.rb
+++ b/rails/app/controllers/api/v1/admin/grades_controller.rb
@@ -6,20 +6,13 @@ module Api
       class GradesController < BaseController
         def index
           school = HighSchool.find(params[:high_school_id])
-          per_page = sanitized_per_page
-          grades = school.grades.order(:year).page(sanitized_page).per(per_page)
+          grades = school.grades.order(:year)
 
           render json: {
             grades: ActiveModelSerializers::SerializableResource.new(
               grades,
               each_serializer: ::Admin::GradeSerializer
-            ),
-            meta: {
-              current_page: grades.current_page,
-              total_pages: grades.total_pages,
-              total_count: grades.total_count,
-              per_page: per_page
-            }
+            )
           }
         end
       end

--- a/rails/app/controllers/api/v1/admin/grades_controller.rb
+++ b/rails/app/controllers/api/v1/admin/grades_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class GradesController < BaseController
+        def index
+          school = HighSchool.find(params[:high_school_id])
+          grades = school.grades.order(:year)
+
+          render json: {
+            grades: ActiveModelSerializers::SerializableResource.new(
+              grades,
+              each_serializer: ::Admin::GradeSerializer
+            )
+          }
+        end
+      end
+    end
+  end
+end

--- a/rails/app/serializers/admin/announcement_serializer.rb
+++ b/rails/app/serializers/admin/announcement_serializer.rb
@@ -10,7 +10,9 @@ module Admin
     end
 
     def targets
-      object.announcement_targets.map do |t|
+      high_school_id = instance_options[:high_school_id]
+
+      object.announcement_targets.select { |t| t.high_school_id == high_school_id }.map do |t|
         {
           id: t.id,
           target_type: t.target_type,

--- a/rails/app/serializers/admin/announcement_serializer.rb
+++ b/rails/app/serializers/admin/announcement_serializer.rb
@@ -9,17 +9,12 @@ module Admin
 
     def targets
       high_school_id = instance_options[:high_school_id]
+      scoped_targets = object.announcement_targets.select { |t| t.high_school_id == high_school_id }
 
-      object.announcement_targets.select { |t| t.high_school_id == high_school_id }.map do |t|
-        {
-          id: t.id,
-          target_type: t.target_type,
-          high_school_id: t.high_school_id,
-          grade_id: t.grade_id,
-          user_role_id: t.user_role_id,
-          user_id: t.user_id
-        }
-      end
+      ActiveModelSerializers::SerializableResource.new(
+        scoped_targets,
+        each_serializer: AnnouncementTargetSerializer
+      )
     end
   end
 end

--- a/rails/app/serializers/admin/announcement_serializer.rb
+++ b/rails/app/serializers/admin/announcement_serializer.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Admin
+  class AnnouncementSerializer < ActiveModel::Serializer
+    attributes :id, :title, :content, :status, :published_at, :scheduled_at,
+               :created_at, :publisher, :targets
+
+    def publisher
+      { id: object.publisher_id, name: object.publisher&.name }
+    end
+
+    def targets
+      object.announcement_targets.map do |t|
+        {
+          id: t.id,
+          target_type: t.target_type,
+          high_school_id: t.high_school_id,
+          grade_id: t.grade_id,
+          user_role_id: t.user_role_id,
+          user_id: t.user_id
+        }
+      end
+    end
+  end
+end

--- a/rails/app/serializers/admin/announcement_serializer.rb
+++ b/rails/app/serializers/admin/announcement_serializer.rb
@@ -3,11 +3,9 @@
 module Admin
   class AnnouncementSerializer < ActiveModel::Serializer
     attributes :id, :title, :content, :status, :published_at, :scheduled_at,
-               :created_at, :publisher, :targets
+               :created_at, :targets
 
-    def publisher
-      { id: object.publisher_id, name: object.publisher&.name }
-    end
+    belongs_to :publisher, serializer: AnnouncementPublisherSerializer
 
     def targets
       high_school_id = instance_options[:high_school_id]

--- a/rails/app/serializers/admin/announcement_target_serializer.rb
+++ b/rails/app/serializers/admin/announcement_target_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Admin
+  class AnnouncementTargetSerializer < ActiveModel::Serializer
+    attributes :id, :target_type, :high_school_id, :grade_id, :user_role_id, :user_id
+  end
+end

--- a/rails/app/serializers/admin/grade_serializer.rb
+++ b/rails/app/serializers/admin/grade_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Admin
+  class GradeSerializer < ActiveModel::Serializer
+    attributes :id, :year, :display_name
+  end
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do
         resources :addresses, only: :index
         resources :high_schools, only: [:index, :show] do
           resources :teachers, only: [:index, :create, :update]
+          resources :grades, only: :index
+          resources :announcements, only: :index
         end
         resources :courses do
           resources :units do

--- a/rails/spec/requests/api/v1/admin/announcements_spec.rb
+++ b/rails/spec/requests/api/v1/admin/announcements_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe 'Api::V1::Admin::Announcements', type: :request do
         expect(response.parsed_body).to have_key('announcements')
       end
 
+      it 'meta にページネーション情報が含まれる' do
+        subject
+        expect(response.parsed_body['meta']).to include(
+          'current_page' => 1,
+          'total_pages' => 1,
+          'total_count' => 1,
+          'per_page' => 20
+        )
+      end
+
       it '各お知らせに必要なフィールドが含まれる' do
         subject
         data = response.parsed_body['announcements'].first

--- a/rails/spec/requests/api/v1/admin/announcements_spec.rb
+++ b/rails/spec/requests/api/v1/admin/announcements_spec.rb
@@ -66,6 +66,16 @@ RSpec.describe 'Api::V1::Admin::Announcements', type: :request do
         expect(data['targets'].first['high_school_id']).to eq(school.id)
       end
 
+      it '他校をターゲットにした行は targets に含まれない' do
+        other_school = create(:high_school)
+        create(:announcement_target, announcement: announcement, target_type: :by_school,
+                                     high_school_id: other_school.id)
+        subject
+        data = response.parsed_body['announcements'].find { |a| a['id'] == announcement.id }
+        school_ids = data['targets'].pluck('high_school_id')
+        expect(school_ids).to all(eq(school.id))
+      end
+
       it 'status が文字列で返される' do
         subject
         data = response.parsed_body['announcements'].first

--- a/rails/spec/requests/api/v1/admin/announcements_spec.rb
+++ b/rails/spec/requests/api/v1/admin/announcements_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Api::V1::Admin::Announcements', type: :request do
         other_school = create(:high_school)
         other_ann = create(:announcement, publisher: publisher)
         create(:announcement_target, announcement: other_ann, target_type: :by_school,
-                                      high_school_id: other_school.id)
+                                     high_school_id: other_school.id)
         subject
         ids = response.parsed_body['announcements'].pluck('id')
         expect(ids).to contain_exactly(announcement.id)

--- a/rails/spec/requests/api/v1/admin/announcements_spec.rb
+++ b/rails/spec/requests/api/v1/admin/announcements_spec.rb
@@ -108,6 +108,16 @@ RSpec.describe 'Api::V1::Admin::Announcements', type: :request do
         ids = response.parsed_body['announcements'].pluck('id')
         expect(ids).to eq([newer.id, announcement.id])
       end
+
+      it 'created_at が同一の場合は id の降順で返される' do
+        same_time = announcement.created_at
+        newer = create(:announcement, publisher: publisher)
+        create(:announcement_target, announcement: newer, target_type: :by_school, high_school_id: school.id)
+        newer.update!(created_at: same_time)
+        subject
+        ids = response.parsed_body['announcements'].pluck('id')
+        expect(ids).to eq([newer.id, announcement.id])
+      end
     end
 
     context '異常系 - 未認証アクセス' do

--- a/rails/spec/requests/api/v1/admin/announcements_spec.rb
+++ b/rails/spec/requests/api/v1/admin/announcements_spec.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Announcements', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/admin/high_schools/:high_school_id/announcements' do
+    context '正常系' do
+      subject do
+        get "/api/v1/admin/high_schools/#{school.id}/announcements",
+            headers: headers.merge('Cookie' => cookie)
+      end
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:publisher)  { create(:user, :admin, high_school: nil, name: '配信者太郎') }
+      let!(:school)     { create(:high_school) }
+      let!(:announcement) do
+        ann = create(:announcement, publisher: publisher)
+        create(:announcement_target, announcement: ann, target_type: :by_school, high_school_id: school.id)
+        ann
+      end
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'announcements キーが含まれる' do
+        subject
+        expect(response.parsed_body).to have_key('announcements')
+      end
+
+      it '各お知らせに必要なフィールドが含まれる' do
+        subject
+        data = response.parsed_body['announcements'].first
+        expect(data.keys).to include(
+          'id', 'title', 'content', 'status', 'published_at', 'scheduled_at',
+          'created_at', 'publisher', 'targets'
+        )
+      end
+
+      it 'publisher に配信者名が含まれる' do
+        subject
+        data = response.parsed_body['announcements'].first
+        expect(data['publisher']['name']).to eq('配信者太郎')
+      end
+
+      it 'targets が配列で返される' do
+        subject
+        data = response.parsed_body['announcements'].first
+        expect(data['targets']).to be_an(Array)
+        expect(data['targets'].first['high_school_id']).to eq(school.id)
+      end
+
+      it 'status が文字列で返される' do
+        subject
+        data = response.parsed_body['announcements'].first
+        expect(data['status']).to eq('draft')
+      end
+
+      it '対象高校をターゲットにしたお知らせのみ返される' do
+        other_school = create(:high_school)
+        other_ann = create(:announcement, publisher: publisher)
+        create(:announcement_target, announcement: other_ann, target_type: :by_school,
+                                      high_school_id: other_school.id)
+        subject
+        ids = response.parsed_body['announcements'].pluck('id')
+        expect(ids).to contain_exactly(announcement.id)
+      end
+
+      it '全体配信のお知らせは含まれない' do
+        all_ann = create(:announcement, publisher: publisher)
+        create(:announcement_target, :all_users, announcement: all_ann)
+        subject
+        ids = response.parsed_body['announcements'].pluck('id')
+        expect(ids).not_to include(all_ann.id)
+      end
+
+      it 'created_at の降順で返される' do
+        newer = create(:announcement, publisher: publisher)
+        create(:announcement_target, announcement: newer, target_type: :by_school, high_school_id: school.id)
+        newer.update!(created_at: 1.day.from_now)
+        subject
+        ids = response.parsed_body['announcements'].pluck('id')
+        expect(ids).to eq([newer.id, announcement.id])
+      end
+    end
+
+    context '異常系 - 未認証アクセス' do
+      let!(:school) { create(:high_school) }
+
+      it '401が返される' do
+        get "/api/v1/admin/high_schools/#{school.id}/announcements", headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+      let!(:school)       { create(:high_school) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(student_user)
+        get "/api/v1/admin/high_schools/#{school.id}/announcements",
+            headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context '異常系 - 存在しない high_school_id' do
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it '404が返される' do
+        get '/api/v1/admin/high_schools/0/announcements',
+            headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/admin/announcements_spec.rb
+++ b/rails/spec/requests/api/v1/admin/announcements_spec.rb
@@ -25,8 +25,10 @@ RSpec.describe 'Api::V1::Admin::Announcements', type: :request do
       end
 
       let!(:admin_user) { create(:user, :admin, high_school: nil) }
-      let!(:publisher)  { create(:user, :admin, high_school: nil, name: '配信者太郎') }
-      let!(:school)     { create(:high_school) }
+      let!(:publisher) do
+        create(:user, :admin, high_school: nil, name: '配信者太郎', name_kana: 'ハイシンシャタロウ')
+      end
+      let!(:school) { create(:high_school) }
       let!(:announcement) do
         ann = create(:announcement, publisher: publisher)
         create(:announcement_target, announcement: ann, target_type: :by_school, high_school_id: school.id)
@@ -57,6 +59,7 @@ RSpec.describe 'Api::V1::Admin::Announcements', type: :request do
         subject
         data = response.parsed_body['announcements'].first
         expect(data['publisher']['name']).to eq('配信者太郎')
+        expect(data['publisher']['name_kana']).to eq('ハイシンシャタロウ')
       end
 
       it 'targets が配列で返される' do

--- a/rails/spec/requests/api/v1/admin/grades_spec.rb
+++ b/rails/spec/requests/api/v1/admin/grades_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe 'Api::V1::Admin::Grades', type: :request do
         expect(response.parsed_body).to have_key('grades')
       end
 
+      it 'meta にページネーション情報が含まれる' do
+        subject
+        expect(response.parsed_body['meta']).to include(
+          'current_page' => 1,
+          'total_pages' => 1,
+          'total_count' => 2,
+          'per_page' => 20
+        )
+      end
+
       it '各学年に必要なフィールドが含まれる' do
         subject
         grade_data = response.parsed_body['grades'].first

--- a/rails/spec/requests/api/v1/admin/grades_spec.rb
+++ b/rails/spec/requests/api/v1/admin/grades_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::Grades', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/admin/high_schools/:high_school_id/grades' do
+    context '正常系' do
+      subject do
+        get "/api/v1/admin/high_schools/#{school.id}/grades",
+            headers: headers.merge('Cookie' => cookie)
+      end
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:school)     { create(:high_school) }
+      let!(:grade2)     { create(:grade, high_school: school, year: 2) }
+      let!(:grade1)     { create(:grade, high_school: school, year: 1) }
+      let(:cookie)      { login_and_get_cookie(admin_user) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'grades キーが含まれる' do
+        subject
+        expect(response.parsed_body).to have_key('grades')
+      end
+
+      it '各学年に必要なフィールドが含まれる' do
+        subject
+        grade_data = response.parsed_body['grades'].first
+        expect(grade_data.keys).to include('id', 'year', 'display_name')
+      end
+
+      it 'display_name が正しく返される' do
+        subject
+        grade_data = response.parsed_body['grades'].find { |g| g['id'] == grade1.id }
+        expect(grade_data['display_name']).to eq(grade1.display_name)
+      end
+
+      it 'year の昇順で返される' do
+        subject
+        years = response.parsed_body['grades'].pluck('year')
+        expect(years).to eq([1, 2])
+      end
+
+      it '対象高校の学年のみ返される' do
+        other_school = create(:high_school)
+        create(:grade, high_school: other_school, year: 1)
+        subject
+        ids = response.parsed_body['grades'].pluck('id')
+        expect(ids).to contain_exactly(grade1.id, grade2.id)
+      end
+    end
+
+    context '異常系 - 未認証アクセス' do
+      let!(:school) { create(:high_school) }
+
+      it '401が返される' do
+        get "/api/v1/admin/high_schools/#{school.id}/grades", headers: headers
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context '異常系 - 管理者以外のアクセス（生徒）' do
+      let!(:student_user) { create(:user) }
+      let!(:school)       { create(:high_school) }
+
+      it '403が返される' do
+        cookie = login_and_get_cookie(student_user)
+        get "/api/v1/admin/high_schools/#{school.id}/grades",
+            headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context '異常系 - 存在しない high_school_id' do
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it '404が返される' do
+        get '/api/v1/admin/high_schools/0/grades',
+            headers: headers.merge('Cookie' => cookie)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/admin/grades_spec.rb
+++ b/rails/spec/requests/api/v1/admin/grades_spec.rb
@@ -40,14 +40,14 @@ RSpec.describe 'Api::V1::Admin::Grades', type: :request do
         expect(response.parsed_body).to have_key('grades')
       end
 
-      it 'meta にページネーション情報が含まれる' do
+      it 'meta は含まれない' do
         subject
-        expect(response.parsed_body['meta']).to include(
-          'current_page' => 1,
-          'total_pages' => 1,
-          'total_count' => 2,
-          'per_page' => 20
-        )
+        expect(response.parsed_body).not_to have_key('meta')
+      end
+
+      it '全件が返される' do
+        subject
+        expect(response.parsed_body['grades'].size).to eq(2)
       end
 
       it '各学年に必要なフィールドが含まれる' do


### PR DESCRIPTION
## 概要

高校詳細画面の各タブに必要な管理者向けAPIを実装します（issue #62 ）。

対象は以下の2つのGETエンドポイントです。

- `GET /api/v1/admin/high_schools/:high_school_id/grades` — 学年一覧
- `GET /api/v1/admin/high_schools/:high_school_id/announcements` — この高校向けお知らせ一覧

## 詳細

- コントローラは既存の `Api::V1::Admin::BaseController` を継承し、認証（Devise / 未認証401）・認可（Pundit `admin?` / 権限外403）・404 は上位の共通処理に委ねています（教師管理APIと同じ流儀）。
- シリアライザは ActiveModelSerializers。既存パターンに合わせています。
- レビュー指摘を反映し、以下に特に注意しています。
  - **お知らせの `targets` は「この高校向けのターゲット行」のみ返します。** 1件のお知らせが複数高校をターゲットにしていても他校の配信先情報（grade_id/user_id等）は露出しません。
  - **`publisher` は既存の `AnnouncementPublisherSerializer` を再利用**（`name_kana` 含む）。
  - **並び順は `created_at DESC, id DESC`** とし、同時刻レコードでも順序が決定的です（teacher側APIに準拠）。
  - **ページネーション（`meta`）を付与**し、既存の一覧API（high_schools / courses / admins / teacher announcements）と統一。

レビュアーへ: お知らせの絞り込みは「`announcement_targets.high_school_id = :id` にマッチするお知らせのみ」という解釈です（全体配信 `all_users` は含めません）。この解釈で問題ないかご確認ください。

## 動作確認

- 対象2spec: 25 examples, 0 failures
- 全体: 677 examples, 0 failures, 2 pending（pending は既存の未実装プレースホルダ）
- RuboCop: 288 files, no offenses

実際のレスポンス例（管理者でログインし、デモ高校に対してリクエスト）:

`GET /api/v1/admin/high_schools/:id/grades`

```json
{
  "grades": [
    { "id": 3, "year": 1, "display_name": "高１生" },
    { "id": 4, "year": 2, "display_name": "高２生" }
  ],
  "meta": { "current_page": 1, "total_pages": 1, "total_count": 2, "per_page": 20 }
}
```

`GET /api/v1/admin/high_schools/:id/announcements`

※このお知らせは「デモ高校(id:3)」と「別高校」の両方をターゲットにしていますが、`targets` にはデモ高校向けの2件のみが返り、別高校向けのターゲット行は含まれていません（情報漏洩対策）。

```json
{
  "announcements": [
    {
      "id": 1,
      "title": "面談のお知らせ",
      "content": "来週面談を行います。",
      "status": "draft",
      "published_at": null,
      "scheduled_at": null,
      "created_at": "2026-07-01T17:42:19.130+09:00",
      "targets": [
        { "id": 1, "target_type": "by_school", "high_school_id": 3, "grade_id": null, "user_role_id": null, "user_id": null },
        { "id": 2, "target_type": "by_grade", "high_school_id": 3, "grade_id": 3, "user_role_id": null, "user_id": null }
      ],
      "publisher": { "id": 2, "name": "配信者太郎", "name_kana": "ハイシンシャタロウ" }
    }
  ],
  "meta": { "current_page": 1, "total_pages": 1, "total_count": 1, "per_page": 20 }
}
```

異常系も spec で確認済み: 未認証 401 / 管理者以外（生徒）403 / 存在しない high_school_id 404。

## その他

新規ライブラリの導入はありません。

## 参考情報

- issue #62（高校詳細タブ用API）
