### PR TITLE
[Next.js]パスワード変更画面

### DIFF
--- a/frontend/app/(main)/password/reset/[token]/page.tsx
+++ b/frontend/app/(main)/password/reset/[token]/page.tsx
@@ -1,0 +1,12 @@
+import { PasswordReset } from "@/features/PasswordReset";
+
+type Props = {
+  params: Promise<{
+    token: string;
+  }>;
+};
+
+export default async function PasswordResetPage({ params }: Props) {
+  const { token } = await params;
+  return <PasswordReset token={token} />;
+}

--- a/frontend/app/(main)/password/reset/page.tsx
+++ b/frontend/app/(main)/password/reset/page.tsx
@@ -1,0 +1,5 @@
+import { PasswordResetRequest } from "@/features/PasswordResetRequest";
+
+export default function PasswordResetRequestPage() {
+  return <PasswordResetRequest />;
+}

--- a/frontend/app/api/auth/password-reset-request/route.ts
+++ b/frontend/app/api/auth/password-reset-request/route.ts
@@ -2,24 +2,28 @@ import { apiFetch } from "@/libs/server/apiFetch";
 import { NextResponse } from "next/server";
 
 export async function POST(req: Request) {
-    const body = await req.json();
-    const email = body.email;
+  const body = await req.json();
+  const email = body.email;
 
-    if (!email) {
-        return NextResponse.json(
-            { errors: ["メールアドレスを入力してください"] },
-            { status: 422 },
-        );
-    }
+  if (!email) {
+    return NextResponse.json(
+      { errors: ["メールアドレスを入力してください"] },
+      { status: 422 },
+    );
+  }
 
-    const receivedRequest = await apiFetch(`/api/v1/password/reset/request`,{
-        method: "POST",
-        body: JSON.stringify({email}),
+  const receivedRequest = await apiFetch(`/api/v1/password/reset/request`, {
+    method: "POST",
+    body: JSON.stringify({ email }),
+  });
+
+  if (!receivedRequest.response.ok) {
+    return NextResponse.json(receivedRequest.data, {
+      status: receivedRequest.response.status,
     });
+  }
 
-    if (!receivedRequest.response.ok) {
-        return NextResponse.json(receivedRequest.data, { status: receivedRequest.response.status });
-    }
-
-    return NextResponse.json(receivedRequest.data, { status: receivedRequest.response.status });
+  return NextResponse.json(receivedRequest.data, {
+    status: receivedRequest.response.status,
+  });
 }

--- a/frontend/app/api/auth/password-reset-request/route.ts
+++ b/frontend/app/api/auth/password-reset-request/route.ts
@@ -1,0 +1,25 @@
+import { apiFetch } from "@/libs/server/apiFetch";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+    const body = await req.json();
+    const email = body.email;
+
+    if (!email) {
+        return NextResponse.json(
+            { errors: ["メールアドレスを入力してください"] },
+            { status: 422 },
+        );
+    }
+
+    const receivedRequest = await apiFetch(`/api/v1/password/reset/request`,{
+        method: "POST",
+        body: JSON.stringify({email}),
+    });
+
+    if (!receivedRequest.response.ok) {
+        return NextResponse.json(receivedRequest.data, { status: receivedRequest.response.status });
+    }
+
+    return NextResponse.json(receivedRequest.data, { status: receivedRequest.response.status });
+}

--- a/frontend/app/api/auth/password-reset/route.ts
+++ b/frontend/app/api/auth/password-reset/route.ts
@@ -1,0 +1,25 @@
+import { apiFetch } from "@/libs/server/apiFetch";
+import { NextResponse } from "next/server";
+
+export async function PATCH(req: Request) {
+  const body = await req.json();
+  const payload = body.password_reset;
+
+  if (!payload) {
+    return NextResponse.json(
+      { errors: ["トークン、パスワードまたは確認用パスワードがありません"] },
+      { status: 422 },
+    );
+  }
+
+  const response = await apiFetch("/api/v1/password/reset", {
+    method: "PATCH",
+    body: JSON.stringify({
+      password_reset: payload,
+    }),
+  });
+
+  return NextResponse.json(response.data, {
+    status: response.response.status,
+  });
+}

--- a/frontend/app/api/auth/password-verify/route.ts
+++ b/frontend/app/api/auth/password-verify/route.ts
@@ -1,0 +1,26 @@
+import { apiFetch } from "@/libs/server/apiFetch";
+import { NextResponse } from "next/server";
+
+export async function POST(req: Request) {
+  const body = await req.json();
+
+  const resetPasswordToken = body.reset_password_token;
+
+  if (!resetPasswordToken) {
+    return NextResponse.json(
+      { errors: ["トークンがありません"] },
+      { status: 422 },
+    );
+  }
+
+  const response = await apiFetch("/api/v1/password/verify", {
+    method: "POST",
+    body: JSON.stringify({
+      reset_password_token: resetPasswordToken,
+    }),
+  });
+
+  return NextResponse.json(response.data, {
+    status: response.response.status,
+  });
+}

--- a/frontend/components/Footer/index.tsx
+++ b/frontend/components/Footer/index.tsx
@@ -13,7 +13,7 @@ import Link from "next/link";
 export const Footer = (): React.JSX.Element => {
   const theme = useTheme();
   const pathName = usePathname();
-  const hidden = pathName === "/login" || pathName.endsWith("/signup");
+  const hidden = pathName === "/login" || pathName.endsWith("/signup") || pathName.startsWith("/password/reset");
   const isAdmin = pathName.startsWith("/admin");
 
   const icons = [

--- a/frontend/components/Footer/index.tsx
+++ b/frontend/components/Footer/index.tsx
@@ -13,7 +13,10 @@ import Link from "next/link";
 export const Footer = (): React.JSX.Element => {
   const theme = useTheme();
   const pathName = usePathname();
-  const hidden = pathName === "/login" || pathName.endsWith("/signup") || pathName.startsWith("/password/reset");
+  const hidden =
+    pathName === "/login" ||
+    pathName.endsWith("/signup") ||
+    pathName.startsWith("/password/reset");
   const isAdmin = pathName.startsWith("/admin");
 
   const icons = [

--- a/frontend/components/PrimaryCta/index.tsx
+++ b/frontend/components/PrimaryCta/index.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Button } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material";
+import Link from "next/link";
+import { ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  href?: string;
+  onClick?: () => void;
+  /** 主ボタン(塗り) か 副ボタン(枠) か */
+  variant?: "contained" | "outlined";
+  fullWidth?: boolean;
+  type?: "button" | "submit";
+  disabled?: boolean;
+  startIcon?: ReactNode;
+  sx?: SxProps<Theme>;
+};
+
+/** 全幅・大きめの主要 CTA。href があれば Link、なければ onClick ボタン。 */
+export const PrimaryCta = ({
+  children,
+  href,
+  onClick,
+  variant = "contained",
+  fullWidth = true,
+  type = "button",
+  disabled,
+  startIcon,
+  sx,
+}: Props): React.JSX.Element => {
+  const common = {
+    size: "large" as const,
+    variant,
+    fullWidth,
+    disabled,
+    startIcon,
+    sx: { fontWeight: 800, ...sx },
+  };
+
+  if (href) {
+    return (
+      <Button LinkComponent={Link} href={href} {...common}>
+        {children}
+      </Button>
+    );
+  }
+
+  return (
+    <Button type={type} onClick={onClick} {...common}>
+      {children}
+    </Button>
+  );
+};

--- a/frontend/features/Login/index.tsx
+++ b/frontend/features/Login/index.tsx
@@ -123,7 +123,7 @@ export const Login = (): React.JSX.Element => {
               </Button>
             </Box>
             <Box sx={{ width: "100%", textAlign: "center" }}>
-              <Link href="/password-reset">パスワードをお忘れの方はこちら</Link>
+              <Link href="/password/reset">パスワードをお忘れの方はこちら</Link>
             </Box>
           </Box>
         </Box>

--- a/frontend/features/PasswordReset/Presenter.tsx
+++ b/frontend/features/PasswordReset/Presenter.tsx
@@ -4,6 +4,8 @@ import {
   Alert,
   Box,
   CircularProgress,
+  IconButton,
+  InputAdornment,
   TextField,
   Typography,
 } from "@mui/material";
@@ -12,6 +14,8 @@ import { FieldErrors, UseFormRegister } from "react-hook-form";
 
 import { PrimaryCta } from "@/components/PrimaryCta";
 import { NewPasswordForm } from "./types";
+import { Dispatch, SetStateAction } from "react";
+import { Visibility, VisibilityOff } from "@mui/icons-material";
 
 type Props = {
   verifying: boolean;
@@ -21,6 +25,10 @@ type Props = {
   errorMessage: string;
   password?: string;
   onSubmit: () => void;
+  showPassword: boolean;
+  showConfirmPassword: boolean;
+  toggeleShowPassword: Dispatch<SetStateAction<boolean>>;
+  toggeleShowConfirmPassword: Dispatch<SetStateAction<boolean>>;
 };
 
 export const Presenter = ({
@@ -31,6 +39,10 @@ export const Presenter = ({
   errorMessage,
   password,
   onSubmit,
+  showPassword,
+  showConfirmPassword,
+  toggeleShowPassword,
+  toggeleShowConfirmPassword
 }: Props) => {
   if (verifying) {
     return (
@@ -128,7 +140,7 @@ export const Presenter = ({
 
                 <TextField
                   fullWidth
-                  type="password"
+                  type={showPassword ? "text" : "password"}
                   {...register("password", {
                     required: "パスワードを入力してください",
                     minLength: {
@@ -136,6 +148,21 @@ export const Presenter = ({
                       message: "8文字以上で入力してください",
                     },
                   })}
+                slotProps={{
+                  input: {
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          aria-label="toggle password visibility"
+                          onClick={() => toggeleShowPassword((prev) => !prev)}
+                          edge="end"
+                        >
+                          {showPassword ? <VisibilityOff /> : <Visibility />}
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  },
+                }}
                   error={!!errors.password}
                   helperText={errors.password?.message}
                 />
@@ -148,12 +175,27 @@ export const Presenter = ({
 
                 <TextField
                   fullWidth
-                  type="password"
+                  type={showConfirmPassword ? "text" : "password"}
                   {...register("password_confirmation", {
                     required: "確認用パスワードを入力してください",
                     validate: (value) =>
                       value === password || "パスワードが一致しません",
                   })}
+                slotProps={{
+                  input: {
+                    endAdornment: (
+                      <InputAdornment position="end">
+                        <IconButton
+                          aria-label="toggle password visibility"
+                          onClick={() => toggeleShowConfirmPassword((prev) => !prev)}
+                          edge="end"
+                        >
+                          {showPassword ? <VisibilityOff /> : <Visibility />}
+                        </IconButton>
+                      </InputAdornment>
+                    ),
+                  },
+                }}
                   error={!!errors.password_confirmation}
                   helperText={errors.password_confirmation?.message}
                 />

--- a/frontend/features/PasswordReset/Presenter.tsx
+++ b/frontend/features/PasswordReset/Presenter.tsx
@@ -192,7 +192,7 @@ export const Presenter = ({
                             }
                             edge="end"
                           >
-                            {showPassword ? <VisibilityOff /> : <Visibility />}
+                            {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
                           </IconButton>
                         </InputAdornment>
                       ),

--- a/frontend/features/PasswordReset/Presenter.tsx
+++ b/frontend/features/PasswordReset/Presenter.tsx
@@ -42,7 +42,7 @@ export const Presenter = ({
   showPassword,
   showConfirmPassword,
   toggeleShowPassword,
-  toggeleShowConfirmPassword
+  toggeleShowConfirmPassword,
 }: Props) => {
   if (verifying) {
     return (
@@ -148,21 +148,21 @@ export const Presenter = ({
                       message: "8文字以上で入力してください",
                     },
                   })}
-                slotProps={{
-                  input: {
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        <IconButton
-                          aria-label="toggle password visibility"
-                          onClick={() => toggeleShowPassword((prev) => !prev)}
-                          edge="end"
-                        >
-                          {showPassword ? <VisibilityOff /> : <Visibility />}
-                        </IconButton>
-                      </InputAdornment>
-                    ),
-                  },
-                }}
+                  slotProps={{
+                    input: {
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <IconButton
+                            aria-label="toggle password visibility"
+                            onClick={() => toggeleShowPassword((prev) => !prev)}
+                            edge="end"
+                          >
+                            {showPassword ? <VisibilityOff /> : <Visibility />}
+                          </IconButton>
+                        </InputAdornment>
+                      ),
+                    },
+                  }}
                   error={!!errors.password}
                   helperText={errors.password?.message}
                 />
@@ -181,21 +181,23 @@ export const Presenter = ({
                     validate: (value) =>
                       value === password || "パスワードが一致しません",
                   })}
-                slotProps={{
-                  input: {
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        <IconButton
-                          aria-label="toggle password visibility"
-                          onClick={() => toggeleShowConfirmPassword((prev) => !prev)}
-                          edge="end"
-                        >
-                          {showPassword ? <VisibilityOff /> : <Visibility />}
-                        </IconButton>
-                      </InputAdornment>
-                    ),
-                  },
-                }}
+                  slotProps={{
+                    input: {
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <IconButton
+                            aria-label="toggle password visibility"
+                            onClick={() =>
+                              toggeleShowConfirmPassword((prev) => !prev)
+                            }
+                            edge="end"
+                          >
+                            {showPassword ? <VisibilityOff /> : <Visibility />}
+                          </IconButton>
+                        </InputAdornment>
+                      ),
+                    },
+                  }}
                   error={!!errors.password_confirmation}
                   helperText={errors.password_confirmation?.message}
                 />

--- a/frontend/features/PasswordReset/Presenter.tsx
+++ b/frontend/features/PasswordReset/Presenter.tsx
@@ -27,6 +27,7 @@ type Props = {
   onSubmit: () => void;
   showPassword: boolean;
   showConfirmPassword: boolean;
+  isSubmitting: boolean;
   toggeleShowPassword: Dispatch<SetStateAction<boolean>>;
   toggeleShowConfirmPassword: Dispatch<SetStateAction<boolean>>;
 };
@@ -41,6 +42,7 @@ export const Presenter = ({
   onSubmit,
   showPassword,
   showConfirmPassword,
+  isSubmitting,
   toggeleShowPassword,
   toggeleShowConfirmPassword,
 }: Props) => {
@@ -203,7 +205,7 @@ export const Presenter = ({
                 />
               </Box>
 
-              <PrimaryCta type="submit">パスワードを更新する</PrimaryCta>
+              <PrimaryCta type="submit" disabled={isSubmitting}>パスワードを更新する</PrimaryCta>
 
               <Box sx={{ textAlign: "center", mt: 3 }}>
                 <Link href="/login">ログインへ戻る</Link>

--- a/frontend/features/PasswordReset/Presenter.tsx
+++ b/frontend/features/PasswordReset/Presenter.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  TextField,
+  Typography,
+} from "@mui/material";
+import Link from "next/link";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+import { PrimaryCta } from "@/components/PrimaryCta";
+import { NewPasswordForm } from "./types";
+
+type Props = {
+  verifying: boolean;
+  tokenValid: boolean;
+  register: UseFormRegister<NewPasswordForm>;
+  errors: FieldErrors<NewPasswordForm>;
+  errorMessage: string;
+  password?: string;
+  onSubmit: () => void;
+};
+
+export const Presenter = ({
+  verifying,
+  tokenValid,
+  register,
+  errors,
+  errorMessage,
+  password,
+  onSubmit,
+}: Props) => {
+  if (verifying) {
+    return (
+      <Box
+        sx={{
+          minHeight: "100vh",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        px: 2,
+      }}
+    >
+      <Box sx={{ width: "100%", maxWidth: 480 }}>
+        {!tokenValid ? (
+          <>
+            <Typography
+              variant="h4"
+              component="h1"
+              sx={{
+                fontWeight: "bold",
+                textAlign: "center",
+                mb: 2,
+              }}
+            >
+              リンクが無効です
+            </Typography>
+
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              textAlign="center"
+              sx={{ mb: 4 }}
+            >
+              このリンクは無効、または有効期限が切れています。
+              <br />
+              お手数ですが、もう一度パスワード再設定を行ってください。
+            </Typography>
+
+            <PrimaryCta href="/password/reset">
+              パスワード再設定をやり直す
+            </PrimaryCta>
+
+            <Box sx={{ textAlign: "center", mt: 3 }}>
+              <Link href="/login">ログインへ戻る</Link>
+            </Box>
+          </>
+        ) : (
+          <>
+            <Typography
+              variant="h4"
+              component="h1"
+              sx={{
+                fontWeight: "bold",
+                textAlign: "center",
+                mb: 1,
+              }}
+            >
+              パスワード再設定
+            </Typography>
+
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              textAlign="center"
+              sx={{ mb: 4 }}
+            >
+              新しいパスワードを入力してください。
+            </Typography>
+
+            {errorMessage && (
+              <Alert severity="error" sx={{ mb: 3 }}>
+                {errorMessage}
+              </Alert>
+            )}
+
+            <Box component="form" onSubmit={onSubmit} noValidate>
+              <Box sx={{ mb: 3 }}>
+                <Typography sx={{ mb: 1, fontWeight: "bold" }}>
+                  新しいパスワード
+                </Typography>
+
+                <TextField
+                  fullWidth
+                  type="password"
+                  {...register("password", {
+                    required: "パスワードを入力してください",
+                    minLength: {
+                      value: 8,
+                      message: "8文字以上で入力してください",
+                    },
+                  })}
+                  error={!!errors.password}
+                  helperText={errors.password?.message}
+                />
+              </Box>
+
+              <Box sx={{ mb: 3 }}>
+                <Typography sx={{ mb: 1, fontWeight: "bold" }}>
+                  新しいパスワード（確認）
+                </Typography>
+
+                <TextField
+                  fullWidth
+                  type="password"
+                  {...register("password_confirmation", {
+                    required: "確認用パスワードを入力してください",
+                    validate: (value) =>
+                      value === password || "パスワードが一致しません",
+                  })}
+                  error={!!errors.password_confirmation}
+                  helperText={errors.password_confirmation?.message}
+                />
+              </Box>
+
+              <PrimaryCta type="submit">パスワードを更新する</PrimaryCta>
+
+              <Box sx={{ textAlign: "center", mt: 3 }}>
+                <Link href="/login">ログインへ戻る</Link>
+              </Box>
+            </Box>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/features/PasswordReset/Presenter.tsx
+++ b/frontend/features/PasswordReset/Presenter.tsx
@@ -194,7 +194,11 @@ export const Presenter = ({
                             }
                             edge="end"
                           >
-                            {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+                            {showConfirmPassword ? (
+                              <VisibilityOff />
+                            ) : (
+                              <Visibility />
+                            )}
                           </IconButton>
                         </InputAdornment>
                       ),
@@ -205,7 +209,9 @@ export const Presenter = ({
                 />
               </Box>
 
-              <PrimaryCta type="submit" disabled={isSubmitting}>パスワードを更新する</PrimaryCta>
+              <PrimaryCta type="submit" disabled={isSubmitting}>
+                パスワードを更新する
+              </PrimaryCta>
 
               <Box sx={{ textAlign: "center", mt: 3 }}>
                 <Link href="/login">ログインへ戻る</Link>

--- a/frontend/features/PasswordReset/hooks/useSubmit.ts
+++ b/frontend/features/PasswordReset/hooks/useSubmit.ts
@@ -11,7 +11,11 @@ type SubmitProps = {
   setIsSubmitting: (b: boolean) => void;
 };
 
-export const useSubmit = ({ token, setErrorMessage, setIsSubmitting }: SubmitProps) => {
+export const useSubmit = ({
+  token,
+  setErrorMessage,
+  setIsSubmitting,
+}: SubmitProps) => {
   const router = useRouter();
 
   const onSubmit: SubmitHandler<NewPasswordForm> = async (data) => {

--- a/frontend/features/PasswordReset/hooks/useSubmit.ts
+++ b/frontend/features/PasswordReset/hooks/useSubmit.ts
@@ -1,0 +1,40 @@
+"use client";
+
+import { SubmitHandler } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { NewPasswordForm } from "../types";
+import { apiClient } from "@/libs/http/apiClient";
+
+type SubmitProps = {
+  token: string;
+  setErrorMessage: (m: string) => void;
+};
+
+export const useSubmit = ({ token, setErrorMessage }: SubmitProps) => {
+  const router = useRouter();
+
+  const onSubmit: SubmitHandler<NewPasswordForm> = async (data) => {
+    setErrorMessage("");
+    try {
+      await updatePassword(token, data);
+      router.push("/login?reset=done");
+    } catch (e) {
+      console.error("パスワード更新に失敗", e);
+      setErrorMessage(
+        "パスワードの更新に失敗しました。リンクの有効期限が切れている可能性があります。",
+      );
+    }
+  };
+
+  return { onSubmit };
+};
+
+const updatePassword = async (token: string, data: NewPasswordForm) => {
+  await apiClient.patch("/api/auth/password-reset", {
+    password_reset: {
+      reset_password_token: token,
+      password: data.password,
+      password_confirmation: data.password_confirmation,
+    },
+  });
+};

--- a/frontend/features/PasswordReset/hooks/useSubmit.ts
+++ b/frontend/features/PasswordReset/hooks/useSubmit.ts
@@ -8,13 +8,16 @@ import { apiClient } from "@/libs/http/apiClient";
 type SubmitProps = {
   token: string;
   setErrorMessage: (m: string) => void;
+  setIsSubmitting: (b: boolean) => void;
 };
 
-export const useSubmit = ({ token, setErrorMessage }: SubmitProps) => {
+export const useSubmit = ({ token, setErrorMessage, setIsSubmitting }: SubmitProps) => {
   const router = useRouter();
 
   const onSubmit: SubmitHandler<NewPasswordForm> = async (data) => {
     setErrorMessage("");
+    setIsSubmitting(true);
+
     try {
       await updatePassword(token, data);
       router.push("/login?reset=done");
@@ -23,6 +26,8 @@ export const useSubmit = ({ token, setErrorMessage }: SubmitProps) => {
       setErrorMessage(
         "パスワードの更新に失敗しました。リンクの有効期限が切れている可能性があります。",
       );
+    } finally {
+      setIsSubmitting(false);
     }
   };
 

--- a/frontend/features/PasswordReset/hooks/useVerifyToken.ts
+++ b/frontend/features/PasswordReset/hooks/useVerifyToken.ts
@@ -1,11 +1,6 @@
 import { useEffect, useState } from "react";
 import { apiClient } from "@/libs/http/apiClient";
 
-export type NewPasswordForm = {
-  password: string;
-  password_confirmation: string;
-};
-
 type VerifyState = {
   verifying: boolean;
   tokenValid: boolean;

--- a/frontend/features/PasswordReset/hooks/useVerifyToken.ts
+++ b/frontend/features/PasswordReset/hooks/useVerifyToken.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from "react";
+import { apiClient } from "@/libs/http/apiClient";
+
+export type NewPasswordForm = {
+  password: string;
+  password_confirmation: string;
+};
+
+type VerifyState = {
+  verifying: boolean;
+  tokenValid: boolean;
+};
+
+/** マウント時にメールのトークンを検証する。 */
+export const useVerifyToken = (token: string): VerifyState => {
+  const [verifying, setVerifying] = useState(true);
+  const [tokenValid, setTokenValid] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      if (!token) {
+        if (active) {
+          setTokenValid(false);
+          setVerifying(false);
+        }
+        return;
+      }
+      try {
+        await verifyResetToken(token);
+        if (active) setTokenValid(true);
+      } catch (e) {
+        console.error("トークン検証に失敗", e);
+        if (active) setTokenValid(false);
+      } finally {
+        if (active) setVerifying(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
+  return { verifying, tokenValid };
+};
+
+const verifyResetToken = async (token: string) => {
+  console.log("verify start", token);
+  const res = await apiClient.post("/api/auth/password-verify", {
+    reset_password_token: token,
+  });
+
+  console.log(res);
+
+  return res;
+};

--- a/frontend/features/PasswordReset/hooks/useVerifyToken.ts
+++ b/frontend/features/PasswordReset/hooks/useVerifyToken.ts
@@ -40,12 +40,9 @@ export const useVerifyToken = (token: string): VerifyState => {
 };
 
 const verifyResetToken = async (token: string) => {
-  console.log("verify start", token);
   const res = await apiClient.post("/api/auth/password-verify", {
     reset_password_token: token,
   });
-
-  console.log(res);
 
   return res;
 };

--- a/frontend/features/PasswordReset/index.tsx
+++ b/frontend/features/PasswordReset/index.tsx
@@ -14,6 +14,8 @@ type Props = {
 export const PasswordReset = ({ token }: Props): React.JSX.Element => {
   const { verifying, tokenValid } = useVerifyToken(token);
   const [errorMessage, setErrorMessage] = useState("");
+  const [showPassword, setShowPassword] = useState<boolean>(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState<boolean>(false);
   const {
     register,
     handleSubmit,
@@ -31,6 +33,10 @@ export const PasswordReset = ({ token }: Props): React.JSX.Element => {
       errorMessage={errorMessage}
       password={watch("password")}
       onSubmit={handleSubmit(onSubmit)}
+      showPassword={showPassword}
+      showConfirmPassword={showConfirmPassword}
+      toggeleShowPassword={setShowPassword}
+      toggeleShowConfirmPassword={setShowConfirmPassword}
     />
   );
 };

--- a/frontend/features/PasswordReset/index.tsx
+++ b/frontend/features/PasswordReset/index.tsx
@@ -15,7 +15,8 @@ export const PasswordReset = ({ token }: Props): React.JSX.Element => {
   const { verifying, tokenValid } = useVerifyToken(token);
   const [errorMessage, setErrorMessage] = useState("");
   const [showPassword, setShowPassword] = useState<boolean>(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState<boolean>(false);
+  const [showConfirmPassword, setShowConfirmPassword] =
+    useState<boolean>(false);
   const {
     register,
     handleSubmit,

--- a/frontend/features/PasswordReset/index.tsx
+++ b/frontend/features/PasswordReset/index.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { Presenter } from "./Presenter";
+import { useVerifyToken } from "./hooks/useVerifyToken";
+import { NewPasswordForm } from "./types";
+import { useSubmit } from "../PasswordReset/hooks/useSubmit";
+
+type Props = {
+  token: string;
+};
+
+export const PasswordReset = ({ token }: Props): React.JSX.Element => {
+  const { verifying, tokenValid } = useVerifyToken(token);
+  const [errorMessage, setErrorMessage] = useState("");
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<NewPasswordForm>();
+  const { onSubmit } = useSubmit({ token, setErrorMessage });
+
+  return (
+    <Presenter
+      verifying={verifying}
+      tokenValid={tokenValid}
+      register={register}
+      errors={errors}
+      errorMessage={errorMessage}
+      password={watch("password")}
+      onSubmit={handleSubmit(onSubmit)}
+    />
+  );
+};

--- a/frontend/features/PasswordReset/index.tsx
+++ b/frontend/features/PasswordReset/index.tsx
@@ -5,7 +5,7 @@ import { useForm } from "react-hook-form";
 import { Presenter } from "./Presenter";
 import { useVerifyToken } from "./hooks/useVerifyToken";
 import { NewPasswordForm } from "./types";
-import { useSubmit } from "../PasswordReset/hooks/useSubmit";
+import { useSubmit } from "./hooks/useSubmit";
 
 type Props = {
   token: string;

--- a/frontend/features/PasswordReset/index.tsx
+++ b/frontend/features/PasswordReset/index.tsx
@@ -17,13 +17,14 @@ export const PasswordReset = ({ token }: Props): React.JSX.Element => {
   const [showPassword, setShowPassword] = useState<boolean>(false);
   const [showConfirmPassword, setShowConfirmPassword] =
     useState<boolean>(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const {
     register,
     handleSubmit,
     watch,
     formState: { errors },
   } = useForm<NewPasswordForm>();
-  const { onSubmit } = useSubmit({ token, setErrorMessage });
+  const { onSubmit } = useSubmit({ token, setErrorMessage, setIsSubmitting });
 
   return (
     <Presenter
@@ -36,6 +37,7 @@ export const PasswordReset = ({ token }: Props): React.JSX.Element => {
       onSubmit={handleSubmit(onSubmit)}
       showPassword={showPassword}
       showConfirmPassword={showConfirmPassword}
+      isSubmitting={isSubmitting}
       toggeleShowPassword={setShowPassword}
       toggeleShowConfirmPassword={setShowConfirmPassword}
     />

--- a/frontend/features/PasswordReset/types.ts
+++ b/frontend/features/PasswordReset/types.ts
@@ -1,0 +1,9 @@
+export type NewPasswordForm = {
+  password: string;
+  password_confirmation: string;
+};
+
+export type VerifyState = {
+  verifying: boolean;
+  tokenValid: boolean;
+};

--- a/frontend/features/PasswordResetRequest/Presenter.tsx
+++ b/frontend/features/PasswordResetRequest/Presenter.tsx
@@ -57,7 +57,7 @@ export const Presenter = ({
               </Typography>
             </Box>
 
-            <Box sx={{ mt: 3 }}>
+            <Box sx={{ textAlign: "center", mt: 3 }}>
               <Link href="/login">ログインに戻る</Link>
             </Box>
           </>

--- a/frontend/features/PasswordResetRequest/Presenter.tsx
+++ b/frontend/features/PasswordResetRequest/Presenter.tsx
@@ -57,9 +57,11 @@ export const Presenter = ({
               </Typography>
             </Box>
 
-            <PrimaryCta component={Link} href="/login">
-              ログイン画面へ
-            </PrimaryCta>
+            <Box sx={{ mt: 3 }}>
+                <Link href="/login">
+                    ログインに戻る
+                </Link>
+            </Box>
           </>
         ) : (
           <>

--- a/frontend/features/PasswordResetRequest/Presenter.tsx
+++ b/frontend/features/PasswordResetRequest/Presenter.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Alert, Box, TextField, Typography } from "@mui/material";
+import MarkEmailReadRoundedIcon from "@mui/icons-material/MarkEmailReadRounded";
+import Link from "next/link";
+import { FieldErrors, UseFormRegister } from "react-hook-form";
+
+import { PrimaryCta } from "@/components/PrimaryCta";
+import { RequestForm } from "./types";
+
+type Props = {
+  sent: boolean;
+  errorMessage: string;
+  onSubmit: () => void;
+  register: UseFormRegister<RequestForm>;
+  errors: FieldErrors<RequestForm>;
+};
+
+export const Presenter = ({
+  sent,
+  errorMessage,
+  onSubmit,
+  register,
+  errors,
+}: Props) => {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        px: 2,
+      }}
+    >
+      <Box sx={{ width: "100%", maxWidth: 480 }}>
+        {sent ? (
+          <>
+            <Box sx={{ textAlign: "center", mb: 4 }}>
+              <MarkEmailReadRoundedIcon
+                sx={{
+                  fontSize: 64,
+                  color: "primary.main",
+                  mb: 2,
+                }}
+              />
+
+              <Typography variant="h5" fontWeight="bold">
+                メールを送信しました
+              </Typography>
+
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+                ご入力いただいたメールアドレス宛に、
+                パスワード再設定用のメールを送信しました。
+                <br />
+                メールが届かない場合は、 迷惑メールフォルダもご確認ください。
+              </Typography>
+            </Box>
+
+            <PrimaryCta component={Link} href="/login">
+              ログイン画面へ
+            </PrimaryCta>
+          </>
+        ) : (
+          <>
+            <Typography
+              variant="h4"
+              component="h1"
+              sx={{
+                fontWeight: "bold",
+                textAlign: "center",
+                mb: 1,
+              }}
+            >
+              パスワード再設定
+            </Typography>
+
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              textAlign="center"
+              sx={{ mb: 4 }}
+            >
+              ご登録のメールアドレスを入力してください。
+              <br />
+              パスワード再設定用のリンクを送信します。
+            </Typography>
+
+            {errorMessage && (
+              <Alert severity="error" sx={{ mb: 3 }}>
+                {errorMessage}
+              </Alert>
+            )}
+
+            <Box component="form" onSubmit={onSubmit} noValidate>
+              <Box sx={{ mb: 3 }}>
+                <Typography sx={{ mb: 1, fontWeight: "bold" }}>
+                  メールアドレス
+                </Typography>
+
+                <TextField
+                  fullWidth
+                  type="email"
+                  {...register("email", {
+                    required: "メールアドレスを入力してください",
+                    pattern: {
+                      value: /^[\w.-]+@[\w.-]+\.[A-Za-z]{2,}$/,
+                      message: "メールアドレスの形式が正しくありません",
+                    },
+                  })}
+                  error={!!errors.email}
+                  helperText={errors.email?.message}
+                />
+              </Box>
+
+              <PrimaryCta type="submit">再設定リンクを送信</PrimaryCta>
+
+              <Box sx={{ textAlign: "center", mt: 3 }}>
+                <Link href="/login">ログインへ戻る</Link>
+              </Box>
+            </Box>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/features/PasswordResetRequest/Presenter.tsx
+++ b/frontend/features/PasswordResetRequest/Presenter.tsx
@@ -104,7 +104,7 @@ export const Presenter = ({
                   {...register("email", {
                     required: "メールアドレスを入力してください",
                     pattern: {
-                      value: /^[\w.-]+@[\w.-]+\.[A-Za-z]{2,}$/,
+                      value: /^[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}$/,
                       message: "メールアドレスの形式が正しくありません",
                     },
                   })}

--- a/frontend/features/PasswordResetRequest/Presenter.tsx
+++ b/frontend/features/PasswordResetRequest/Presenter.tsx
@@ -58,9 +58,7 @@ export const Presenter = ({
             </Box>
 
             <Box sx={{ mt: 3 }}>
-                <Link href="/login">
-                    ログインに戻る
-                </Link>
+              <Link href="/login">ログインに戻る</Link>
             </Box>
           </>
         ) : (

--- a/frontend/features/PasswordResetRequest/hooks/useSubmit.ts
+++ b/frontend/features/PasswordResetRequest/hooks/useSubmit.ts
@@ -15,7 +15,7 @@ export const useSubmit = ({ setSent, setErrorMessage }: Props) => {
 
     try {
       await apiClient.post("/api/auth/password-reset-request", {
-        data,
+        email: data.email,
       });
 
       setSent(true);

--- a/frontend/features/PasswordResetRequest/hooks/useSubmit.ts
+++ b/frontend/features/PasswordResetRequest/hooks/useSubmit.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { apiClient } from "@/libs/http/apiClient";
+import { RequestForm } from "../types";
+import { SubmitHandler } from "react-hook-form";
+
+type Props = {
+  setSent: (v: boolean) => void;
+  setErrorMessage: (m: string) => void;
+};
+
+export const useSubmit = ({ setSent, setErrorMessage }: Props) => {
+  const onSubmit: SubmitHandler<RequestForm> = async (data: RequestForm) => {
+    setErrorMessage("");
+
+    try {
+      await apiClient.post("/api/auth/password-reset-request", {
+        data,
+      });
+
+      setSent(true);
+    } catch (error) {
+      console.error("再設定リクエストに失敗", error);
+      setErrorMessage("送信に失敗しました。時間をおいて再度お試しください。");
+    }
+  };
+
+  return { onSubmit };
+};

--- a/frontend/features/PasswordResetRequest/index.tsx
+++ b/frontend/features/PasswordResetRequest/index.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState } from "react";
+import { Presenter } from "./Presenter";
+import { useForm } from "react-hook-form";
+import { RequestForm } from "./types";
+import { useSubmit } from "./hooks/useSubmit";
+
+export const PasswordResetRequest = () => {
+  const [sent, setSent] = useState<boolean>(false);
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RequestForm>();
+
+  const { onSubmit } = useSubmit({ setSent, setErrorMessage });
+  return (
+    <Presenter
+      sent={sent}
+      errorMessage={errorMessage}
+      onSubmit={handleSubmit(onSubmit)}
+      register={register}
+      errors={errors}
+    />
+  );
+};

--- a/frontend/features/PasswordResetRequest/types.ts
+++ b/frontend/features/PasswordResetRequest/types.ts
@@ -1,0 +1,3 @@
+export type RequestForm = {
+  email: string;
+};

--- a/rails/app/controllers/api/v1/password_resets_controller.rb
+++ b/rails/app/controllers/api/v1/password_resets_controller.rb
@@ -3,8 +3,8 @@
 module Api
   module V1
     class PasswordResetsController < ApplicationController
-      skip_before_action :authenticate_user!, only: %i[create update]
-
+      skip_before_action :authenticate_user!, only: %i[create update verify]
+      wrap_parameters false
       def create
         user = User.find_by(email: params[:email])
         Auth::ResetPasswordService.new(user).call
@@ -24,10 +24,29 @@ module Api
         render json: { errors: e.errors }, status: :unprocessable_content
       end
 
+      def verify
+        Rails.logger.debug params.inspect
+        user = User.with_reset_password_token(params[:reset_password_token])
+
+        Rails.logger.debug user.inspect
+        return render_user_not_found unless user
+        return render_expired_token unless user.reset_password_period_valid?
+
+        render json: { message: 'トークンは有効です。' }, status: :ok
+      end
+
       private
 
       def password_reset_params
-        params.permit(:reset_password_token, :password, :password_confirmation)
+        params.require(:password_reset).permit(:reset_password_token, :password, :password_confirmation)
+      end
+
+      def render_user_not_found
+        render json: { errors: ['ユーザーが見つかりません。'] }, status: :not_found
+      end
+
+      def render_expired_token
+        render json: { errors: ['トークンの有効期限が切れています。'] }, status: :unauthorized
       end
     end
   end

--- a/rails/app/controllers/api/v1/password_resets_controller.rb
+++ b/rails/app/controllers/api/v1/password_resets_controller.rb
@@ -24,10 +24,8 @@ module Api
       end
 
       def verify
-        Rails.logger.debug params.inspect
         user = User.with_reset_password_token(params[:reset_password_token])
 
-        Rails.logger.debug user.inspect
         return render_user_not_found unless user
         return render_expired_token unless user.reset_password_period_valid?
 

--- a/rails/app/controllers/api/v1/password_resets_controller.rb
+++ b/rails/app/controllers/api/v1/password_resets_controller.rb
@@ -4,7 +4,6 @@ module Api
   module V1
     class PasswordResetsController < ApplicationController
       skip_before_action :authenticate_user!, only: %i[create update verify]
-      wrap_parameters false
       def create
         user = User.find_by(email: params[:email])
         Auth::ResetPasswordService.new(user).call

--- a/rails/app/mailers/auth_mailer.rb
+++ b/rails/app/mailers/auth_mailer.rb
@@ -5,7 +5,7 @@ class AuthMailer < Devise::Mailer
   layout 'mailer'
 
   def send_email(user, token)
-    url = "#{ENV.fetch('FRONTEND_URL', nil)}/password/reset/#{token}?email=#{user.email}"
+    url = "#{ENV.fetch('FRONTEND_URL', nil)}/password/reset/#{token}"
 
     mail(to: user.email, subject: 'パスワード再設定のご案内', body: "パスワード再設定はこちらのリンクからお願いします： #{url}")
   end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
       post "/password/reset/request", to: "password_resets#create"
       patch "/password/reset", to: "password_resets#update"
+      post "password/verify", to: "password_resets#verify"
 
       get "/me", to: "users#show"
       patch "/profile", to: "profiles#update"


### PR DESCRIPTION
## 概要
https://app.notion.com/p/Next-js-36a2946467fd80de863bce664f220cfa
<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細
### 画面遷移

1. **ログイン画面**

   * 「パスワードを忘れた方」からパスワード再設定画面へ遷移

2. **パスワード再設定メール送信画面**

   * メールアドレスを入力し、再設定メールを送信

3. **メール送信完了画面**

   * パスワード再設定メール送信完了を表示

4. **パスワード再設定画面**

   * メール内のURLからアクセス
   * トークンの有効性を確認
   * 新しいパスワードを入力・更新

5. **ログイン画面**

   * パスワード更新完了後、ログイン画面へ遷移

## APIフロー

### 1. パスワード再設定メール送信

**Frontend**

* `POST /api/auth/password-reset-request`

**Backend**

* `POST /api/v1/password/reset/request`
* メールアドレスからユーザーを検索
* リセットトークンを生成
* パスワード再設定メールを送信

---

### 2. トークン検証

**Frontend**

* `POST /api/auth/password-verify`

**Backend**

* `POST /api/v1/password/verify`
* リセットトークンの存在を確認
* トークンの有効期限を確認
* 有効な場合は `200 OK` を返却

---

### 3. パスワード更新

**Frontend**

* `PATCH /api/auth/password-reset`

**Backend**

* `PATCH /api/v1/password/reset`
* リセットトークンを用いてユーザーを取得
* パスワード・確認用パスワードを検証
* パスワードを更新
* リセットトークンを無効化
* 更新完了レスポンスを返却

<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

## 動作確認
### パスワード再設定用メール設定画面
<img width="2526" height="1724" alt="image" src="https://github.com/user-attachments/assets/e8d2320e-6420-4aee-850b-3d4a29f91313" />

### メール送信報告画面
<img width="2528" height="1720" alt="image" src="https://github.com/user-attachments/assets/a3b4b901-f085-4a84-a711-db97971a38cf" />


### パスワード更新画面
<img width="2526" height="1728" alt="image" src="https://github.com/user-attachments/assets/cb42f700-8de1-47f5-a598-404feabc2d40" />


<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

## その他
本チケットでは開発環境用の設定・修正しか行っていない。
<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
