### PR TITLE
[Rails]教員用　教員権限管理機能API実装

### DIFF
--- a/rails/app/controllers/api/v1/teacher/permissions_controller.rb
+++ b/rails/app/controllers/api/v1/teacher/permissions_controller.rb
@@ -5,6 +5,7 @@ module Api
     module Teacher
       class PermissionsController < Api::V1::Teacher::BaseController
         before_action :set_teacher, only: %i[show update]
+        before_action :require_manage_other_teachers!, only: :update
 
         def index
           teachers = teachers_query.order(:name_kana).page(params[:page]).per(20)
@@ -66,6 +67,12 @@ module Api
 
         def render_update_error(message)
           render json: { errors: [message] }, status: :unprocessable_content
+        end
+
+        def require_manage_other_teachers!
+          return if current_user.teacher_permission.manage_other_teachers?
+
+          render_update_error('他教員を編集する権限がありません')
         end
       end
     end

--- a/rails/app/controllers/api/v1/teacher/permissions_controller.rb
+++ b/rails/app/controllers/api/v1/teacher/permissions_controller.rb
@@ -31,8 +31,8 @@ module Api
         end
 
         def update
-          return render_update_error('最後の教員は更新できません') if only_active_teacher?(@teacher)
           return render_update_error('自分自身は更新できません') if @teacher == current_user
+          return render_update_error('最後の教員は更新できません') if only_active_teacher?(@teacher)
 
           form = ::Teacher::UpdatePermissionForm.new(
             target: @teacher,

--- a/rails/app/controllers/api/v1/teacher/permissions_controller.rb
+++ b/rails/app/controllers/api/v1/teacher/permissions_controller.rb
@@ -4,6 +4,8 @@ module Api
   module V1
     module Teacher
       class PermissionsController < Api::V1::Teacher::BaseController
+        before_action :set_teacher, only: %i[show update]
+
         def index
           teachers = teachers_query.order(:name_kana).page(params[:page]).per(20)
 
@@ -24,15 +26,46 @@ module Api
         end
 
         def show
-          teacher = teachers_query.find(params[:id])
-          render json: teacher, serializer: ::Teacher::TeacherPermissionManagementSerializer
+          render json: @teacher, serializer: ::Teacher::TeacherPermissionManagementSerializer
+        end
+
+        def update
+          return render_update_error('最後の教員は更新できません') if only_active_teacher?(@teacher)
+          return render_update_error('自分自身は更新できません') if @teacher == current_user
+
+          form = ::Teacher::UpdatePermissionForm.new(
+            target: @teacher,
+            **update_permission_params.to_h.symbolize_keys
+          )
+
+          if form.save
+            render json: { message: '権限更新に成功しました' }, status: :ok
+          else
+            render json: { errors: form.errors.full_messages }, status: :unprocessable_content
+          end
         end
 
         private
 
+        def set_teacher
+          @teacher = teachers_query.active.find(params[:id])
+        end
+
+        def update_permission_params
+          params.require(:teacher_permission).permit(:grade_scope, :manage_other_teachers)
+        end
+
         def teachers_query
           query = ::Teacher::TeachersQuery.new(current_user.high_school.users).colleagues_for_permissions
           query.result
+        end
+
+        def only_active_teacher?(target)
+          !teachers_query.active.where.not(id: target.id).exists?
+        end
+
+        def render_update_error(message)
+          render json: { errors: [message] }, status: :unprocessable_content
         end
       end
     end

--- a/rails/app/controllers/api/v1/teacher/permissions_controller.rb
+++ b/rails/app/controllers/api/v1/teacher/permissions_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Teacher
+      class PermissionsController < Api::V1::Teacher::BaseController
+        def index
+          teachers = teachers_query.order(:name_kana).page(params[:page]).per(20)
+
+          render json: {
+            current_user: ActiveModelSerializers::SerializableResource.new(
+              current_user, serializer: TeacherSerializer
+            ),
+            teachers: ActiveModelSerializers::SerializableResource.new(
+              teachers, each_serializer: ::Teacher::TeacherPermissionManagementSerializer
+            ),
+            meta: {
+              current_page: teachers.current_page,
+              total_pages: teachers.total_pages,
+              total_count: teachers.total_count,
+              per_page: 20
+            }
+          }, status: :ok
+        end
+
+        def show
+          teacher = teachers_query.find(params[:id])
+          render json: teacher, serializer: ::Teacher::TeacherPermissionManagementSerializer
+        end
+
+        private
+
+        def teachers_query
+          query = ::Teacher::TeachersQuery.new(current_user.high_school.users).colleagues_for_permissions
+          query.result
+        end
+      end
+    end
+  end
+end

--- a/rails/app/forms/teacher/update_permission_form.rb
+++ b/rails/app/forms/teacher/update_permission_form.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Teacher
+  class UpdatePermissionForm
+    include ActiveModel::Model
+    include ActiveModel::Attributes
+    include ActiveModel::Validations
+
+    attribute :grade_scope
+    attribute :manage_other_teachers, :boolean
+
+    validates :grade_scope, inclusion: { in: TeacherPermission.grade_scopes.keys }
+    validates :manage_other_teachers, inclusion: { in: [true, false] }
+
+    def initialize(target:, **attributes)
+      super(attributes)
+      @target = target
+    end
+
+    def save
+      return false unless valid?
+
+      @target.teacher_permission.update!(
+        grade_scope: grade_scope,
+        manage_other_teachers: manage_other_teachers
+      )
+
+      true
+    end
+  end
+end

--- a/rails/app/queries/teacher/teachers_query.rb
+++ b/rails/app/queries/teacher/teachers_query.rb
@@ -7,13 +7,26 @@ module Teacher
     end
 
     def colleagues
-      @relation = @relation.includes(:grade,
-                                     :teacher_permission).joins(:user_role).where(user_roles: { name: :teacher })
+      @relation = teacher_scope.includes(:grade,
+                                         :teacher_permission)
+      self
+    end
+
+    def colleagues_for_permissions
+      @relation = teacher_scope.includes(
+        :teacher_permission
+      )
       self
     end
 
     def result
       @relation
+    end
+
+    private
+
+    def teacher_scope
+      @relation.joins(:user_role).where(user_roles: { name: :teacher })
     end
   end
 end

--- a/rails/app/serializers/teacher/teacher_permission_management_serializer.rb
+++ b/rails/app/serializers/teacher/teacher_permission_management_serializer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Teacher
+  class TeacherPermissionManagementSerializer < ActiveModel::Serializer
+    attributes :id, :name
+
+    has_one :teacher_permission, serializer: TeacherPermissionSerializer
+  end
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
       namespace :teacher do
         resources :colleagues, controller: "teachers"
         resources :students
-        resources :permissions, only: [:index, :show]
+        resources :permissions, only: [:index, :show, :update]
         resources :announcements, only: [:index, :show, :create, :update]
         resources :teacher_notifications
         resources :teacher_notification_results

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
       namespace :teacher do
         resources :colleagues, controller: "teachers"
         resources :students
+        resources :permissions, only: [:index, :show]
         resources :announcements, only: [:index, :show, :create, :update]
         resources :teacher_notifications
         resources :teacher_notification_results

--- a/rails/spec/forms/teacher/update_permission_form_spec.rb
+++ b/rails/spec/forms/teacher/update_permission_form_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Teacher::UpdatePermissionForm, type: :model do
+  let!(:teacher_role) { create(:user_role, name: :teacher) }
+
+  let!(:teacher) do
+    create(
+      :user,
+      user_role: teacher_role
+    )
+  end
+
+  let!(:teacher_permission) do
+    create(
+      :teacher_permission,
+      user: teacher,
+      grade_scope: :own_grade,
+      manage_other_teachers: false
+    )
+  end
+
+  describe '#valid?' do
+    context '正常な値の場合' do
+      subject do
+        described_class.new(
+          target: teacher,
+          grade_scope: 'all_grades',
+          manage_other_teachers: true
+        )
+      end
+
+      it '有効であること' do
+        expect(subject).to be_valid
+      end
+    end
+
+    context 'grade_scopeが不正な場合' do
+      subject do
+        described_class.new(
+          target: teacher,
+          grade_scope: 'invalid',
+          manage_other_teachers: true
+        )
+      end
+
+      it '無効であること' do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:grade_scope]).to be_present
+      end
+    end
+
+    context 'manage_other_teachersがnilの場合' do
+      subject do
+        described_class.new(
+          target: teacher,
+          grade_scope: 'all_grades',
+          manage_other_teachers: nil
+        )
+      end
+
+      it '無効であること' do
+        expect(subject).not_to be_valid
+        expect(subject.errors[:manage_other_teachers]).to be_present
+      end
+    end
+  end
+
+  describe '#save' do
+    subject do
+      described_class.new(
+        target: teacher,
+        grade_scope: 'all_grades',
+        manage_other_teachers: true
+      )
+    end
+
+    it 'teacher_permissionを更新できること' do
+      expect(subject.save).to be(true)
+
+      teacher_permission.reload
+
+      expect(teacher_permission.grade_scope).to eq('all_grades')
+      expect(teacher_permission.manage_other_teachers).to be(true)
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/teacher/permissions_spec.rb
+++ b/rails/spec/requests/api/v1/teacher/permissions_spec.rb
@@ -167,13 +167,26 @@ RSpec.describe 'Api::V1::Teacher::Permissions', type: :request do
 
   context '最後のアクティブ教員を更新する場合' do
     subject do
-      patch "/api/v1/teacher/permissions/#{login_teacher.id}",
+      patch "/api/v1/teacher/permissions/#{target_teacher.id}",
             params: params.to_json,
             headers: headers.merge('Cookie' => cookie)
     end
 
+    let!(:target_teacher) do
+      create(
+        :user,
+        user_role: teacher_role,
+        high_school: high_school
+      )
+    end
+
+    let!(:target_teacher_permission) do
+      create(:teacher_permission, user: target_teacher)
+    end
+
     before do
       same_school_teacher.update!(deleted_at: Time.current)
+      login_teacher.update!(deleted_at: Time.current)
     end
 
     it '更新できないこと' do

--- a/rails/spec/requests/api/v1/teacher/permissions_spec.rb
+++ b/rails/spec/requests/api/v1/teacher/permissions_spec.rb
@@ -232,4 +232,24 @@ RSpec.describe 'Api::V1::Teacher::Permissions', type: :request do
       expect(response.parsed_body['errors']).to be_present
     end
   end
+
+  context '他教員を管理する権限がない場合' do
+    subject do
+      patch "/api/v1/teacher/permissions/#{same_school_teacher.id}",
+            params: params.to_json,
+            headers: headers.merge('Cookie' => cookie)
+    end
+
+    before do
+      teacher_permission.update!(manage_other_teachers: false)
+    end
+
+    it '更新できないこと' do
+      subject
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body['errors'])
+        .to include('他教員を編集する権限がありません')
+    end
+  end
 end

--- a/rails/spec/requests/api/v1/teacher/permissions_spec.rb
+++ b/rails/spec/requests/api/v1/teacher/permissions_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Teacher::Permissions', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  let(:cookie) { login_and_get_cookie(login_teacher) }
+
+  let!(:teacher_role) { create(:user_role, name: :teacher) }
+
+  let!(:high_school) { create(:high_school) }
+  let!(:other_high_school) { create(:high_school) }
+
+  let!(:login_teacher) do
+    create(
+      :user,
+      user_role: teacher_role,
+      high_school: high_school
+    )
+  end
+
+  let!(:teacher_permission) do
+    create(
+      :teacher_permission,
+      user: login_teacher,
+      manage_other_teachers: true
+    )
+  end
+
+  let!(:same_school_teacher) do
+    create(
+      :user,
+      user_role: teacher_role,
+      high_school: high_school
+    )
+  end
+
+  let!(:same_school_teacher_permission) do
+    create(:teacher_permission, user: same_school_teacher)
+  end
+
+  let!(:other_school_teacher) do
+    create(
+      :user,
+      user_role: teacher_role,
+      high_school: other_high_school
+    )
+  end
+
+  let!(:other_school_teacher_permission) do
+    create(:teacher_permission, user: other_school_teacher)
+  end
+
+  let(:params) do
+    {
+      teacher_permission: {
+        grade_scope: 'all_grades',
+        manage_other_teachers: true
+      }
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: {
+           email: user.email,
+           password: 'password'
+         }.to_json,
+         headers: headers
+
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/teacher/permissions' do
+    subject do
+      get '/api/v1/teacher/permissions',
+          headers: headers.merge('Cookie' => cookie)
+    end
+
+    it '同じ高校の教員一覧を取得できること' do
+      subject
+
+      expect(response).to have_http_status(:ok)
+
+      json = response.parsed_body
+
+      expect(json['teachers'].pluck('id')).to include(login_teacher.id)
+      expect(json['teachers'].pluck('id')).to include(same_school_teacher.id)
+      expect(json['teachers'].pluck('id')).not_to include(other_school_teacher.id)
+
+      expect(json['current_user']['id']).to eq(login_teacher.id)
+      expect(json['meta']).to be_present
+    end
+  end
+
+  describe 'GET /api/v1/teacher/permissions/:id' do
+    subject do
+      get "/api/v1/teacher/permissions/#{same_school_teacher.id}",
+          headers: headers.merge('Cookie' => cookie)
+    end
+
+    it '教員詳細を取得できること' do
+      subject
+
+      expect(response).to have_http_status(:ok)
+
+      json = response.parsed_body
+
+      expect(json['id']).to eq(same_school_teacher.id)
+    end
+  end
+
+  describe 'PATCH /api/v1/teacher/permissions/:id' do
+    subject do
+      patch "/api/v1/teacher/permissions/#{same_school_teacher.id}",
+            params: params.to_json,
+            headers: headers.merge('Cookie' => cookie)
+    end
+
+    it '権限を更新できること' do
+      subject
+
+      expect(response).to have_http_status(:ok)
+
+      expect(
+        same_school_teacher.reload.teacher_permission.manage_other_teachers
+      ).to be(true)
+    end
+  end
+
+  context '自分自身を更新する場合' do
+    subject do
+      patch "/api/v1/teacher/permissions/#{login_teacher.id}",
+            params: params.to_json,
+            headers: headers.merge('Cookie' => cookie)
+    end
+
+    it '更新できないこと' do
+      subject
+
+      expect(response).to have_http_status(:unprocessable_content)
+
+      expect(response.parsed_body['errors'])
+        .to include('自分自身は更新できません')
+    end
+  end
+
+  context '他校教員の場合' do
+    subject do
+      patch "/api/v1/teacher/permissions/#{other_school_teacher.id}",
+            params: params.to_json,
+            headers: headers.merge('Cookie' => cookie)
+    end
+
+    it '404になること' do
+      subject
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context '最後のアクティブ教員を更新する場合' do
+    subject do
+      patch "/api/v1/teacher/permissions/#{login_teacher.id}",
+            params: params.to_json,
+            headers: headers.merge('Cookie' => cookie)
+    end
+
+    before do
+      same_school_teacher.update!(deleted_at: Time.current)
+    end
+
+    it '更新できないこと' do
+      subject
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body['errors'])
+        .to include('最後の教員は更新できません')
+    end
+  end
+
+  context 'grade_scopeが不正な場合' do
+    subject do
+      patch "/api/v1/teacher/permissions/#{same_school_teacher.id}",
+            params: params.to_json,
+            headers: headers.merge('Cookie' => cookie)
+    end
+
+    let(:params) do
+      {
+        teacher_permission: {
+          grade_scope: 'invalid',
+          manage_other_teachers: true
+        }
+      }
+    end
+
+    it '更新できないこと' do
+      subject
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body['errors']).to be_present
+    end
+  end
+
+  context 'manage_other_teachersが不正な場合' do
+    subject do
+      patch "/api/v1/teacher/permissions/#{same_school_teacher.id}",
+            params: params.to_json,
+            headers: headers.merge('Cookie' => cookie)
+    end
+
+    let(:params) do
+      {
+        teacher_permission: {
+          grade_scope: 'all',
+          manage_other_teachers: nil
+        }
+      }
+    end
+
+    it '更新できないこと' do
+      subject
+
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.parsed_body['errors']).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## 概要
教員権限管理者（`manage_other_teachers = true` を持つ教員）が、他教員の権限設定を確認・変更できる機能。

通常の教員一覧・教員詳細とは分離し、権限管理専用画面として提供する。

<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

## 詳細
https://app.notion.com/p/Rails-API-3962946467fd80a6991effd78ca8e5ac
<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

## 動作確認
Docker compose 環境にて確認済み。
- `rubocop` 293 files inspected, no offenses detected
- `bundle exec rspec` 692 examples, 0 failures, 2 pending(本 PR と無関係)
<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

## その他
- PermissionsController の index / show は TeachersController と処理が同じになっちゃっているが、権限管理画面用のAPIとして責務を分けています。現時点では取得ロジックは共通ですが、返却するSerializer（レスポンス）が異なるため、別Controllerとして実装しています。
<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
