### PR TITLE
json脆弱性修正とRails EOL警告の一時抑止

### DIFF
--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.21.1)
+    json (2.21.2)
     jsonapi-renderer (0.2.2)
     jwt (3.2.0)
       base64

--- a/rails/config/brakeman.ignore
+++ b/rails/config/brakeman.ignore
@@ -3,9 +3,9 @@
     {
       "warning_type": "Unmaintained Dependency",
       "warning_code": 122,
-      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
+      "fingerprint": "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
       "check_name": "EOLRails",
-      "message": "Support for Rails 7.2.3.1 ends on 2026-08-09",
+      "message": "Support for Rails 7.2.3.2 ended on 2026-08-09",
       "file": "Gemfile.lock",
       "line": 266,
       "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
@@ -13,11 +13,11 @@
       "render_path": null,
       "location": null,
       "user_input": null,
-      "confidence": "Medium",
+      "confidence": "High",
       "cwe_id": [
         1104
       ],
-      "note": ""
+      "note": "Rails 7.2系のEOL警告。7.4系へのメジャーアップグレードは別issueで対応予定のため一時的に抑止する。"
     }
   ],
   "brakeman_version": "8.0.5"


### PR DESCRIPTION
## 概要

mainブランチのCI（Bundler Audit・Brakeman）が2026-08-10時点で失敗するようになっていたため修正する。

## 詳細

以下2件のCI失敗原因に対応する。いずれもリポジトリの依存関係の経年変化によるもので、特定の機能追加に起因するものではない。

1. **Bundler Audit失敗**: `json 2.21.1` にクラッシュ系脆弱性 CVE-2026-71847（`JSON::ResumableParser#partial_value` が解放済みバッファを参照する不具合）が新たに検出された。`bundle update json` で修正版 `2.21.2` に更新した。
2. **Brakeman失敗**: `Gemfile`で`gem 'rails', '7.2.3.2'`としていたことで、Rails 7.2系のサポート終了（EOL, 2026-08-09）が「Unmaintained Dependency」として検出された。既存の`config/brakeman.ignore`はRails 7.2.3.1時点のfingerprintで登録されていたため、バージョンが上がった時点で「Obsolete Ignore Entries」として無効化され、新しいfingerprintで再度警告が出ていた。7.2.3.2用の新しいfingerprintで再登録し、一時的に抑止する。Rails 7.4系以降へのメジャーアップグレードは対応コストが大きいため別issueで検討する。

## 動作確認

- `bundle exec rspec`: 793 examples, 0 failures, 2 pending（既存分、無関係）
- `bundle exec rubocop`: 321 files inspected, no offenses detected
- `bundle exec bundler-audit check --update`: No vulnerabilities found
- `bundle exec brakeman -q -c config/brakeman.yml -i config/brakeman.ignore`: Security Warnings: 0, exit code 0（CIと同一コマンドで確認）

## その他

なし（既存gemのパッチバージョン更新のみ）

## 参考情報

- CVE-2026-71847: https://nvd.nist.gov/vuln/detail/CVE-2026-71847
- Rails 7.2系のメジャーアップグレードは別途対応が必要（本PRのスコープ外）