### PR TITLE
【Next.js】CSVインポートウィザード（4ステップ）

### DIFF
--- a/frontend/app/(admin)/admin/(authenticated)/courses/[courseId]/units/[unitId]/import/page.tsx
+++ b/frontend/app/(admin)/admin/(authenticated)/courses/[courseId]/units/[unitId]/import/page.tsx
@@ -1,0 +1,16 @@
+import { AdminCsvImport } from "@/features/AdminCsvImport";
+
+type Props = {
+  params: Promise<{ courseId: string; unitId: string }>;
+};
+
+export default async function AdminCsvImportFromUnitPage({ params }: Props) {
+  const { courseId, unitId } = await params;
+
+  return (
+    <AdminCsvImport
+      presetCourseId={Number(courseId)}
+      presetUnitId={Number(unitId)}
+    />
+  );
+}

--- a/frontend/app/(admin)/admin/(authenticated)/csv-import/page.tsx
+++ b/frontend/app/(admin)/admin/(authenticated)/csv-import/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { AdminCsvImport } from "@/features/AdminCsvImport";
+
+const parsePresetId = (value: string | null): number | null => {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+};
+
+export default function AdminCsvImportPage() {
+  const searchParams = useSearchParams();
+
+  return (
+    <AdminCsvImport
+      presetCourseId={parsePresetId(searchParams.get("courseId"))}
+      presetUnitId={parsePresetId(searchParams.get("unitId"))}
+    />
+  );
+}

--- a/frontend/app/api/admin/courses/[courseId]/units/[unitId]/import_questions/dry_run/route.ts
+++ b/frontend/app/api/admin/courses/[courseId]/units/[unitId]/import_questions/dry_run/route.ts
@@ -1,0 +1,28 @@
+import { handleRailsRouteError } from "@/libs/server/rails/handleRailsRouteError";
+import { railsFetchMultipart } from "@/libs/server/rails/railsFetchMultipart";
+import { type NextRequest, NextResponse } from "next/server";
+
+type Params = { params: Promise<{ courseId: string; unitId: string }> };
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const { courseId, unitId } = await params;
+
+  if (!/^\d+$/.test(courseId) || !/^\d+$/.test(unitId)) {
+    return NextResponse.json({ message: "BAD_REQUEST" }, { status: 400 });
+  }
+
+  const formData = await request.formData();
+
+  try {
+    const { status, data, setCookie } = await railsFetchMultipart(
+      `/api/v1/admin/courses/${courseId}/units/${unitId}/import_questions/dry_run`,
+      formData,
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    return handleRailsRouteError(error, "CSVの検証に失敗しました");
+  }
+}

--- a/frontend/app/api/admin/courses/[courseId]/units/[unitId]/import_questions/route.ts
+++ b/frontend/app/api/admin/courses/[courseId]/units/[unitId]/import_questions/route.ts
@@ -1,0 +1,28 @@
+import { handleRailsRouteError } from "@/libs/server/rails/handleRailsRouteError";
+import { railsFetchMultipart } from "@/libs/server/rails/railsFetchMultipart";
+import { type NextRequest, NextResponse } from "next/server";
+
+type Params = { params: Promise<{ courseId: string; unitId: string }> };
+
+export async function POST(request: NextRequest, { params }: Params) {
+  const { courseId, unitId } = await params;
+
+  if (!/^\d+$/.test(courseId) || !/^\d+$/.test(unitId)) {
+    return NextResponse.json({ message: "BAD_REQUEST" }, { status: 400 });
+  }
+
+  const formData = await request.formData();
+
+  try {
+    const { status, data, setCookie } = await railsFetchMultipart(
+      `/api/v1/admin/courses/${courseId}/units/${unitId}/import_questions`,
+      formData,
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    return handleRailsRouteError(error, "インポートの実行に失敗しました");
+  }
+}

--- a/frontend/app/api/admin/csv_template/questions/route.ts
+++ b/frontend/app/api/admin/csv_template/questions/route.ts
@@ -18,10 +18,13 @@ export async function GET() {
     .map((c) => `${c.name}=${c.value}`)
     .join("; ");
 
-  const response = await fetch(`${origin}/api/v1/admin/csv_template/questions`, {
-    headers: cookieHeader ? { Cookie: cookieHeader } : {},
-    cache: "no-store",
-  });
+  const response = await fetch(
+    `${origin}/api/v1/admin/csv_template/questions`,
+    {
+      headers: cookieHeader ? { Cookie: cookieHeader } : {},
+      cache: "no-store",
+    },
+  );
 
   if (response.status === 401) {
     return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
@@ -39,7 +42,8 @@ export async function GET() {
   const contentType = response.headers.get("content-type");
   const contentDisposition = response.headers.get("content-disposition");
   if (contentType) headers.set("content-type", contentType);
-  if (contentDisposition) headers.set("content-disposition", contentDisposition);
+  if (contentDisposition)
+    headers.set("content-disposition", contentDisposition);
 
   return new NextResponse(body, { status: response.status, headers });
 }

--- a/frontend/app/api/admin/csv_template/questions/route.ts
+++ b/frontend/app/api/admin/csv_template/questions/route.ts
@@ -1,0 +1,45 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+// テンプレートCSVは railsFetch(JSON専用) を使わず、Rails のレスポンス
+// （Content-Type/Content-Disposition・バイナリボディ）をそのままパススルーする。
+export async function GET() {
+  const origin = process.env.API_URL;
+  if (!origin) {
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join("; ");
+
+  const response = await fetch(`${origin}/api/v1/admin/csv_template/questions`, {
+    headers: cookieHeader ? { Cookie: cookieHeader } : {},
+    cache: "no-store",
+  });
+
+  if (response.status === 401) {
+    return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  if (!response.ok) {
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+
+  const body = await response.arrayBuffer();
+  const headers = new Headers();
+  const contentType = response.headers.get("content-type");
+  const contentDisposition = response.headers.get("content-disposition");
+  if (contentType) headers.set("content-type", contentType);
+  if (contentDisposition) headers.set("content-disposition", contentDisposition);
+
+  return new NextResponse(body, { status: response.status, headers });
+}

--- a/frontend/features/AdminCsvImport/Presenter.test.tsx
+++ b/frontend/features/AdminCsvImport/Presenter.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Presenter } from "./Presenter";
+import type { CourseOption, CsvImportState, UnitOption } from "./types";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const courses: CourseOption[] = [
+  {
+    id: 1,
+    subject: { id: 1, name: "数学" },
+    level_name: "標準",
+    level_number: 1,
+  },
+];
+const units: UnitOption[] = [{ id: 11, unit_name: "二次関数" }];
+
+const csvFile = (name = "questions.csv") =>
+  new File(["a"], name, { type: "text/csv" });
+
+const buildState = (overrides: Partial<CsvImportState>): CsvImportState => ({
+  step: 1,
+  courseId: 1,
+  unitId: 11,
+  isPreset: true,
+  file: null,
+  fileError: null,
+  mode: "append",
+  dryRunLoading: false,
+  dryRunResult: null,
+  dryRunError: null,
+  submitting: false,
+  submitError: null,
+  importResult: null,
+  ...overrides,
+});
+
+const baseProps = {
+  courses,
+  coursesLoading: false,
+  units,
+  unitsLoading: false,
+  handleCourseChange: vi.fn(),
+  handleUnitChange: vi.fn(),
+  handleFileSelect: vi.fn(),
+  handleFileClear: vi.fn(),
+  handleModeChange: vi.fn(),
+  goNext: vi.fn(),
+  goBack: vi.fn(),
+};
+
+describe("Presenter", () => {
+  it("step1のときStep1FileSelectの内容が表示される", () => {
+    render(<Presenter state={buildState({ step: 1 })} {...baseProps} />);
+    expect(
+      screen.getByText(/ドラッグ&ドロップ、またはクリックして選択/),
+    ).toBeInTheDocument();
+  });
+
+  it("step2のときStep2Previewの内容が表示される", () => {
+    render(
+      <Presenter
+        state={buildState({
+          step: 2,
+          file: csvFile(),
+          dryRunResult: { total_count: 1, valid_count: 1, rows: [] },
+        })}
+        {...baseProps}
+      />,
+    );
+    expect(screen.getByText(/全1行中 1行が有効/)).toBeInTheDocument();
+  });
+
+  it("step3のときStep3Confirmの内容が表示される", () => {
+    render(
+      <Presenter
+        state={buildState({
+          step: 3,
+          file: csvFile("questions.csv"),
+          dryRunResult: { total_count: 1, valid_count: 1, rows: [] },
+        })}
+        {...baseProps}
+      />,
+    );
+    expect(screen.getByText("questions.csv")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /実行/ })).toBeInTheDocument();
+  });
+
+  it("step4のときStep4Completeの内容が表示される", () => {
+    render(
+      <Presenter
+        state={buildState({
+          step: 4,
+          dryRunResult: { total_count: 3, valid_count: 3, rows: [] },
+          importResult: { message: "インポートを開始しました" },
+        })}
+        {...baseProps}
+      />,
+    );
+    expect(screen.getByText("インポートを開始しました")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /単元詳細/ })).toHaveAttribute(
+      "href",
+      "/admin/courses/1/units/11",
+    );
+  });
+
+  it("step1で次へをクリックするとgoNextが呼ばれる", () => {
+    const goNext = vi.fn();
+    render(
+      <Presenter
+        state={buildState({ step: 1, file: csvFile() })}
+        {...baseProps}
+        goNext={goNext}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "次へ" }));
+    expect(goNext).toHaveBeenCalled();
+  });
+
+  it("step2で戻るをクリックするとgoBackが呼ばれる", () => {
+    const goBack = vi.fn();
+    render(
+      <Presenter
+        state={buildState({
+          step: 2,
+          dryRunResult: { total_count: 1, valid_count: 1, rows: [] },
+        })}
+        {...baseProps}
+        goBack={goBack}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "戻る" }));
+    expect(goBack).toHaveBeenCalled();
+  });
+});

--- a/frontend/features/AdminCsvImport/Presenter.tsx
+++ b/frontend/features/AdminCsvImport/Presenter.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { buildCourseLabel } from "@/libs/domain/course/courseLabel";
+import { Step1FileSelect } from "./steps/Step1FileSelect";
+import { Step2Preview } from "./steps/Step2Preview";
+import { Step3Confirm } from "./steps/Step3Confirm";
+import { Step4Complete } from "./steps/Step4Complete";
+import type {
+  CourseOption,
+  CsvImportState,
+  ImportMode,
+  UnitOption,
+} from "./types";
+
+type Props = {
+  state: CsvImportState;
+  courses: CourseOption[];
+  coursesLoading: boolean;
+  units: UnitOption[];
+  unitsLoading: boolean;
+  handleCourseChange: (courseId: number) => void;
+  handleUnitChange: (unitId: number) => void;
+  handleFileSelect: (file: File) => void;
+  handleFileClear: () => void;
+  handleModeChange: (mode: ImportMode) => void;
+  goNext: () => void | Promise<void>;
+  goBack: () => void;
+};
+
+export const Presenter = ({
+  state,
+  courses,
+  coursesLoading,
+  units,
+  unitsLoading,
+  handleCourseChange,
+  handleUnitChange,
+  handleFileSelect,
+  handleFileClear,
+  handleModeChange,
+  goNext,
+  goBack,
+}: Props) => {
+  if (state.step === 1) {
+    return (
+      <Step1FileSelect
+        courses={courses}
+        coursesLoading={coursesLoading}
+        units={units}
+        unitsLoading={unitsLoading}
+        courseId={state.courseId}
+        unitId={state.unitId}
+        isPreset={state.isPreset}
+        onCourseChange={handleCourseChange}
+        onUnitChange={handleUnitChange}
+        file={state.file}
+        fileError={state.fileError}
+        onFileSelect={handleFileSelect}
+        onFileClear={handleFileClear}
+        mode={state.mode}
+        onModeChange={handleModeChange}
+        onNext={goNext}
+        canProceed={
+          state.courseId != null &&
+          state.unitId != null &&
+          state.file != null &&
+          !state.fileError
+        }
+      />
+    );
+  }
+
+  if (state.step === 2) {
+    return (
+      <Step2Preview
+        loading={state.dryRunLoading}
+        result={state.dryRunResult}
+        error={state.dryRunError}
+        onBack={goBack}
+        onNext={goNext}
+      />
+    );
+  }
+
+  const course = courses.find((c) => c.id === state.courseId);
+  const unit = units.find((u) => u.id === state.unitId);
+
+  if (state.step === 3) {
+    return (
+      <Step3Confirm
+        courseLabel={
+          course ? buildCourseLabel(course) : `講座 ${state.courseId}`
+        }
+        unitName={unit ? unit.unit_name : `単元 ${state.unitId}`}
+        fileName={state.file?.name ?? ""}
+        mode={state.mode}
+        validCount={state.dryRunResult?.valid_count ?? 0}
+        totalCount={state.dryRunResult?.total_count ?? 0}
+        submitting={state.submitting}
+        submitError={state.submitError}
+        onBack={goBack}
+        onSubmit={goNext}
+      />
+    );
+  }
+
+  return (
+    <Step4Complete
+      courseId={state.courseId ?? 0}
+      unitId={state.unitId ?? 0}
+      message={state.importResult?.message ?? ""}
+      validCount={state.dryRunResult?.valid_count ?? 0}
+      totalCount={state.dryRunResult?.total_count ?? 0}
+    />
+  );
+};

--- a/frontend/features/AdminCsvImport/Presenter.tsx
+++ b/frontend/features/AdminCsvImport/Presenter.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Box, Typography } from "@mui/material";
+import { colors } from "@/app/theme/colors";
 import { buildCourseLabel } from "@/libs/domain/course/courseLabel";
 import { Step1FileSelect } from "./steps/Step1FileSelect";
 import { Step2Preview } from "./steps/Step2Preview";
@@ -27,6 +29,13 @@ type Props = {
   goBack: () => void;
 };
 
+const STEP_LABELS: Record<CsvImportState["step"], string> = {
+  1: "Step 1: ファイル選択",
+  2: "Step 2: プレビュー・検証",
+  3: "Step 3: 確認",
+  4: "Step 4: 完了",
+};
+
 export const Presenter = ({
   state,
   courses,
@@ -41,76 +50,96 @@ export const Presenter = ({
   goNext,
   goBack,
 }: Props) => {
-  if (state.step === 1) {
-    return (
-      <Step1FileSelect
-        courses={courses}
-        coursesLoading={coursesLoading}
-        units={units}
-        unitsLoading={unitsLoading}
-        courseId={state.courseId}
-        unitId={state.unitId}
-        isPreset={state.isPreset}
-        onCourseChange={handleCourseChange}
-        onUnitChange={handleUnitChange}
-        file={state.file}
-        fileError={state.fileError}
-        onFileSelect={handleFileSelect}
-        onFileClear={handleFileClear}
-        mode={state.mode}
-        onModeChange={handleModeChange}
-        onNext={goNext}
-        canProceed={
-          state.courseId != null &&
-          state.unitId != null &&
-          state.file != null &&
-          !state.fileError
-        }
-      />
-    );
-  }
-
-  if (state.step === 2) {
-    return (
-      <Step2Preview
-        loading={state.dryRunLoading}
-        result={state.dryRunResult}
-        error={state.dryRunError}
-        onBack={goBack}
-        onNext={goNext}
-      />
-    );
-  }
-
   const course = courses.find((c) => c.id === state.courseId);
   const unit = units.find((u) => u.id === state.unitId);
 
-  if (state.step === 3) {
+  const content = (() => {
+    if (state.step === 1) {
+      return (
+        <Step1FileSelect
+          courses={courses}
+          coursesLoading={coursesLoading}
+          units={units}
+          unitsLoading={unitsLoading}
+          courseId={state.courseId}
+          unitId={state.unitId}
+          isPreset={state.isPreset}
+          onCourseChange={handleCourseChange}
+          onUnitChange={handleUnitChange}
+          file={state.file}
+          fileError={state.fileError}
+          onFileSelect={handleFileSelect}
+          onFileClear={handleFileClear}
+          mode={state.mode}
+          onModeChange={handleModeChange}
+          onNext={goNext}
+          canProceed={
+            state.courseId != null &&
+            state.unitId != null &&
+            state.file != null &&
+            !state.fileError
+          }
+        />
+      );
+    }
+
+    if (state.step === 2) {
+      return (
+        <Step2Preview
+          loading={state.dryRunLoading}
+          result={state.dryRunResult}
+          error={state.dryRunError}
+          onBack={goBack}
+          onNext={goNext}
+        />
+      );
+    }
+
+    if (state.step === 3) {
+      return (
+        <Step3Confirm
+          courseLabel={
+            course ? buildCourseLabel(course) : `講座 ${state.courseId}`
+          }
+          unitName={unit ? unit.unit_name : `単元 ${state.unitId}`}
+          fileName={state.file?.name ?? ""}
+          mode={state.mode}
+          validCount={state.dryRunResult?.valid_count ?? 0}
+          totalCount={state.dryRunResult?.total_count ?? 0}
+          submitting={state.submitting}
+          submitError={state.submitError}
+          onBack={goBack}
+          onSubmit={goNext}
+        />
+      );
+    }
+
     return (
-      <Step3Confirm
-        courseLabel={
-          course ? buildCourseLabel(course) : `講座 ${state.courseId}`
-        }
-        unitName={unit ? unit.unit_name : `単元 ${state.unitId}`}
-        fileName={state.file?.name ?? ""}
-        mode={state.mode}
+      <Step4Complete
+        courseId={state.courseId ?? 0}
+        unitId={state.unitId ?? 0}
+        message={state.importResult?.message ?? ""}
         validCount={state.dryRunResult?.valid_count ?? 0}
         totalCount={state.dryRunResult?.total_count ?? 0}
-        submitting={state.submitting}
-        submitError={state.submitError}
-        onBack={goBack}
-        onSubmit={goNext}
       />
     );
-  }
+  })();
 
   return (
-    <Step4Complete
-      courseId={state.courseId ?? 0}
-      unitId={state.unitId ?? 0}
-      message={state.importResult?.message ?? ""}
-      validCount={state.dryRunResult?.valid_count ?? 0}
-      totalCount={state.dryRunResult?.total_count ?? 0}
-    />
+    <Box sx={{ p: 3 }}>
+      <Box sx={{ mb: 3 }}>
+        <Typography
+          variant="h5"
+          fontWeight={700}
+          sx={{ color: colors.text.primary }}
+        >
+          CSVインポート
+        </Typography>
+        <Typography variant="body2" sx={{ color: colors.text.muted }}>
+          {STEP_LABELS[state.step]}
+        </Typography>
+      </Box>
+      <Box sx={{ maxWidth: 720 }}>{content}</Box>
+    </Box>
   );
 };

--- a/frontend/features/AdminCsvImport/hooks/useCsvImport.test.ts
+++ b/frontend/features/AdminCsvImport/hooks/useCsvImport.test.ts
@@ -1,0 +1,380 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { apiClient } from "@/libs/http/apiClient";
+import { useCsvImport } from "./useCsvImport";
+
+const pushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/libs/http/apiClient", () => ({
+  apiClient: { post: vi.fn() },
+}));
+
+const csvFile = (name: string, sizeBytes: number) => {
+  const file = new File(["a".repeat(Math.min(sizeBytes, 10))], name, {
+    type: "text/csv",
+  });
+  Object.defineProperty(file, "size", { value: sizeBytes });
+  return file;
+};
+
+describe("useCsvImport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("初期状態はstep1で、プリセットがなければisPresetはfalse", () => {
+    const { result } = renderHook(() =>
+      useCsvImport({ presetCourseId: null, presetUnitId: null }),
+    );
+    expect(result.current.state.step).toBe(1);
+    expect(result.current.state.isPreset).toBe(false);
+    expect(result.current.state.courseId).toBeNull();
+    expect(result.current.state.mode).toBe("append");
+  });
+
+  it("courseId/unitIdプリセットがあればisPresetはtrueで初期値にセットされる", () => {
+    const { result } = renderHook(() =>
+      useCsvImport({ presetCourseId: 7, presetUnitId: 11 }),
+    );
+    expect(result.current.state.isPreset).toBe(true);
+    expect(result.current.state.courseId).toBe(7);
+    expect(result.current.state.unitId).toBe(11);
+  });
+
+  it("拡張子が.csv以外のファイルはfileErrorになりfileはセットされない", () => {
+    const { result } = renderHook(() =>
+      useCsvImport({ presetCourseId: null, presetUnitId: null }),
+    );
+    act(() => {
+      result.current.handleFileSelect(csvFile("questions.txt", 100));
+    });
+    expect(result.current.state.file).toBeNull();
+    expect(result.current.state.fileError).toBe(
+      "CSVファイル（.csv）のみアップロード可能です",
+    );
+  });
+
+  it("5MBを超えるファイルはfileErrorになりfileはセットされない", () => {
+    const { result } = renderHook(() =>
+      useCsvImport({ presetCourseId: null, presetUnitId: null }),
+    );
+    act(() => {
+      result.current.handleFileSelect(
+        csvFile("questions.csv", 5 * 1024 * 1024 + 1),
+      );
+    });
+    expect(result.current.state.file).toBeNull();
+    expect(result.current.state.fileError).toBe(
+      "ファイルサイズは5MB以内にしてください",
+    );
+  });
+
+  it("正常なCSVファイルはfileにセットされfileErrorはnull", () => {
+    const { result } = renderHook(() =>
+      useCsvImport({ presetCourseId: null, presetUnitId: null }),
+    );
+    const file = csvFile("questions.csv", 100);
+    act(() => {
+      result.current.handleFileSelect(file);
+    });
+    expect(result.current.state.file).toBe(file);
+    expect(result.current.state.fileError).toBeNull();
+  });
+
+  it("handleFileClearでfile/fileError/dryRunResultがリセットされる", () => {
+    const { result } = renderHook(() =>
+      useCsvImport({ presetCourseId: null, presetUnitId: null }),
+    );
+    act(() => {
+      result.current.handleFileSelect(csvFile("questions.csv", 100));
+    });
+    act(() => {
+      result.current.handleFileClear();
+    });
+    expect(result.current.state.file).toBeNull();
+    expect(result.current.state.fileError).toBeNull();
+    expect(result.current.state.dryRunResult).toBeNull();
+  });
+
+  it("handleCourseChangeで講座を変更するとunitIdがリセットされる", () => {
+    const { result } = renderHook(() =>
+      useCsvImport({ presetCourseId: null, presetUnitId: null }),
+    );
+    act(() => {
+      result.current.handleUnitChange(3);
+    });
+    act(() => {
+      result.current.handleCourseChange(5);
+    });
+    expect(result.current.state.courseId).toBe(5);
+    expect(result.current.state.unitId).toBeNull();
+  });
+
+  it("handleModeChangeでdryRunResultがリセットされる", async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { total_count: 1, valid_count: 1, rows: [] },
+    });
+    const { result } = renderHook(() =>
+      useCsvImport({ presetCourseId: 1, presetUnitId: 2 }),
+    );
+    act(() => {
+      result.current.handleFileSelect(csvFile("questions.csv", 100));
+    });
+    await act(async () => {
+      await result.current.goNext();
+    });
+    await waitFor(() =>
+      expect(result.current.state.dryRunResult).not.toBeNull(),
+    );
+
+    act(() => {
+      result.current.handleModeChange("overwrite");
+    });
+    expect(result.current.state.mode).toBe("overwrite");
+    expect(result.current.state.dryRunResult).toBeNull();
+  });
+
+  it("goBackはstepを1つ戻すが1未満にはならない", () => {
+    const { result } = renderHook(() =>
+      useCsvImport({ presetCourseId: null, presetUnitId: null }),
+    );
+    act(() => {
+      result.current.goBack();
+    });
+    expect(result.current.state.step).toBe(1);
+  });
+
+  describe("dry_run", () => {
+    it("step1でgoNextするとdry_runを呼びstep2へ遷移し結果が保持される", async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({
+        data: {
+          total_count: 3,
+          valid_count: 2,
+          rows: [{ row_number: 3, severity: "error", message: "NG", data: {} }],
+        },
+      });
+      const { result } = renderHook(() =>
+        useCsvImport({ presetCourseId: 1, presetUnitId: 2 }),
+      );
+      act(() => {
+        result.current.handleFileSelect(csvFile("questions.csv", 100));
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+
+      expect(apiClient.post).toHaveBeenCalledWith(
+        "/api/admin/courses/1/units/2/import_questions/dry_run",
+        expect.any(FormData),
+        { headers: { "Content-Type": "multipart/form-data" } },
+      );
+      expect(result.current.state.step).toBe(2);
+      expect(result.current.state.dryRunResult?.valid_count).toBe(2);
+      expect(result.current.state.dryRunResult?.rows).toHaveLength(1);
+    });
+
+    it("422エラー時はstep2へ遷移しdryRunErrorにメッセージが入る", async () => {
+      vi.mocked(apiClient.post).mockRejectedValue({
+        response: {
+          status: 422,
+          data: { errors: ["CSVファイルのみアップロード可能です"] },
+        },
+      });
+      const { result } = renderHook(() =>
+        useCsvImport({ presetCourseId: 1, presetUnitId: 2 }),
+      );
+      act(() => {
+        result.current.handleFileSelect(csvFile("questions.csv", 100));
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+
+      expect(result.current.state.step).toBe(2);
+      expect(result.current.state.dryRunError).toBe(
+        "CSVファイルのみアップロード可能です",
+      );
+      expect(result.current.state.dryRunResult).toBeNull();
+    });
+
+    it("401エラー時はログイン画面へリダイレクトする", async () => {
+      vi.mocked(apiClient.post).mockRejectedValue({
+        response: { status: 401 },
+      });
+      const { result } = renderHook(() =>
+        useCsvImport({ presetCourseId: 1, presetUnitId: 2 }),
+      );
+      act(() => {
+        result.current.handleFileSelect(csvFile("questions.csv", 100));
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+
+      expect(pushMock).toHaveBeenCalledWith("/login");
+    });
+
+    it("404エラー時はisPresetを解除してStep1選択に戻す", async () => {
+      vi.mocked(apiClient.post).mockRejectedValue({
+        response: { status: 404 },
+      });
+      const { result } = renderHook(() =>
+        useCsvImport({ presetCourseId: 1, presetUnitId: 2 }),
+      );
+      act(() => {
+        result.current.handleFileSelect(csvFile("questions.csv", 100));
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+
+      expect(result.current.state.isPreset).toBe(false);
+      expect(result.current.state.courseId).toBeNull();
+      expect(result.current.state.unitId).toBeNull();
+      expect(result.current.state.dryRunError).toBe(
+        "指定された講座・単元が見つかりません。選択し直してください",
+      );
+    });
+
+    it("dry_run結果にエラー行があるとstep2からstep3へgoNextしても進まない", async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({
+        data: {
+          total_count: 1,
+          valid_count: 0,
+          rows: [{ row_number: 2, severity: "error", message: "NG", data: {} }],
+        },
+      });
+      const { result } = renderHook(() =>
+        useCsvImport({ presetCourseId: 1, presetUnitId: 2 }),
+      );
+      act(() => {
+        result.current.handleFileSelect(csvFile("questions.csv", 100));
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+      expect(result.current.state.step).toBe(2);
+
+      await act(async () => {
+        await result.current.goNext();
+      });
+      expect(result.current.state.step).toBe(2);
+    });
+
+    it("dry_run結果にエラー行がなければstep2からstep3へ進める", async () => {
+      vi.mocked(apiClient.post).mockResolvedValue({
+        data: { total_count: 1, valid_count: 1, rows: [] },
+      });
+      const { result } = renderHook(() =>
+        useCsvImport({ presetCourseId: 1, presetUnitId: 2 }),
+      );
+      act(() => {
+        result.current.handleFileSelect(csvFile("questions.csv", 100));
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+      expect(result.current.state.step).toBe(2);
+
+      await act(async () => {
+        await result.current.goNext();
+      });
+      expect(result.current.state.step).toBe(3);
+    });
+  });
+
+  describe("submitImport", () => {
+    const validDryRunResult = {
+      data: { total_count: 1, valid_count: 1, rows: [] },
+    };
+
+    it("step3でgoNextすると実行APIを呼び202でstep4へ遷移する", async () => {
+      vi.mocked(apiClient.post)
+        .mockResolvedValueOnce(validDryRunResult)
+        .mockResolvedValueOnce({
+          data: { message: "インポートを開始しました" },
+        });
+      const { result } = renderHook(() =>
+        useCsvImport({ presetCourseId: 1, presetUnitId: 2 }),
+      );
+      act(() => {
+        result.current.handleFileSelect(csvFile("questions.csv", 100));
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+      expect(result.current.state.step).toBe(3);
+
+      await act(async () => {
+        await result.current.goNext();
+      });
+
+      expect(apiClient.post).toHaveBeenLastCalledWith(
+        "/api/admin/courses/1/units/2/import_questions",
+        expect.any(FormData),
+        { headers: { "Content-Type": "multipart/form-data" } },
+      );
+      expect(result.current.state.step).toBe(4);
+      expect(result.current.state.importResult?.message).toBe(
+        "インポートを開始しました",
+      );
+    });
+
+    it("実行APIが422を返すとstep3のままsubmitErrorが入る", async () => {
+      vi.mocked(apiClient.post)
+        .mockResolvedValueOnce(validDryRunResult)
+        .mockRejectedValueOnce({
+          response: { status: 422, data: { errors: ["バリデーションエラー"] } },
+        });
+      const { result } = renderHook(() =>
+        useCsvImport({ presetCourseId: 1, presetUnitId: 2 }),
+      );
+      act(() => {
+        result.current.handleFileSelect(csvFile("questions.csv", 100));
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+
+      await act(async () => {
+        await result.current.goNext();
+      });
+
+      expect(result.current.state.step).toBe(3);
+      expect(result.current.state.submitError).toBe("バリデーションエラー");
+    });
+
+    it("実行APIが401を返すとログイン画面へリダイレクトする", async () => {
+      vi.mocked(apiClient.post)
+        .mockResolvedValueOnce(validDryRunResult)
+        .mockRejectedValueOnce({ response: { status: 401 } });
+      const { result } = renderHook(() =>
+        useCsvImport({ presetCourseId: 1, presetUnitId: 2 }),
+      );
+      act(() => {
+        result.current.handleFileSelect(csvFile("questions.csv", 100));
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+      await act(async () => {
+        await result.current.goNext();
+      });
+
+      await act(async () => {
+        await result.current.goNext();
+      });
+
+      expect(pushMock).toHaveBeenCalledWith("/login");
+    });
+  });
+});

--- a/frontend/features/AdminCsvImport/hooks/useCsvImport.ts
+++ b/frontend/features/AdminCsvImport/hooks/useCsvImport.ts
@@ -1,0 +1,200 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient } from "@/libs/http/apiClient";
+import { extractApiError } from "@/libs/http/extractApiError";
+import type {
+  CsvImportState,
+  DryRunResult,
+  ImportAcceptedResult,
+  ImportMode,
+  WizardStep,
+} from "../types";
+
+type UseCsvImportParams = {
+  presetCourseId: number | null;
+  presetUnitId: number | null;
+};
+
+const ALLOWED_EXTENSION = ".csv";
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+const validateFile = (file: File): string | null => {
+  if (!file.name.toLowerCase().endsWith(ALLOWED_EXTENSION)) {
+    return "CSVファイル（.csv）のみアップロード可能です";
+  }
+  if (file.size > MAX_FILE_SIZE) {
+    return "ファイルサイズは5MB以内にしてください";
+  }
+  return null;
+};
+
+export const useCsvImport = ({
+  presetCourseId,
+  presetUnitId,
+}: UseCsvImportParams) => {
+  const router = useRouter();
+  const [state, setState] = useState<CsvImportState>(() => ({
+    step: 1,
+    courseId: presetCourseId,
+    unitId: presetUnitId,
+    isPreset: presetCourseId != null && presetUnitId != null,
+    file: null,
+    fileError: null,
+    mode: "append",
+    dryRunLoading: false,
+    dryRunResult: null,
+    dryRunError: null,
+    submitting: false,
+    submitError: null,
+    importResult: null,
+  }));
+
+  const handleCourseChange = (courseId: number) => {
+    setState((prev) => ({ ...prev, courseId, unitId: null }));
+  };
+
+  const handleUnitChange = (unitId: number) => {
+    setState((prev) => ({ ...prev, unitId }));
+  };
+
+  const handleFileSelect = (file: File) => {
+    const error = validateFile(file);
+    setState((prev) => ({
+      ...prev,
+      file: error ? null : file,
+      fileError: error,
+      dryRunResult: null,
+      dryRunError: null,
+    }));
+  };
+
+  const handleFileClear = () => {
+    setState((prev) => ({
+      ...prev,
+      file: null,
+      fileError: null,
+      dryRunResult: null,
+      dryRunError: null,
+    }));
+  };
+
+  const handleModeChange = (mode: ImportMode) => {
+    setState((prev) => ({ ...prev, mode, dryRunResult: null }));
+  };
+
+  const runDryRun = async () => {
+    if (!state.courseId || !state.unitId || !state.file) return;
+    setState((prev) => ({ ...prev, dryRunLoading: true, dryRunError: null }));
+
+    const formData = new FormData();
+    formData.append("file", state.file);
+    formData.append("mode", state.mode);
+
+    try {
+      const res = await apiClient.post<DryRunResult>(
+        `/api/admin/courses/${state.courseId}/units/${state.unitId}/import_questions/dry_run`,
+        formData,
+        { headers: { "Content-Type": "multipart/form-data" } },
+      );
+      setState((prev) => ({
+        ...prev,
+        dryRunResult: res.data,
+        dryRunLoading: false,
+        step: 2,
+      }));
+    } catch (err) {
+      const { status, errors } = extractApiError(err);
+      if (status === 401) {
+        router.push("/login");
+        return;
+      }
+      if (status === 404) {
+        setState((prev) => ({
+          ...prev,
+          dryRunLoading: false,
+          isPreset: false,
+          courseId: null,
+          unitId: null,
+          dryRunError:
+            "指定された講座・単元が見つかりません。選択し直してください",
+        }));
+        return;
+      }
+      setState((prev) => ({
+        ...prev,
+        dryRunLoading: false,
+        dryRunError: errors?.[0] ?? "CSVの検証に失敗しました",
+        step: 2,
+      }));
+    }
+  };
+
+  const submitImport = async () => {
+    if (!state.courseId || !state.unitId || !state.file) return;
+    setState((prev) => ({ ...prev, submitting: true, submitError: null }));
+
+    const formData = new FormData();
+    formData.append("file", state.file);
+    formData.append("mode", state.mode);
+
+    try {
+      const res = await apiClient.post<ImportAcceptedResult>(
+        `/api/admin/courses/${state.courseId}/units/${state.unitId}/import_questions`,
+        formData,
+        { headers: { "Content-Type": "multipart/form-data" } },
+      );
+      setState((prev) => ({
+        ...prev,
+        submitting: false,
+        importResult: res.data,
+        step: 4,
+      }));
+    } catch (err) {
+      const { status, errors } = extractApiError(err);
+      if (status === 401) {
+        router.push("/login");
+        return;
+      }
+      setState((prev) => ({
+        ...prev,
+        submitting: false,
+        submitError: errors?.[0] ?? "インポートの実行に失敗しました",
+      }));
+    }
+  };
+
+  const goNext = async () => {
+    if (state.step === 1) {
+      await runDryRun();
+      return;
+    }
+    if (state.step === 2) {
+      if (!state.dryRunResult || state.dryRunResult.rows.length > 0) return;
+      setState((prev) => ({ ...prev, step: 3 }));
+      return;
+    }
+    if (state.step === 3) {
+      await submitImport();
+    }
+  };
+
+  const goBack = () => {
+    setState((prev) => ({
+      ...prev,
+      step: Math.max(1, prev.step - 1) as WizardStep,
+    }));
+  };
+
+  return {
+    state,
+    handleCourseChange,
+    handleUnitChange,
+    handleFileSelect,
+    handleFileClear,
+    handleModeChange,
+    goNext,
+    goBack,
+  };
+};

--- a/frontend/features/AdminCsvImport/hooks/useFetchCourseOptions.test.ts
+++ b/frontend/features/AdminCsvImport/hooks/useFetchCourseOptions.test.ts
@@ -1,0 +1,61 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { apiClient } from "@/libs/http/apiClient";
+import { useFetchCourseOptions } from "./useFetchCourseOptions";
+
+const pushMock = vi.fn();
+const routerMock = { push: pushMock };
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock,
+}));
+
+vi.mock("@/libs/http/apiClient", () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+describe("useFetchCourseOptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("講座一覧を取得しcoursesにセットする", async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: {
+        courses: [
+          {
+            id: 1,
+            subject: { id: 1, name: "数学" },
+            level_name: "標準",
+            level_number: 1,
+          },
+        ],
+        meta: {
+          current_page: 1,
+          total_pages: 1,
+          total_count: 1,
+          per_page: 100,
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useFetchCourseOptions());
+
+    await waitFor(() => expect(result.current.coursesLoading).toBe(false));
+    expect(result.current.courses).toHaveLength(1);
+    expect(result.current.courses[0].level_name).toBe("標準");
+    expect(apiClient.get).toHaveBeenCalledWith("/api/admin/courses", {
+      params: { per_page: "100" },
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("401エラー時はログイン画面へリダイレクトする", async () => {
+    vi.mocked(apiClient.get).mockRejectedValue({
+      response: { status: 401 },
+    });
+
+    renderHook(() => useFetchCourseOptions());
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/login"));
+  });
+});

--- a/frontend/features/AdminCsvImport/hooks/useFetchCourseOptions.ts
+++ b/frontend/features/AdminCsvImport/hooks/useFetchCourseOptions.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+import { apiClient } from "@/libs/http/apiClient";
+import { extractApiError } from "@/libs/http/extractApiError";
+import type { CourseOption } from "../types";
+
+type CoursesResponse = {
+  courses: CourseOption[];
+};
+
+// Step1のセレクト用に全件相当を軽量取得する（一覧画面のページネーション付きフックとは別物）
+const PER_PAGE = "100";
+
+export const useFetchCourseOptions = () => {
+  const [courses, setCourses] = useState<CourseOption[]>([]);
+  const [coursesLoading, setCoursesLoading] = useState<boolean>(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setCoursesLoading(true);
+
+    apiClient
+      .get<CoursesResponse>("/api/admin/courses", {
+        params: { per_page: PER_PAGE },
+        signal: controller.signal,
+      })
+      .then((res) => {
+        setCourses(res.data.courses);
+      })
+      .catch((err) => {
+        if (axios.isCancel(err)) return;
+        if (extractApiError(err).status === 401) {
+          router.push("/login");
+          return;
+        }
+        setCourses([]);
+      })
+      .finally(() => {
+        if (controller.signal.aborted) return;
+        setCoursesLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [router]);
+
+  return { courses, coursesLoading };
+};

--- a/frontend/features/AdminCsvImport/hooks/useFetchUnitOptions.test.ts
+++ b/frontend/features/AdminCsvImport/hooks/useFetchUnitOptions.test.ts
@@ -1,0 +1,59 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { apiClient } from "@/libs/http/apiClient";
+import { useFetchUnitOptions } from "./useFetchUnitOptions";
+
+const pushMock = vi.fn();
+const routerMock = { push: pushMock };
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock,
+}));
+
+vi.mock("@/libs/http/apiClient", () => ({
+  apiClient: { get: vi.fn() },
+}));
+
+describe("useFetchUnitOptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("courseIdがnullのときは取得せずunitsは空配列", () => {
+    const { result } = renderHook(() => useFetchUnitOptions(null));
+    expect(result.current.units).toEqual([]);
+    expect(apiClient.get).not.toHaveBeenCalled();
+  });
+
+  it("courseIdが指定されると講座詳細から単元一覧を取得する", async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: {
+        id: 7,
+        units: [
+          { id: 11, unit_name: "二次関数", questions_count: 5 },
+          { id: 12, unit_name: "図形", questions_count: 0 },
+        ],
+      },
+    });
+
+    const { result } = renderHook(() => useFetchUnitOptions(7));
+
+    await waitFor(() => expect(result.current.unitsLoading).toBe(false));
+    expect(result.current.units).toEqual([
+      { id: 11, unit_name: "二次関数" },
+      { id: 12, unit_name: "図形" },
+    ]);
+    expect(apiClient.get).toHaveBeenCalledWith("/api/admin/courses/7", {
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("401エラー時はログイン画面へリダイレクトする", async () => {
+    vi.mocked(apiClient.get).mockRejectedValue({
+      response: { status: 401 },
+    });
+
+    renderHook(() => useFetchUnitOptions(7));
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/login"));
+  });
+});

--- a/frontend/features/AdminCsvImport/hooks/useFetchUnitOptions.ts
+++ b/frontend/features/AdminCsvImport/hooks/useFetchUnitOptions.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import axios from "axios";
+import { apiClient } from "@/libs/http/apiClient";
+import { extractApiError } from "@/libs/http/extractApiError";
+import type { UnitOption } from "../types";
+
+type CourseDetailResponse = {
+  id: number;
+  units: Array<{ id: number; unit_name: string; questions_count: number }>;
+};
+
+export const useFetchUnitOptions = (courseId: number | null) => {
+  const [units, setUnits] = useState<UnitOption[]>([]);
+  const [unitsLoading, setUnitsLoading] = useState<boolean>(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (courseId == null) {
+      setUnits((prev) => (prev.length === 0 ? prev : []));
+      return;
+    }
+
+    const controller = new AbortController();
+    setUnitsLoading(true);
+
+    apiClient
+      .get<CourseDetailResponse>(`/api/admin/courses/${courseId}`, {
+        signal: controller.signal,
+      })
+      .then((res) => {
+        setUnits(
+          res.data.units.map((unit) => ({
+            id: unit.id,
+            unit_name: unit.unit_name,
+          })),
+        );
+      })
+      .catch((err) => {
+        if (axios.isCancel(err)) return;
+        if (extractApiError(err).status === 401) {
+          router.push("/login");
+          return;
+        }
+        setUnits([]);
+      })
+      .finally(() => {
+        if (controller.signal.aborted) return;
+        setUnitsLoading(false);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [courseId, router]);
+
+  return { units, unitsLoading };
+};

--- a/frontend/features/AdminCsvImport/index.tsx
+++ b/frontend/features/AdminCsvImport/index.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Presenter } from "./Presenter";
+import { useCsvImport } from "./hooks/useCsvImport";
+import { useFetchCourseOptions } from "./hooks/useFetchCourseOptions";
+import { useFetchUnitOptions } from "./hooks/useFetchUnitOptions";
+
+type Props = {
+  presetCourseId: number | null;
+  presetUnitId: number | null;
+};
+
+export const AdminCsvImport = ({ presetCourseId, presetUnitId }: Props) => {
+  const wizard = useCsvImport({ presetCourseId, presetUnitId });
+  const { courses, coursesLoading } = useFetchCourseOptions();
+  const { units, unitsLoading } = useFetchUnitOptions(wizard.state.courseId);
+
+  return (
+    <Presenter
+      state={wizard.state}
+      courses={courses}
+      coursesLoading={coursesLoading}
+      units={units}
+      unitsLoading={unitsLoading}
+      handleCourseChange={wizard.handleCourseChange}
+      handleUnitChange={wizard.handleUnitChange}
+      handleFileSelect={wizard.handleFileSelect}
+      handleFileClear={wizard.handleFileClear}
+      handleModeChange={wizard.handleModeChange}
+      goNext={wizard.goNext}
+      goBack={wizard.goBack}
+    />
+  );
+};

--- a/frontend/features/AdminCsvImport/steps/Step1FileSelect.test.tsx
+++ b/frontend/features/AdminCsvImport/steps/Step1FileSelect.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Step1FileSelect } from "./Step1FileSelect";
+import type { CourseOption, UnitOption } from "../types";
+
+const courses: CourseOption[] = [
+  {
+    id: 1,
+    subject: { id: 1, name: "数学" },
+    level_name: "標準",
+    level_number: 1,
+  },
+];
+const units: UnitOption[] = [{ id: 11, unit_name: "二次関数" }];
+
+const csvFile = (name = "questions.csv") =>
+  new File(["a"], name, { type: "text/csv" });
+
+const baseProps = {
+  courses,
+  coursesLoading: false,
+  units,
+  unitsLoading: false,
+  courseId: null as number | null,
+  unitId: null as number | null,
+  isPreset: false,
+  onCourseChange: vi.fn(),
+  onUnitChange: vi.fn(),
+  file: null as File | null,
+  fileError: null as string | null,
+  onFileSelect: vi.fn(),
+  onFileClear: vi.fn(),
+  mode: "append" as const,
+  onModeChange: vi.fn(),
+  onNext: vi.fn(),
+  canProceed: false,
+};
+
+describe("Step1FileSelect", () => {
+  it("プリセットがない場合は講座・単元のSelectが表示される", () => {
+    render(<Step1FileSelect {...baseProps} />);
+    expect(screen.getByLabelText("講座")).toBeInTheDocument();
+    expect(screen.getByLabelText("単元")).toBeInTheDocument();
+  });
+
+  it("プリセットがある場合は選択UIをスキップし読み取り表示になる", () => {
+    render(
+      <Step1FileSelect {...baseProps} isPreset courseId={1} unitId={11} />,
+    );
+    expect(screen.queryByLabelText("講座")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("単元")).not.toBeInTheDocument();
+  });
+
+  it("courseIdが未選択のとき単元Selectは無効", () => {
+    render(<Step1FileSelect {...baseProps} />);
+    expect(screen.getByLabelText("単元")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+  });
+
+  it("ファイルドロップでonFileSelectが呼ばれる", () => {
+    const onFileSelect = vi.fn();
+    render(<Step1FileSelect {...baseProps} onFileSelect={onFileSelect} />);
+    const file = csvFile();
+    const dropzone = screen.getByTestId("csv-dropzone");
+
+    fireEvent.drop(dropzone, { dataTransfer: { files: [file] } });
+
+    expect(onFileSelect).toHaveBeenCalledWith(file);
+  });
+
+  it("fileErrorがあるとAlertが表示される", () => {
+    render(
+      <Step1FileSelect
+        {...baseProps}
+        fileError="CSVファイル（.csv）のみアップロード可能です"
+      />,
+    );
+    expect(
+      screen.getByText("CSVファイル（.csv）のみアップロード可能です"),
+    ).toBeInTheDocument();
+  });
+
+  it("選択済みファイルがあればファイル名と削除ボタンが表示される", () => {
+    const onFileClear = vi.fn();
+    render(
+      <Step1FileSelect
+        {...baseProps}
+        file={csvFile("my_questions.csv")}
+        onFileClear={onFileClear}
+      />,
+    );
+    expect(screen.getByText("my_questions.csv")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "削除" }));
+    expect(onFileClear).toHaveBeenCalled();
+  });
+
+  it("上書きモードを選択すると警告Alertが表示される", () => {
+    render(<Step1FileSelect {...baseProps} mode="overwrite" />);
+    expect(
+      screen.getByText(/既存の問題を全て置き換えます/),
+    ).toBeInTheDocument();
+  });
+
+  it("追加モードでは上書き警告は表示されない", () => {
+    render(<Step1FileSelect {...baseProps} mode="append" />);
+    expect(
+      screen.queryByText(/既存の問題を全て置き換えます/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("モードラジオを変更するとonModeChangeが呼ばれる", () => {
+    const onModeChange = vi.fn();
+    render(<Step1FileSelect {...baseProps} onModeChange={onModeChange} />);
+    fireEvent.click(screen.getByLabelText("上書き"));
+    expect(onModeChange).toHaveBeenCalledWith("overwrite");
+  });
+
+  it("テンプレートDLリンクが正しいhrefとdownload属性を持つ", () => {
+    render(<Step1FileSelect {...baseProps} />);
+    const link = screen.getByRole("link", { name: /テンプレート/ });
+    expect(link).toHaveAttribute("href", "/api/admin/csv_template/questions");
+    expect(link).toHaveAttribute("download");
+  });
+
+  it("canProceedがfalseなら次へボタンは無効", () => {
+    render(<Step1FileSelect {...baseProps} canProceed={false} />);
+    expect(screen.getByRole("button", { name: "次へ" })).toBeDisabled();
+  });
+
+  it("canProceedがtrueなら次へボタンは有効でクリックするとonNextが呼ばれる", () => {
+    const onNext = vi.fn();
+    render(<Step1FileSelect {...baseProps} canProceed onNext={onNext} />);
+    const button = screen.getByRole("button", { name: "次へ" });
+    expect(button).toBeEnabled();
+    fireEvent.click(button);
+    expect(onNext).toHaveBeenCalled();
+  });
+});

--- a/frontend/features/AdminCsvImport/steps/Step1FileSelect.tsx
+++ b/frontend/features/AdminCsvImport/steps/Step1FileSelect.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useRef, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  FormControlLabel,
+  MenuItem,
+  Radio,
+  RadioGroup,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import UploadFileOutlinedIcon from "@mui/icons-material/UploadFileOutlined";
+import { colors } from "@/app/theme/colors";
+import type { CourseOption, ImportMode, UnitOption } from "../types";
+import { buildCourseLabel } from "@/libs/domain/course/courseLabel";
+
+type Props = {
+  courses: CourseOption[];
+  coursesLoading: boolean;
+  units: UnitOption[];
+  unitsLoading: boolean;
+  courseId: number | null;
+  unitId: number | null;
+  isPreset: boolean;
+  onCourseChange: (courseId: number) => void;
+  onUnitChange: (unitId: number) => void;
+  file: File | null;
+  fileError: string | null;
+  onFileSelect: (file: File) => void;
+  onFileClear: () => void;
+  mode: ImportMode;
+  onModeChange: (mode: ImportMode) => void;
+  onNext: () => void;
+  canProceed: boolean;
+};
+
+export const Step1FileSelect = ({
+  courses,
+  coursesLoading,
+  units,
+  unitsLoading,
+  courseId,
+  unitId,
+  isPreset,
+  onCourseChange,
+  onUnitChange,
+  file,
+  fileError,
+  onFileSelect,
+  onFileClear,
+  mode,
+  onModeChange,
+  onNext,
+  canProceed,
+}: Props) => {
+  const [dragActive, setDragActive] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragActive(false);
+    const droppedFile = e.dataTransfer.files[0];
+    if (droppedFile) onFileSelect(droppedFile);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0];
+    if (selected) onFileSelect(selected);
+    e.target.value = "";
+  };
+
+  return (
+    <Stack spacing={3}>
+      {isPreset ? (
+        <Box>
+          <Typography variant="body2" sx={{ color: colors.text.muted, mb: 1 }}>
+            インポート対象
+          </Typography>
+          <Stack direction="row" spacing={1}>
+            <Chip label={`講座: ${courseId}`} />
+            <Chip label={`単元: ${unitId}`} />
+          </Stack>
+        </Box>
+      ) : (
+        <Stack direction="row" spacing={2}>
+          <TextField
+            select
+            label="講座"
+            fullWidth
+            disabled={coursesLoading}
+            value={courseId ?? ""}
+            onChange={(e) => onCourseChange(Number(e.target.value))}
+          >
+            {courses.map((course) => (
+              <MenuItem key={course.id} value={course.id}>
+                {buildCourseLabel(course)}
+              </MenuItem>
+            ))}
+          </TextField>
+          <TextField
+            select
+            label="単元"
+            fullWidth
+            disabled={courseId == null || unitsLoading}
+            value={unitId ?? ""}
+            onChange={(e) => onUnitChange(Number(e.target.value))}
+          >
+            {units.map((unit) => (
+              <MenuItem key={unit.id} value={unit.id}>
+                {unit.unit_name}
+              </MenuItem>
+            ))}
+          </TextField>
+        </Stack>
+      )}
+
+      <Box
+        data-testid="csv-dropzone"
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragActive(true);
+        }}
+        onDragLeave={() => setDragActive(false)}
+        onDrop={handleDrop}
+        sx={{
+          border: `2px dashed ${dragActive ? colors.brand.primary : colors.border.light}`,
+          borderRadius: 2,
+          p: 4,
+          textAlign: "center",
+          cursor: "pointer",
+          bgcolor: dragActive ? colors.surface.light : "transparent",
+        }}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".csv"
+          hidden
+          onChange={handleInputChange}
+        />
+        <UploadFileOutlinedIcon
+          fontSize="large"
+          sx={{ color: colors.text.muted }}
+        />
+        <Typography variant="body2" sx={{ mt: 1 }}>
+          CSVファイルをドラッグ&ドロップ、またはクリックして選択
+        </Typography>
+        <Typography variant="caption" sx={{ color: colors.text.muted }}>
+          .csv形式、5MB以内
+        </Typography>
+      </Box>
+
+      {file && (
+        <Stack direction="row" alignItems="center" spacing={1}>
+          <Typography variant="body2">{file.name}</Typography>
+          <Button size="small" onClick={onFileClear}>
+            削除
+          </Button>
+        </Stack>
+      )}
+
+      {fileError && <Alert severity="error">{fileError}</Alert>}
+
+      <Box>
+        <Typography variant="body2" sx={{ mb: 1 }}>
+          インポートモード
+        </Typography>
+        <RadioGroup
+          row
+          value={mode}
+          onChange={(e) => onModeChange(e.target.value as ImportMode)}
+        >
+          <FormControlLabel value="append" control={<Radio />} label="追加" />
+          <FormControlLabel
+            value="overwrite"
+            control={<Radio />}
+            label="上書き"
+          />
+        </RadioGroup>
+        {mode === "overwrite" && (
+          <Alert severity="warning" sx={{ mt: 1 }}>
+            既存の問題を全て置き換えます
+          </Alert>
+        )}
+      </Box>
+
+      <Box>
+        <Button
+          component="a"
+          href="/api/admin/csv_template/questions"
+          download
+          size="small"
+        >
+          テンプレートをダウンロード
+        </Button>
+      </Box>
+
+      {coursesLoading && <CircularProgress size={20} />}
+
+      <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+        <Button variant="contained" disabled={!canProceed} onClick={onNext}>
+          次へ
+        </Button>
+      </Box>
+    </Stack>
+  );
+};

--- a/frontend/features/AdminCsvImport/steps/Step2Preview.test.tsx
+++ b/frontend/features/AdminCsvImport/steps/Step2Preview.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Step2Preview } from "./Step2Preview";
+import type { DryRunResult } from "../types";
+
+const baseProps = {
+  loading: false,
+  result: null as DryRunResult | null,
+  error: null as string | null,
+  onBack: vi.fn(),
+  onNext: vi.fn(),
+};
+
+describe("Step2Preview", () => {
+  it("loading中はローディング表示のみでテーブルは出さない", () => {
+    render(<Step2Preview {...baseProps} loading />);
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("errorがあるとAlertのみ表示されテーブルは出さない", () => {
+    render(
+      <Step2Preview
+        {...baseProps}
+        error="CSVファイルのみアップロード可能です"
+      />,
+    );
+    expect(
+      screen.getByText("CSVファイルのみアップロード可能です"),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "次へ" })).toBeDisabled();
+  });
+
+  it("エラー行がない場合はサマリとsuccess表示、次へが活性", () => {
+    const result: DryRunResult = { total_count: 5, valid_count: 5, rows: [] };
+    render(<Step2Preview {...baseProps} result={result} />);
+    expect(screen.getByText(/全5行中 5行が有効/)).toBeInTheDocument();
+    expect(screen.getByText("エラーはありません")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "次へ" })).toBeEnabled();
+  });
+
+  it("エラー行がある場合は警告とテーブルが表示され、次へは無効", () => {
+    const result: DryRunResult = {
+      total_count: 3,
+      valid_count: 2,
+      rows: [
+        {
+          row_number: 3,
+          severity: "error",
+          message: "問題文が空です",
+          data: {},
+        },
+      ],
+    };
+    render(<Step2Preview {...baseProps} result={result} />);
+    expect(screen.getByText(/エラーが1件あります/)).toBeInTheDocument();
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByText("問題文が空です")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "次へ" })).toBeDisabled();
+  });
+
+  it("戻るボタンをクリックするとonBackが呼ばれる", () => {
+    const onBack = vi.fn();
+    render(<Step2Preview {...baseProps} onBack={onBack} />);
+    fireEvent.click(screen.getByRole("button", { name: "戻る" }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("エラー行なしで次へをクリックするとonNextが呼ばれる", () => {
+    const onNext = vi.fn();
+    const result: DryRunResult = { total_count: 1, valid_count: 1, rows: [] };
+    render(<Step2Preview {...baseProps} result={result} onNext={onNext} />);
+    fireEvent.click(screen.getByRole("button", { name: "次へ" }));
+    expect(onNext).toHaveBeenCalled();
+  });
+});

--- a/frontend/features/AdminCsvImport/steps/Step2Preview.tsx
+++ b/frontend/features/AdminCsvImport/steps/Step2Preview.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import type { DryRunResult, DryRunRowSeverity } from "../types";
+
+type Props = {
+  loading: boolean;
+  result: DryRunResult | null;
+  error: string | null;
+  onBack: () => void;
+  onNext: () => void;
+};
+
+const SEVERITY_COLOR: Record<DryRunRowSeverity, "error" | "warning"> = {
+  error: "error",
+  warning: "warning",
+};
+
+export const Step2Preview = ({
+  loading,
+  result,
+  error,
+  onBack,
+  onNext,
+}: Props) => {
+  const hasErrorRows = (result?.rows.length ?? 0) > 0;
+  const canProceed = result != null && !error && !hasErrorRows;
+
+  return (
+    <Box>
+      {loading && (
+        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {!loading && error && <Alert severity="error">{error}</Alert>}
+
+      {!loading && !error && result && (
+        <Box>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            全{result.total_count}行中 {result.valid_count}行が有効
+          </Typography>
+
+          {hasErrorRows ? (
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              エラーが{result.rows.length}
+              件あります。修正後に再アップロードしてください。
+            </Alert>
+          ) : (
+            <Alert severity="success" sx={{ mb: 2 }}>
+              エラーはありません
+            </Alert>
+          )}
+
+          {hasErrorRows && (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>行番号</TableCell>
+                    <TableCell>種別</TableCell>
+                    <TableCell>メッセージ</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {result.rows.map((row) => (
+                    <TableRow key={row.row_number}>
+                      <TableCell>{row.row_number}</TableCell>
+                      <TableCell>
+                        <Chip
+                          label={row.severity}
+                          size="small"
+                          color={SEVERITY_COLOR[row.severity]}
+                        />
+                      </TableCell>
+                      <TableCell>{row.message}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </Box>
+      )}
+
+      <Box sx={{ display: "flex", justifyContent: "space-between", mt: 3 }}>
+        <Button onClick={onBack}>戻る</Button>
+        <Button variant="contained" disabled={!canProceed} onClick={onNext}>
+          次へ
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/features/AdminCsvImport/steps/Step3Confirm.test.tsx
+++ b/frontend/features/AdminCsvImport/steps/Step3Confirm.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Step3Confirm } from "./Step3Confirm";
+
+const baseProps = {
+  courseLabel: "標準レベル1",
+  unitName: "二次関数",
+  fileName: "questions.csv",
+  mode: "append" as const,
+  validCount: 5,
+  totalCount: 5,
+  submitting: false,
+  submitError: null as string | null,
+  onBack: vi.fn(),
+  onSubmit: vi.fn(),
+};
+
+describe("Step3Confirm", () => {
+  it("影響範囲のサマリが表示される", () => {
+    render(<Step3Confirm {...baseProps} />);
+    expect(screen.getByText("標準レベル1")).toBeInTheDocument();
+    expect(screen.getByText("二次関数")).toBeInTheDocument();
+    expect(screen.getByText("questions.csv")).toBeInTheDocument();
+    expect(screen.getByText(/5.*\/.*5/)).toBeInTheDocument();
+  });
+
+  it("追加モードでは上書き警告は表示されない", () => {
+    render(<Step3Confirm {...baseProps} mode="append" />);
+    expect(screen.queryByText(/取り消せません/)).not.toBeInTheDocument();
+  });
+
+  it("上書きモードでは強い警告が表示される", () => {
+    render(<Step3Confirm {...baseProps} mode="overwrite" />);
+    expect(screen.getByText(/取り消せません/)).toBeInTheDocument();
+  });
+
+  it("submitting中は実行ボタンが無効になる", () => {
+    render(<Step3Confirm {...baseProps} submitting />);
+    expect(screen.getByRole("button", { name: /実行/ })).toBeDisabled();
+  });
+
+  it("submitErrorがあるとAlertが表示され再実行可能", () => {
+    render(<Step3Confirm {...baseProps} submitError="失敗しました" />);
+    expect(screen.getByText("失敗しました")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /実行/ })).toBeEnabled();
+  });
+
+  it("戻るボタンでonBackが呼ばれる", () => {
+    const onBack = vi.fn();
+    render(<Step3Confirm {...baseProps} onBack={onBack} />);
+    fireEvent.click(screen.getByRole("button", { name: "戻る" }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("実行ボタンでonSubmitが呼ばれる", () => {
+    const onSubmit = vi.fn();
+    render(<Step3Confirm {...baseProps} onSubmit={onSubmit} />);
+    fireEvent.click(screen.getByRole("button", { name: /実行/ }));
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/frontend/features/AdminCsvImport/steps/Step3Confirm.tsx
+++ b/frontend/features/AdminCsvImport/steps/Step3Confirm.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CircularProgress,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { colors } from "@/app/theme/colors";
+import type { ImportMode } from "../types";
+
+type Props = {
+  courseLabel: string;
+  unitName: string;
+  fileName: string;
+  mode: ImportMode;
+  validCount: number;
+  totalCount: number;
+  submitting: boolean;
+  submitError: string | null;
+  onBack: () => void;
+  onSubmit: () => void;
+};
+
+const MODE_LABEL: Record<ImportMode, string> = {
+  append: "追加",
+  overwrite: "上書き",
+};
+
+export const Step3Confirm = ({
+  courseLabel,
+  unitName,
+  fileName,
+  mode,
+  validCount,
+  totalCount,
+  submitting,
+  submitError,
+  onBack,
+  onSubmit,
+}: Props) => {
+  return (
+    <Box>
+      <Card
+        elevation={0}
+        sx={{
+          border: `1px solid ${colors.border.light}`,
+          borderRadius: 2,
+          mb: 2,
+        }}
+      >
+        <CardContent>
+          <Stack spacing={1.5}>
+            <Stack direction="row" justifyContent="space-between">
+              <Typography variant="body2" color="text.secondary">
+                講座
+              </Typography>
+              <Typography variant="body2">{courseLabel}</Typography>
+            </Stack>
+            <Stack direction="row" justifyContent="space-between">
+              <Typography variant="body2" color="text.secondary">
+                単元
+              </Typography>
+              <Typography variant="body2">{unitName}</Typography>
+            </Stack>
+            <Stack direction="row" justifyContent="space-between">
+              <Typography variant="body2" color="text.secondary">
+                ファイル
+              </Typography>
+              <Typography variant="body2">{fileName}</Typography>
+            </Stack>
+            <Stack direction="row" justifyContent="space-between">
+              <Typography variant="body2" color="text.secondary">
+                モード
+              </Typography>
+              <Typography variant="body2">{MODE_LABEL[mode]}</Typography>
+            </Stack>
+            <Stack direction="row" justifyContent="space-between">
+              <Typography variant="body2" color="text.secondary">
+                有効行数
+              </Typography>
+              <Typography variant="body2">
+                {validCount} / {totalCount}
+              </Typography>
+            </Stack>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      {mode === "overwrite" && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          この操作は取り消せません。既存の問題は全て削除され、CSVの内容で置き換わります。
+        </Alert>
+      )}
+
+      {submitError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {submitError}
+        </Alert>
+      )}
+
+      <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+        <Button onClick={onBack} disabled={submitting}>
+          戻る
+        </Button>
+        <Button
+          variant="contained"
+          disabled={submitting}
+          onClick={onSubmit}
+          startIcon={
+            submitting ? <CircularProgress size={16} color="inherit" /> : null
+          }
+        >
+          インポートを実行
+        </Button>
+      </Box>
+    </Box>
+  );
+};

--- a/frontend/features/AdminCsvImport/steps/Step4Complete.test.tsx
+++ b/frontend/features/AdminCsvImport/steps/Step4Complete.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Step4Complete } from "./Step4Complete";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const baseProps = {
+  courseId: 7,
+  unitId: 11,
+  message: "インポートを開始しました",
+  validCount: 5,
+  totalCount: 5,
+};
+
+describe("Step4Complete", () => {
+  it("受付完了メッセージが表示される", () => {
+    render(<Step4Complete {...baseProps} />);
+    expect(screen.getByText("インポートを開始しました")).toBeInTheDocument();
+  });
+
+  it("dry_run由来の参考件数が表示される", () => {
+    render(<Step4Complete {...baseProps} />);
+    expect(screen.getByText(/5.*\/.*5/)).toBeInTheDocument();
+  });
+
+  it("単元詳細へのリンクが正しいhrefを持つ", () => {
+    render(<Step4Complete {...baseProps} />);
+    const link = screen.getByRole("link", { name: /単元詳細/ });
+    expect(link).toHaveAttribute("href", "/admin/courses/7/units/11");
+  });
+
+  it("インポート履歴へのリンクが正しいhrefを持つ", () => {
+    render(<Step4Complete {...baseProps} />);
+    const link = screen.getByRole("link", { name: /インポート履歴/ });
+    expect(link).toHaveAttribute("href", "/admin/courses/7/units/11");
+  });
+});

--- a/frontend/features/AdminCsvImport/steps/Step4Complete.tsx
+++ b/frontend/features/AdminCsvImport/steps/Step4Complete.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { Box, Button, Stack, Typography } from "@mui/material";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import Link from "next/link";
+import { colors } from "@/app/theme/colors";
+
+type Props = {
+  courseId: number;
+  unitId: number;
+  message: string;
+  validCount: number;
+  totalCount: number;
+};
+
+export const Step4Complete = ({
+  courseId,
+  unitId,
+  message,
+  validCount,
+  totalCount,
+}: Props) => {
+  const unitDetailHref = `/admin/courses/${courseId}/units/${unitId}`;
+
+  return (
+    <Box sx={{ textAlign: "center", py: 4 }}>
+      <CheckCircleOutlineIcon
+        sx={{ fontSize: 48, color: colors.status.success, mb: 2 }}
+      />
+      <Typography variant="h6" fontWeight={700} sx={{ mb: 1 }}>
+        {message}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+        検証時点の有効行数: {validCount} / {totalCount}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        結果はインポート履歴で確認できます（反映まで数分かかる場合があります）
+      </Typography>
+      <Stack direction="row" spacing={2} justifyContent="center">
+        <Button component={Link} href={unitDetailHref} variant="contained">
+          単元詳細に戻る
+        </Button>
+        <Button component={Link} href={unitDetailHref} variant="outlined">
+          インポート履歴を見る
+        </Button>
+      </Stack>
+    </Box>
+  );
+};

--- a/frontend/features/AdminCsvImport/types.ts
+++ b/frontend/features/AdminCsvImport/types.ts
@@ -1,0 +1,56 @@
+import type { Subject } from "@/types/common/subject";
+
+export type ImportMode = "append" | "overwrite";
+
+export type WizardStep = 1 | 2 | 3 | 4;
+
+export type CourseOption = {
+  id: number;
+  subject: Subject | null;
+  level_name: string;
+  level_number: number;
+};
+
+export type UnitOption = {
+  id: number;
+  unit_name: string;
+};
+
+// 現状は "error" のみ。将来のwarning拡張を見込みユニオンで用意する
+export type DryRunRowSeverity = "error" | "warning";
+
+export type DryRunRow = {
+  row_number: number;
+  severity: DryRunRowSeverity;
+  message: string;
+  data: Record<string, string | null>;
+};
+
+export type DryRunResult = {
+  total_count: number;
+  valid_count: number;
+  rows: DryRunRow[];
+};
+
+export type ImportAcceptedResult = {
+  message: string;
+};
+
+export type CsvImportState = {
+  step: WizardStep;
+
+  courseId: number | null;
+  unitId: number | null;
+  isPreset: boolean;
+  file: File | null;
+  fileError: string | null;
+  mode: ImportMode;
+
+  dryRunLoading: boolean;
+  dryRunResult: DryRunResult | null;
+  dryRunError: string | null;
+
+  submitting: boolean;
+  submitError: string | null;
+  importResult: ImportAcceptedResult | null;
+};

--- a/frontend/libs/server/rails/railsFetchMultipart.ts
+++ b/frontend/libs/server/rails/railsFetchMultipart.ts
@@ -1,0 +1,66 @@
+import { cookies } from "next/headers";
+import { RailsFetchError, RailsUnauthorizedError } from "./railsError";
+
+type RailsFetchMultipartResult<T> = {
+  status: number;
+  data: T;
+  setCookie: string | null;
+};
+
+/**
+ * サーバ専用：multipart/form-data を Rails API へ Cookie をforwardして送る共通関数
+ * - railsFetch は JSON専用のため、ファイルアップロードにはこちらを使う
+ * - FormData を渡すと fetch が Content-Type: multipart/form-data を自動付与する
+ */
+export async function railsFetchMultipart<T = unknown>(
+  path: string,
+  formData: FormData,
+): Promise<RailsFetchMultipartResult<T>> {
+  const origin = process.env.API_URL;
+  if (!origin) {
+    throw new Error("API_URL is not set");
+  }
+
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore
+    .getAll()
+    .map((c) => `${c.name}=${c.value}`)
+    .join("; ");
+
+  const response = await fetch(`${origin}${path}`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      ...(cookieHeader ? { Cookie: cookieHeader } : {}),
+    },
+    body: formData,
+    cache: "no-store",
+  });
+
+  if (response.status === 401) {
+    throw new RailsUnauthorizedError();
+  }
+
+  const setCookie = response.headers.get("set-cookie");
+
+  let data: T;
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    data = (await response.json()) as T;
+  } else {
+    const text = await response.text();
+    data = text as T;
+  }
+
+  if (!response.ok) {
+    const bodyText =
+      typeof data === "string" ? data : JSON.stringify(data).slice(0, 2000);
+    throw new RailsFetchError(
+      response.status,
+      `Rails request failed: ${response.status}`,
+      bodyText,
+    );
+  }
+
+  return { status: response.status, data, setCookie };
+}


### PR DESCRIPTION
## 概要

issue: #55

管理画面の最重要機能であるCSVインポートウィザードを4ステップで実装する。アクセス経路は3箇所（単元詳細・講座詳細単元行・サイドバー）を想定。

## 詳細

- `frontend/app/(admin)/admin/(authenticated)/csv-import/page.tsx`（講座・単元選択から開始、`?courseId=xxx&unitId=yyy`でプリセット対応）
- `frontend/app/(admin)/admin/(authenticated)/courses/[courseId]/units/[unitId]/import/page.tsx`（単元詳細からのプリセット付きアクセス）
- `frontend/features/AdminCsvImport/` にウィザード本体を実装
  - `Step1FileSelect`: 講座・単元選択、ドロップゾーン（.csv、5MB以内）、追加/上書きモード、テンプレートDLリンク
  - `Step2Preview`: dry_run APIを呼び出し行ごとのエラーをプレビュー。エラーがあると次へ進めない
  - `Step3Confirm`: 影響範囲の最終確認。上書きモード時は取り消し不可の警告
  - `Step4Complete`: 結果サマリと単元詳細・インポート履歴へのリンク
  - `useCsvImport` にファイル検証・dry_run・実行APIの呼び出しロジックを集約
- `frontend/app/api/admin/csv_template/questions/route.ts` ほか、Rails APIへのBFF Route Handlerを追加（`railsFetchMultipart.ts`でmultipart/form-dataの中継を共通化）
- Rails側の対応API（テンプレートDL・dry_run）は #109 で先行実装・マージ済み


## 動作確認
<img width="962" height="680" alt="スクリーンショット 2026-08-13 15 17 57" src="https://github.com/user-attachments/assets/2af24be6-8649-4af8-8732-4b207a8b0a8c" />
<img width="860" height="734" alt="スクリーンショット 2026-08-13 15 18 31" src="https://github.com/user-attachments/assets/64022f56-9513-487c-8e10-e3fb418177bc" />
<img width="1920" height="1080" alt="スクリーンショット 2026-08-13 15 18 38（2）" src="https://github.com/user-attachments/assets/7dbf43f2-0bb3-47c5-9d32-f484e679f3d1" />
<img width="871" height="395" alt="スクリーンショット 2026-08-13 15 18 44" src="https://github.com/user-attachments/assets/5e37ceb5-6fff-4f29-a238-a49bb7960067" />
<img width="855" height="522" alt="スクリーンショット 2026-08-13 15 18 53" src="https://github.com/user-attachments/assets/05c6b1c6-5db0-47b3-882e-e16604bd6511" />
<img width="791" height="469" alt="スクリーンショット 2026-08-13 15 19 03" src="https://github.com/user-attachments/assets/e083a8f4-4e9d-4eaf-8ffb-4debedc1b0ea" />


- 4ステップを進める/戻るの一連の操作
- クエリパラメータでの単元プリセット
- Step2でエラー行がある場合に次へ進めないこと
- Step3の上書き警告表示
- Step4の遷移リンク動作
- `npm run test`（Vitest）: 全144件green
- `npm run typecheck` / `npm run lint` / `npm run format:check`: green

## その他

なし

## 参考情報