### PR TITLE
[Next.js]教員 教員権限管理画面作成

### DIFF
--- a/frontend/app/(teacher)/teacher/(authenticated)/permissions/page.tsx
+++ b/frontend/app/(teacher)/teacher/(authenticated)/permissions/page.tsx
@@ -1,0 +1,5 @@
+import { TeacherPermissions } from "@/features/TeacherPermissions";
+
+export default function TeacherPermissionsPage() {
+  return <TeacherPermissions />;
+}

--- a/frontend/app/api/teacher/permissions/[teacherId]/route.ts
+++ b/frontend/app/api/teacher/permissions/[teacherId]/route.ts
@@ -1,0 +1,74 @@
+import {
+  RailsFetchError,
+  RailsUnauthorizedError,
+} from "@/libs/server/rails/railsError";
+import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(
+  _: NextRequest,
+  { params }: { params: Promise<{ teacherId: string }> },
+) {
+  const { teacherId } = await params;
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/teacher/permissions/${teacherId}`,
+    );
+
+    const res = NextResponse.json(data, { status });
+
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+
+    return res;
+  } catch (error) {
+    if (error instanceof RailsUnauthorizedError) {
+      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+    }
+
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ teacherId: string }> },
+) {
+  const { teacherId } = await params;
+  const body = await request.json();
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/teacher/permissions/${teacherId}`,
+      { method: "PATCH", body },
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    if (error instanceof RailsUnauthorizedError) {
+      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+    }
+
+    if (error instanceof RailsFetchError) {
+      let data: unknown = { errors: ["権限の更新に失敗しました"] };
+      if (error.bodyText) {
+        try {
+          data = JSON.parse(error.bodyText);
+        } catch (error) {
+          // パース失敗時はデフォルトのエラーメッセージを使う
+        }
+      }
+      return NextResponse.json(data, { status: error.status });
+    }
+
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/app/api/teacher/permissions/[teacherId]/route.ts
+++ b/frontend/app/api/teacher/permissions/[teacherId]/route.ts
@@ -1,37 +1,6 @@
-import {
-  RailsFetchError,
-  RailsUnauthorizedError,
-} from "@/libs/server/rails/railsError";
 import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { handleRailsRouteError } from "@/libs/server/rails/handleRailsRouteError";
 import { type NextRequest, NextResponse } from "next/server";
-
-export async function GET(
-  _: NextRequest,
-  { params }: { params: Promise<{ teacherId: string }> },
-) {
-  const { teacherId } = await params;
-
-  try {
-    const { status, data, setCookie } = await railsFetch(
-      `/api/v1/teacher/permissions/${teacherId}`,
-    );
-
-    const res = NextResponse.json(data, { status });
-
-    if (setCookie) res.headers.set("set-cookie", setCookie);
-
-    return res;
-  } catch (error) {
-    if (error instanceof RailsUnauthorizedError) {
-      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
-    }
-
-    return NextResponse.json(
-      { message: "INTERNAL_SERVER_ERROR" },
-      { status: 500 },
-    );
-  }
-}
 
 export async function PATCH(
   request: NextRequest,
@@ -50,25 +19,6 @@ export async function PATCH(
     if (setCookie) res.headers.set("set-cookie", setCookie);
     return res;
   } catch (error) {
-    if (error instanceof RailsUnauthorizedError) {
-      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
-    }
-
-    if (error instanceof RailsFetchError) {
-      let data: unknown = { errors: ["権限の更新に失敗しました"] };
-      if (error.bodyText) {
-        try {
-          data = JSON.parse(error.bodyText);
-        } catch (error) {
-          // パース失敗時はデフォルトのエラーメッセージを使う
-        }
-      }
-      return NextResponse.json(data, { status: error.status });
-    }
-
-    return NextResponse.json(
-      { message: "INTERNAL_SERVER_ERROR" },
-      { status: 500 },
-    );
+    return handleRailsRouteError(error, "権限の更新に失敗しました");
   }
 }

--- a/frontend/app/api/teacher/permissions/route.ts
+++ b/frontend/app/api/teacher/permissions/route.ts
@@ -1,0 +1,45 @@
+import {
+  RailsFetchError,
+  RailsUnauthorizedError,
+} from "@/libs/server/rails/railsError";
+import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const page = searchParams.get("page") ?? "1";
+
+  const params = new URLSearchParams({ page });
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/teacher/permissions?${params.toString()}`,
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+
+    return res;
+  } catch (error) {
+    if (error instanceof RailsUnauthorizedError) {
+      return NextResponse.json({ message: "UNAUTHORIZED" }, { status: 401 });
+    }
+
+    if (error instanceof RailsFetchError) {
+      let data: unknown = { errors: ["教員一覧の取得に失敗しました"] };
+      if (error.bodyText) {
+        try {
+          data = JSON.parse(error.bodyText);
+        } catch (error) {
+          // パース失敗時はデフォルトのエラーメッセージを使う
+        }
+      }
+      return NextResponse.json(data, { status: error.status });
+    }
+
+    return NextResponse.json(
+      { message: "INTERNAL_SERVER_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/frontend/features/TeacherPermissions/Presenter.tsx
+++ b/frontend/features/TeacherPermissions/Presenter.tsx
@@ -19,48 +19,46 @@ import {
   Typography,
 } from "@mui/material";
 import Link from "next/link";
-import {
-  CreateTeacherInput,
-  GradeOption,
-  SnackbarState,
-  TeachersData,
-} from "./types";
-import { CollegueCreateDrawer } from "./components/CollegueCreateDrawer";
 import { UseFormReturn } from "react-hook-form";
-import { invitationStatusConfig } from "./constants";
+import { PermissionEditDrawer } from "./components/PermissionEditDrawer";
+import {
+  PermissionTeacher,
+  SnackbarState,
+  TeacherPermissionsData,
+  UpdatePermissionInput,
+} from "./types";
 
 type Props = {
-  data: TeachersData;
+  data: TeacherPermissionsData;
   page: number;
   onPageChange: (page: number) => void;
-  drawerOpen: boolean;
-  onAddClick: () => void;
+  editingTeacher: PermissionTeacher | null;
+  onEditClick: (teacher: PermissionTeacher) => void;
   onDrawerClose: () => void;
-  onCreate: (input: CreateTeacherInput) => void;
-  creating: boolean;
-  createErrors: string[];
+  onUpdate: (input: UpdatePermissionInput) => void;
+  updating: boolean;
+  updateErrors: string[];
   snackbar: SnackbarState;
   onSnackbarClose: () => void;
-  gradeOptions: GradeOption[];
-  form: UseFormReturn<CreateTeacherInput>;
+  form: UseFormReturn<UpdatePermissionInput>;
 };
 
 export const Presenter = ({
   data,
   page,
   onPageChange,
-  drawerOpen,
-  onAddClick,
+  editingTeacher,
+  onEditClick,
   onDrawerClose,
-  onCreate,
-  creating,
-  createErrors,
+  onUpdate,
+  updating,
+  updateErrors,
   snackbar,
   onSnackbarClose,
-  gradeOptions,
   form,
 }: Props) => {
   const { current_user, teachers, meta } = data;
+  const canManage = current_user.teacher_permission.manage_other_teachers;
 
   return (
     <Box sx={{ p: 3 }}>
@@ -85,7 +83,7 @@ export const Presenter = ({
             fontWeight={700}
             sx={{ color: colors.text.primary }}
           >
-            教員一覧
+            教員権限管理
           </Typography>
 
           <Typography variant="body2" sx={{ color: colors.text.muted }}>
@@ -93,57 +91,29 @@ export const Presenter = ({
           </Typography>
         </Box>
 
-        {current_user.teacher_permission.manage_other_teachers && (
-          <Box sx={{ display: "flex", gap: 1.5, ml: "auto" }}>
-            <Button
-              component={Link}
-              href="/teacher/permissions"
-              variant="outlined"
-              size="small"
-              sx={{
-                minWidth: 110,
-                height: 36,
-                borderRadius: 2,
-                textTransform: "none",
-                fontWeight: 600,
-              }}
-            >
-              権限管理
-            </Button>
-            <Button
-              component={Link}
-              href="/teacher/colleague-invitation"
-              variant="outlined"
-              size="small"
-              sx={{
-                minWidth: 110,
-                height: 36,
-                borderRadius: 2,
-                textTransform: "none",
-                fontWeight: 600,
-              }}
-            >
-              未招待者一覧
-            </Button>
-            <Button
-              component={Link}
-              href=""
-              variant="outlined"
-              size="small"
-              sx={{
-                minWidth: 110,
-                height: 36,
-                borderRadius: 2,
-                textTransform: "none",
-                fontWeight: 600,
-              }}
-              onClick={onAddClick}
-            >
-              新規登録
-            </Button>
-          </Box>
-        )}
+        <Button
+          component={Link}
+          href="/teacher/colleagues"
+          variant="outlined"
+          size="small"
+          sx={{
+            minWidth: 110,
+            height: 36,
+            borderRadius: 2,
+            textTransform: "none",
+            fontWeight: 600,
+          }}
+        >
+          教員一覧へ戻る
+        </Button>
       </Box>
+
+      {!canManage && (
+        <Alert severity="info" sx={{ mb: 3 }}>
+          権限を編集するには「他の教員操作権限」が必要です。
+        </Alert>
+      )}
+
       <Card
         elevation={0}
         sx={{
@@ -178,19 +148,15 @@ export const Presenter = ({
                   }}
                 >
                   <TableCell>氏名</TableCell>
-                  <TableCell>氏名カナ</TableCell>
-                  <TableCell>担当学年</TableCell>
                   <TableCell align="center">操作範囲</TableCell>
                   <TableCell align="center">他職員権限</TableCell>
-                  <TableCell align="center">送信状況</TableCell>
-                  <TableCell align="center">詳細</TableCell>
+                  <TableCell align="center">編集</TableCell>
                 </TableRow>
               </TableHead>
 
               <TableBody>
                 {teachers.map((teacher) => {
-                  const status =
-                    invitationStatusConfig[teacher.invitation_status];
+                  const isSelf = teacher.id === current_user.id;
 
                   return (
                     <TableRow
@@ -205,11 +171,16 @@ export const Presenter = ({
                     >
                       <TableCell sx={{ fontWeight: 600 }}>
                         {teacher.name}
+                        {isSelf && (
+                          <Typography
+                            component="span"
+                            variant="caption"
+                            sx={{ color: colors.text.muted, ml: 1 }}
+                          >
+                            （自分）
+                          </Typography>
+                        )}
                       </TableCell>
-
-                      <TableCell>{teacher.name_kana}</TableCell>
-
-                      <TableCell>{teacher.grade.display_name}</TableCell>
 
                       <TableCell align="center">
                         <Chip
@@ -254,28 +225,11 @@ export const Presenter = ({
                       </TableCell>
 
                       <TableCell align="center">
-                        <Chip
-                          label={status.label}
-                          size="small"
-                          color={status.color}
-                          variant="outlined"
-                          sx={{
-                            minWidth: 64,
-                            height: 24,
-                            fontSize: "0.75rem",
-                            fontWeight: 600,
-                            opacity:
-                              teacher.invitation_status === "sent" ? 0.7 : 1,
-                          }}
-                        />
-                      </TableCell>
-
-                      <TableCell align="center">
                         <Button
-                          component={Link}
-                          href={`/teacher/colleagues/${teacher.id}`}
                           size="small"
                           variant="outlined"
+                          disabled={!canManage || isSelf}
+                          onClick={() => onEditClick(teacher)}
                           sx={{
                             minWidth: 64,
                             height: 28,
@@ -285,7 +239,7 @@ export const Presenter = ({
                             textTransform: "none",
                           }}
                         >
-                          詳細
+                          編集
                         </Button>
                       </TableCell>
                     </TableRow>
@@ -297,13 +251,12 @@ export const Presenter = ({
         </CardContent>
       </Card>
 
-      <CollegueCreateDrawer
-        open={drawerOpen}
+      <PermissionEditDrawer
+        teacher={editingTeacher}
         onClose={onDrawerClose}
-        onCreate={onCreate}
-        creating={creating}
-        createErrors={createErrors}
-        gradeOptions={gradeOptions}
+        onUpdate={onUpdate}
+        updating={updating}
+        updateErrors={updateErrors}
         form={form}
       />
 

--- a/frontend/features/TeacherPermissions/components/PermissionEditDrawer.tsx
+++ b/frontend/features/TeacherPermissions/components/PermissionEditDrawer.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { colors } from "@/app/theme/colors";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Drawer,
+  FormControlLabel,
+  FormHelperText,
+  Radio,
+  RadioGroup,
+  Stack,
+  Typography,
+} from "@mui/material";
+import { Controller, UseFormReturn } from "react-hook-form";
+import type { PermissionTeacher, UpdatePermissionInput } from "../types";
+
+type Props = {
+  teacher: PermissionTeacher | null;
+  onClose: () => void;
+  onUpdate: (input: UpdatePermissionInput) => void;
+  updating: boolean;
+  updateErrors: string[];
+  form: UseFormReturn<UpdatePermissionInput>;
+};
+
+export const PermissionEditDrawer = ({
+  teacher,
+  onClose,
+  onUpdate,
+  updating,
+  updateErrors,
+  form,
+}: Props) => {
+  const {
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = form;
+
+  return (
+    <Drawer
+      anchor="right"
+      open={teacher !== null}
+      onClose={onClose}
+      slotProps={{ paper: { sx: { width: 480, maxWidth: "100%" } } }}
+    >
+      <Box
+        component="form"
+        onSubmit={handleSubmit(onUpdate)}
+        sx={{ display: "flex", flexDirection: "column", height: "100%" }}
+      >
+        <Box
+          sx={{
+            p: 3,
+            borderBottom: `1px solid ${colors.border.light}`,
+          }}
+        >
+          <Typography variant="h6" fontWeight={700}>
+            権限を編集
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={{ color: colors.text.muted, mt: 0.5 }}
+          >
+            {teacher?.name}
+          </Typography>
+        </Box>
+
+        <Box sx={{ p: 3, flex: 1, overflow: "auto" }}>
+          {updateErrors.length > 0 && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              <Stack component="ul" sx={{ m: 0, pl: 2 }} spacing={0.5}>
+                {updateErrors.map((message, index) => (
+                  <li key={index}>{message}</li>
+                ))}
+              </Stack>
+            </Alert>
+          )}
+          <Stack spacing={3}>
+            <Controller
+              name="grade_scope"
+              control={control}
+              rules={{ required: "操作範囲を選択してください" }}
+              render={({ field }) => (
+                <Box>
+                  <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+                    操作範囲
+                  </Typography>
+                  <RadioGroup row {...field} value={field.value}>
+                    <FormControlLabel
+                      value="own_grade"
+                      control={<Radio />}
+                      label="自学年"
+                    />
+                    <FormControlLabel
+                      value="all_grades"
+                      control={<Radio />}
+                      label="全学年"
+                    />
+                  </RadioGroup>
+                  {errors.grade_scope && (
+                    <FormHelperText error>
+                      {errors.grade_scope.message}
+                    </FormHelperText>
+                  )}
+                </Box>
+              )}
+            />
+
+            <Controller
+              name="manage_other_teachers"
+              control={control}
+              render={({ field }) => (
+                <Box>
+                  <Typography variant="body2" sx={{ mb: 1, fontWeight: 600 }}>
+                    他の教員操作権限
+                  </Typography>
+
+                  <RadioGroup
+                    row
+                    value={field.value ? "1" : "0"}
+                    onChange={(event) =>
+                      field.onChange(event.target.value === "1")
+                    }
+                  >
+                    <FormControlLabel
+                      value="0"
+                      control={<Radio />}
+                      label="無"
+                    />
+                    <FormControlLabel
+                      value="1"
+                      control={<Radio />}
+                      label="有"
+                    />
+                  </RadioGroup>
+                </Box>
+              )}
+            />
+          </Stack>
+        </Box>
+
+        <Box
+          sx={{
+            p: 3,
+            borderTop: `1px solid ${colors.border.light}`,
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: 1.5,
+          }}
+        >
+          <Button onClick={onClose} disabled={updating} color="inherit">
+            キャンセル
+          </Button>
+          <Button
+            type="submit"
+            variant="contained"
+            disabled={updating}
+            startIcon={
+              updating ? <CircularProgress size={16} color="inherit" /> : null
+            }
+          >
+            保存
+          </Button>
+        </Box>
+      </Box>
+    </Drawer>
+  );
+};

--- a/frontend/features/TeacherPermissions/hooks/useFetchTeacherPermissions.ts
+++ b/frontend/features/TeacherPermissions/hooks/useFetchTeacherPermissions.ts
@@ -7,6 +7,7 @@ import { TeacherPermissionsData } from "../types";
 
 export const useFetchTeacherPermissions = () => {
   const [data, setData] = useState<TeacherPermissionsData | null>(null);
+  const [error, setError] = useState<unknown>(null);
   const [page, setPage] = useState(1);
   const router = useRouter();
 
@@ -15,11 +16,16 @@ export const useFetchTeacherPermissions = () => {
 
     apiClient
       .get<TeacherPermissionsData>("/api/teacher/permissions", { params })
-      .then((res) => setData(res.data))
+      .then((res) => {
+        setData(res.data);
+        setError(null);
+      })
       .catch((err) => {
         if (err.response?.status === 401) {
           router.push("/login");
+          return;
         }
+        setError(err);
       });
   }, [page, router]);
 
@@ -27,5 +33,5 @@ export const useFetchTeacherPermissions = () => {
     fetchTeacherPermissions();
   }, [fetchTeacherPermissions]);
 
-  return { data, page, setPage, refetch: fetchTeacherPermissions };
+  return { data, page, setPage, error, refetch: fetchTeacherPermissions };
 };

--- a/frontend/features/TeacherPermissions/hooks/useFetchTeacherPermissions.ts
+++ b/frontend/features/TeacherPermissions/hooks/useFetchTeacherPermissions.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { apiClient } from "@/libs/http/apiClient";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { TeacherPermissionsData } from "../types";
+
+export const useFetchTeacherPermissions = () => {
+  const [data, setData] = useState<TeacherPermissionsData | null>(null);
+  const [page, setPage] = useState(1);
+  const router = useRouter();
+
+  const fetchTeacherPermissions = useCallback(() => {
+    const params: Record<string, string> = { page: String(page) };
+
+    apiClient
+      .get<TeacherPermissionsData>("/api/teacher/permissions", { params })
+      .then((res) => setData(res.data))
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          router.push("/login");
+        }
+      });
+  }, [page, router]);
+
+  useEffect(() => {
+    fetchTeacherPermissions();
+  }, [fetchTeacherPermissions]);
+
+  return { data, page, setPage, refetch: fetchTeacherPermissions };
+};

--- a/frontend/features/TeacherPermissions/hooks/usePermissionForm.ts
+++ b/frontend/features/TeacherPermissions/hooks/usePermissionForm.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import type { UpdatePermissionInput } from "../types";
+
+const defaultValues: UpdatePermissionInput = {
+  grade_scope: "own_grade",
+  manage_other_teachers: false,
+};
+
+export const usePermissionForm = () => {
+  return useForm<UpdatePermissionInput>({
+    defaultValues,
+  });
+};

--- a/frontend/features/TeacherPermissions/hooks/useUpdatePermission.ts
+++ b/frontend/features/TeacherPermissions/hooks/useUpdatePermission.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { apiClient } from "@/libs/http/apiClient";
+import { extractApiError } from "@/libs/http/extractApiError";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { UseFormReturn } from "react-hook-form";
+import type {
+  PermissionTeacher,
+  SnackbarState,
+  UpdatePermissionInput,
+} from "../types";
+
+const initialSnackbar: SnackbarState = {
+  open: false,
+  message: "",
+  severity: "success",
+};
+
+type UseUpdatePermissionParams = {
+  // 更新成功後に呼ばれる（一覧の再取得など）
+  onUpdated: () => void;
+  form: UseFormReturn<UpdatePermissionInput>;
+};
+
+export const useUpdatePermission = ({
+  onUpdated,
+  form,
+}: UseUpdatePermissionParams) => {
+  const [editingTeacher, setEditingTeacher] =
+    useState<PermissionTeacher | null>(null);
+  const [updating, setUpdating] = useState(false);
+  const [updateErrors, setUpdateErrors] = useState<string[]>([]);
+  const [snackbar, setSnackbar] = useState<SnackbarState>(initialSnackbar);
+  const router = useRouter();
+
+  const handleEditClick = (teacher: PermissionTeacher) => {
+    form.reset({
+      grade_scope: teacher.teacher_permission.grade_scope,
+      manage_other_teachers: teacher.teacher_permission.manage_other_teachers,
+    });
+    setUpdateErrors([]);
+    setEditingTeacher(teacher);
+  };
+
+  const handleDrawerClose = () => {
+    form.reset();
+    setEditingTeacher(null);
+    setUpdateErrors([]);
+  };
+
+  const handleUpdate = async (input: UpdatePermissionInput) => {
+    if (!editingTeacher) return;
+
+    setUpdating(true);
+    setUpdateErrors([]);
+
+    try {
+      await apiClient.patch(`/api/teacher/permissions/${editingTeacher.id}`, {
+        teacher_permission: input,
+      });
+      setEditingTeacher(null);
+      setSnackbar({
+        open: true,
+        message: "権限を更新しました",
+        severity: "success",
+      });
+      onUpdated();
+    } catch (err) {
+      const { status, errors } = extractApiError(err);
+
+      if (status === 401) {
+        router.push("/login");
+      }
+
+      setUpdateErrors(errors ?? ["権限の更新に失敗しました"]);
+    } finally {
+      setUpdating(false);
+    }
+  };
+
+  const handleSnackbarClose = () => {
+    setSnackbar((prev) => ({ ...prev, open: false }));
+  };
+
+  return {
+    editingTeacher,
+    updating,
+    updateErrors,
+    snackbar,
+    handleEditClick,
+    handleDrawerClose,
+    handleUpdate,
+    handleSnackbarClose,
+  };
+};

--- a/frontend/features/TeacherPermissions/index.tsx
+++ b/frontend/features/TeacherPermissions/index.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Box, CircularProgress } from "@mui/material";
+import { useFetchTeacherPermissions } from "./hooks/useFetchTeacherPermissions";
+import { usePermissionForm } from "./hooks/usePermissionForm";
+import { useUpdatePermission } from "./hooks/useUpdatePermission";
+import { Presenter } from "./Presenter";
+
+export const TeacherPermissions = () => {
+  const { data, page, setPage, refetch } = useFetchTeacherPermissions();
+
+  const form = usePermissionForm();
+
+  const {
+    editingTeacher,
+    updating,
+    updateErrors,
+    snackbar,
+    handleEditClick,
+    handleDrawerClose,
+    handleUpdate,
+    handleSnackbarClose,
+  } = useUpdatePermission({ onUpdated: refetch, form });
+
+  if (!data) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <Presenter
+      data={data}
+      page={page}
+      onPageChange={setPage}
+      editingTeacher={editingTeacher}
+      onEditClick={handleEditClick}
+      onDrawerClose={handleDrawerClose}
+      onUpdate={handleUpdate}
+      updating={updating}
+      updateErrors={updateErrors}
+      snackbar={snackbar}
+      onSnackbarClose={handleSnackbarClose}
+      form={form}
+    />
+  );
+};

--- a/frontend/features/TeacherPermissions/index.tsx
+++ b/frontend/features/TeacherPermissions/index.tsx
@@ -7,7 +7,7 @@ import { useUpdatePermission } from "./hooks/useUpdatePermission";
 import { Presenter } from "./Presenter";
 
 export const TeacherPermissions = () => {
-  const { data, page, setPage, refetch } = useFetchTeacherPermissions();
+  const { data, page, setPage, error, refetch } = useFetchTeacherPermissions();
 
   const form = usePermissionForm();
 
@@ -21,6 +21,21 @@ export const TeacherPermissions = () => {
     handleUpdate,
     handleSnackbarClose,
   } = useUpdatePermission({ onUpdated: refetch, form });
+
+  if (error) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        データの取得に失敗しました
+      </Box>
+    );
+  }
 
   if (!data) {
     return (

--- a/frontend/features/TeacherPermissions/types.ts
+++ b/frontend/features/TeacherPermissions/types.ts
@@ -1,0 +1,49 @@
+export type GradeScope = "own_grade" | "all_grades";
+
+export type TeacherPermission = {
+  id: number;
+  grade_scope: GradeScope;
+  manage_other_teachers: boolean;
+};
+
+export type CurrentUser = {
+  id: number;
+  name: string;
+  name_kana: string;
+  grade: {
+    year: number;
+    display_name: string;
+  };
+  invitation_status: "pending" | "sent" | "failed";
+  teacher_permission: TeacherPermission;
+};
+
+export type PermissionTeacher = {
+  id: number;
+  name: string;
+  teacher_permission: TeacherPermission;
+};
+
+export type TeacherPermissionsMeta = {
+  current_page: number;
+  total_pages: number;
+  total_count: number;
+  per_page: number;
+};
+
+export type TeacherPermissionsData = {
+  current_user: CurrentUser;
+  teachers: PermissionTeacher[];
+  meta: TeacherPermissionsMeta;
+};
+
+export type UpdatePermissionInput = {
+  grade_scope: GradeScope;
+  manage_other_teachers: boolean;
+};
+
+export type SnackbarState = {
+  open: boolean;
+  message: string;
+  severity: "success" | "error";
+};


### PR DESCRIPTION
教員一覧画面の「権限管理」ボタン（未実装だった空リンク）から遷移する
教員権限管理画面を追加。既存のTeacher::PermissionsController（index/ show/update）に対応するBFF APIルートとfeature一式を実装。

## 概要
Notionに特に記載していないため貼っていない
<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

教員が同僚教員の権限（操作範囲・他教員操作権限）を管理できる「教員権限管理画面」を追加。教員一覧画面に元々あった「権限管理」ボタン（href=""の未実装リンク）の遷移先を実装した形。
バックエンドのTeacher::PermissionsController（index/show/update）は既存実装済みのため、今回はフロントエンドのみの対応。

## 詳細

<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

### frontend/app/api/teacher/permissions/route.ts
・[teacherId]/route.ts 既存のcolleagues用BFFルートと同じパターンで、Rails GET/PATCH /api/v1/teacher/permissions へのプロキシを追加
### frontend/features/TeacherPermissions/ 
- 一覧テーブル（氏名・操作範囲・他職員権限・編集）＋編集用ドロワー（CollegueCreateDrawerのRadioGroupと同じUI）
自分自身の行は「（自分）」表示＋編集ボタンを無効化（Rails側の自己編集禁止バリデーションと対応）
manage_other_teachers権限を持たない教員は一覧の閲覧はできるが編集ボタンは無効化（require_manage_other_teachers!と対応）最後の1人のアクティブ教員を降格しようとした場合などのエラーは、Rails側のバリデーションメッセージをそのままドロワー上部に表示
### frontend/features/Colleagues/Presenter.tsx 
「権限管理」ボタンのhrefを""→/teacher/permissionsに修正
レビュアーへの補足：一覧（GET）はmanage_other_teachersを持たない教員でも閲覧可能（編集のみ不可）という設計は、既存のRailsコントローラの挙動をそのまま踏襲しています（indexには権限チェックのbefore_actionが付いていない）。

## 動作確認

<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/2af239d6-8841-4b15-92c4-646774fe47e4" />

### Rails/Next.jsをローカル起動し、教員アカウントでログインして以下を確認済み。

- 教員一覧画面の「権限管理」ボタンから/teacher/permissionsへ遷移できること
- 一覧に氏名・操作範囲・他職員権限が表示され、自分の行の編集ボタンが無効化されていること
- 編集ボタンから対象教員の現在値がプリセットされたドロワーが開くこと
- 操作範囲・他職員権限を変更して保存すると、成功トースト表示後に一覧へ反映されること

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
