### PR TITLE
[Rails]生徒コード・学校コードの基盤追加

### DIFF
--- a/rails/app/models/high_school.rb
+++ b/rails/app/models/high_school.rb
@@ -9,8 +9,12 @@
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  prefecture_id :bigint           not null
+#  school_code   :string
+#  csv_managed   :boolean          default(FALSE), not null
 #
 class HighSchool < ApplicationRecord
+  before_create :generate_school_code
+
   belongs_to :prefecture
   has_many :users
   has_many :grades
@@ -18,4 +22,18 @@ class HighSchool < ApplicationRecord
   scope :by_prefecture, ->(prefecture_id) { prefecture_id.present? ? where(prefecture_id: prefecture_id) : all }
 
   validates :name, presence: true
+  validates :school_code, uniqueness: true, allow_nil: true
+
+  def self.generate_unique_school_code
+    loop do
+      code = SecureRandom.alphanumeric(6).upcase
+      break code unless HighSchool.exists?(school_code: code)
+    end
+  end
+
+  private
+
+  def generate_school_code
+    self.school_code ||= self.class.generate_unique_school_code
+  end
 end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -120,7 +120,7 @@ class User < ApplicationRecord
     raise "生徒以外(#{user_role&.name})にstudent_numberは発行できません" unless student?
 
     self.student_number = loop do
-      code = "#{high_school.school_code}#{SecureRandom.alphanumeric(8).upcase}"
+      code = "#{high_school.school_code}-#{SecureRandom.alphanumeric(8).upcase}"
       break code unless User.exists?(student_number: code)
     end
   end

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -23,6 +23,7 @@
 #  password_reset_required :boolean          default(FALSE), not null
 #  activated_at            :datetime
 #  school_class_id         :bigint
+#  student_number          :string
 #
 class User < ApplicationRecord
   include Devise::JWT::RevocationStrategies::JTIMatcher
@@ -66,6 +67,8 @@ class User < ApplicationRecord
   validates :user_role, presence: true
   validates :high_school, presence: true, if: :requires_high_school?
   validates :grade, presence: true, if: :student?
+  validates :student_number, uniqueness: true, allow_nil: true
+  validates :student_number, absence: true, unless: :student?
 
   validate :school_class_belongs_to_grade
 
@@ -112,6 +115,15 @@ class User < ApplicationRecord
   scope :high_school_current, -> { joins(:grade).where(grades: { year: 1..3 }) }
   scope :invitation_pending, -> { where(password_reset_required: true) }
   scope :active, -> { where(deleted_at: nil) }
+
+  def generate_student_number
+    raise "生徒以外(#{user_role&.name})にstudent_numberは発行できません" unless student?
+
+    self.student_number = loop do
+      code = "#{high_school.school_code}#{SecureRandom.alphanumeric(8).upcase}"
+      break code unless User.exists?(student_number: code)
+    end
+  end
 
   private
 

--- a/rails/db/migrate/20260817143314_add_columns_to_high_school.rb
+++ b/rails/db/migrate/20260817143314_add_columns_to_high_school.rb
@@ -1,0 +1,8 @@
+class AddColumnsToHighSchool < ActiveRecord::Migration[7.2]
+  def change
+    add_column :high_schools, :school_code, :string
+    add_column :high_schools, :csv_managed, :boolean, null: false, default: false
+
+    add_index :high_schools, :school_code, unique: true
+  end
+end

--- a/rails/db/migrate/20260817145736_add_column_to_user.rb
+++ b/rails/db/migrate/20260817145736_add_column_to_user.rb
@@ -1,0 +1,6 @@
+class AddColumnToUser < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :student_number, :string
+    add_index :users, :student_number, unique: true
+  end
+end

--- a/rails/db/schema.rb
+++ b/rails/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_08_08_174745) do
+ActiveRecord::Schema[7.2].define(version: 2026_08_17_145736) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -155,8 +155,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_174745) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "prefecture_id", null: false
+    t.string "school_code"
+    t.boolean "csv_managed", default: false, null: false
     t.index ["name", "prefecture_id"], name: "index_high_schools_on_name_and_prefecture_id", unique: true
     t.index ["prefecture_id"], name: "index_high_schools_on_prefecture_id"
+    t.index ["school_code"], name: "index_high_schools_on_school_code", unique: true
   end
 
   create_table "import_errors", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -306,6 +309,25 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_174745) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["course_id"], name: "index_review_tests_on_course_id"
+  end
+
+  create_table "school_class_requests", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "school_class_id"
+    t.bigint "applicant_id", null: false
+    t.bigint "approver_id"
+    t.bigint "grade_id", null: false
+    t.integer "action", null: false
+    t.integer "status", default: 0, null: false
+    t.string "name"
+    t.datetime "approved_at"
+    t.datetime "cancelled_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "lock_version", default: 0, null: false
+    t.index ["applicant_id"], name: "index_school_class_requests_on_applicant_id"
+    t.index ["approver_id"], name: "index_school_class_requests_on_approver_id"
+    t.index ["grade_id"], name: "index_school_class_requests_on_grade_id"
+    t.index ["school_class_id"], name: "index_school_class_requests_on_school_class_id"
   end
 
   create_table "school_classes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -508,6 +530,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_174745) do
     t.boolean "password_reset_required", default: false, null: false
     t.datetime "activated_at"
     t.bigint "school_class_id"
+    t.string "student_number"
     t.index ["address_id"], name: "index_users_on_address_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["grade_id"], name: "index_users_on_grade_id"
@@ -515,6 +538,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_174745) do
     t.index ["jti"], name: "index_users_on_jti", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["school_class_id"], name: "index_users_on_school_class_id"
+    t.index ["student_number"], name: "index_users_on_student_number", unique: true
     t.index ["user_role_id"], name: "index_users_on_user_role_id"
   end
 
@@ -554,6 +578,10 @@ ActiveRecord::Schema[7.2].define(version: 2026_08_08_174745) do
   add_foreign_key "review_question_choices", "review_questions"
   add_foreign_key "review_questions", "review_tests"
   add_foreign_key "review_tests", "courses"
+  add_foreign_key "school_class_requests", "grades"
+  add_foreign_key "school_class_requests", "school_classes"
+  add_foreign_key "school_class_requests", "users", column: "applicant_id"
+  add_foreign_key "school_class_requests", "users", column: "approver_id"
   add_foreign_key "school_classes", "grades"
   add_foreign_key "study_logs", "tasks"
   add_foreign_key "study_logs", "units"

--- a/rails/lib/tasks/backfill_school_codes.rake
+++ b/rails/lib/tasks/backfill_school_codes.rake
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+namespace :high_schools do
+  desc 'school_code が未設定の high_schools に一意なコードを一括採番する（何度実行しても未設定の分のみ処理する）'
+  task backfill_school_codes: :environment do
+    target = HighSchool.where(school_code: [nil, ''])
+    total = target.count
+
+    if total.zero?
+      puts 'school_code が未設定の高校はありません（対象0件）。'
+      next
+    end
+
+    puts "#{total}件の高校に school_code を採番します..."
+
+    updated = 0
+    target.find_each do |high_school|
+      high_school.update!(school_code: HighSchool.generate_unique_school_code)
+      updated += 1
+      puts "  [#{updated}/#{total}] #{high_school.name} -> #{high_school.school_code}" if (updated % 100).zero? || updated == total
+    end
+
+    puts "完了: #{updated}件の school_code を採番しました。"
+  end
+end

--- a/rails/lib/tasks/backfill_school_codes.rake
+++ b/rails/lib/tasks/backfill_school_codes.rake
@@ -17,7 +17,9 @@ namespace :high_schools do
     target.find_each do |high_school|
       high_school.update!(school_code: HighSchool.generate_unique_school_code)
       updated += 1
-      puts "  [#{updated}/#{total}] #{high_school.name} -> #{high_school.school_code}" if (updated % 100).zero? || updated == total
+      if (updated % 100).zero? || updated == total
+        puts "  [#{updated}/#{total}] #{high_school.name} -> #{high_school.school_code}"
+      end
     end
 
     puts "完了: #{updated}件の school_code を採番しました。"

--- a/rails/spec/models/high_school_spec.rb
+++ b/rails/spec/models/high_school_spec.rb
@@ -15,5 +15,48 @@ require 'rails_helper'
 RSpec.describe HighSchool, type: :model do
   describe 'バリデーション' do
     it { is_expected.to validate_presence_of(:name) }
+
+    it 'school_codeが重複していると無効' do
+      create(:high_school, school_code: 'ABC123')
+      high_school = build(:high_school, school_code: 'ABC123')
+
+      expect(high_school).to be_invalid
+      expect(high_school.errors[:school_code]).to be_present
+    end
+
+    it 'school_codeがnilなら重複チェック対象外(newの時点では有効)' do
+      high_school = build(:high_school, school_code: nil)
+
+      expect(high_school).to be_valid
+    end
+  end
+
+  describe '#generate_school_code (before_create)' do
+    it 'school_code未設定なら作成時に自動生成される' do
+      high_school = create(:high_school, school_code: nil)
+
+      expect(high_school.school_code).to be_present
+    end
+
+    it 'school_codeが既に設定されていれば上書きしない' do
+      high_school = create(:high_school, school_code: 'FIXED1')
+
+      expect(high_school.school_code).to eq('FIXED1')
+    end
+
+    it '生成されるschool_codeは高校ごとに一意になる' do
+      codes = create_list(:high_school, 5).map(&:school_code)
+
+      expect(codes.uniq.size).to eq(5)
+    end
+
+    it '生成したコードが既存と衝突する場合は別のコードを再生成する' do
+      create(:high_school, school_code: 'AAAAAA')
+      allow(SecureRandom).to receive(:alphanumeric).with(6).and_return('aaaaaa', 'bbbbbb')
+
+      new_school = create(:high_school, school_code: nil)
+
+      expect(new_school.school_code).to eq('BBBBBB')
+    end
   end
 end

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe User, type: :model do
       student.generate_student_number
 
       expect(student.student_number).to start_with(high_school.school_code)
-      expect(student.student_number.length).to eq(high_school.school_code.length + 8)
+      expect(student.student_number.length).to eq(high_school.school_code.length + 1 + 8)
     end
 
     it '生徒以外に対して呼ぶと例外になる' do
@@ -148,12 +148,12 @@ RSpec.describe User, type: :model do
 
     it '生成されるstudent_numberは既存と衝突しない' do
       create(:user, user_role: student_role, high_school:, grade:,
-                    student_number: "#{high_school.school_code}AAAAAAAA")
+                    student_number: "#{high_school.school_code}-AAAAAAAA")
       allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('aaaaaaaa', 'bbbbbbbb')
 
       student.generate_student_number
 
-      expect(student.student_number).to eq("#{high_school.school_code}BBBBBBBB")
+      expect(student.student_number).to eq("#{high_school.school_code}-BBBBBBBB")
     end
   end
 end

--- a/rails/spec/models/user_spec.rb
+++ b/rails/spec/models/user_spec.rb
@@ -98,5 +98,62 @@ RSpec.describe User, type: :model do
         expect(user.errors[:school_class]).to include('学年が一致しません')
       end
     end
+
+    describe 'student_number' do
+      it '生徒はstudent_numberを保持できる' do
+        student = build(:user, user_role: student_role, high_school:, grade:, student_number: 'ABC12345')
+
+        expect(student).to be_valid
+      end
+
+      it '生徒以外はstudent_numberを保持できない' do
+        teacher = build(:user, user_role: teacher_role, high_school:, student_number: 'ABC12345')
+
+        expect(teacher).to be_invalid
+        expect(teacher.errors[:student_number]).to be_present
+      end
+
+      it 'student_numberが重複していると無効' do
+        create(:user, user_role: student_role, high_school:, grade:, student_number: 'DUPLICATE1')
+        student2 = build(:user, user_role: student_role, high_school:, grade:, student_number: 'DUPLICATE1')
+
+        expect(student2).to be_invalid
+        expect(student2.errors[:student_number]).to be_present
+      end
+
+      it 'student_numberがnilな生徒は複数存在できる' do
+        create(:user, user_role: student_role, high_school:, grade:, student_number: nil)
+        student2 = build(:user, user_role: student_role, high_school:, grade:, student_number: nil)
+
+        expect(student2).to be_valid
+      end
+    end
+  end
+
+  describe '#generate_student_number' do
+    let(:student) { create(:user, user_role: student_role, high_school:, grade:) }
+
+    it '生徒であればschool_code+ランダム値のstudent_numberが生成される' do
+      student.generate_student_number
+
+      expect(student.student_number).to start_with(high_school.school_code)
+      expect(student.student_number.length).to eq(high_school.school_code.length + 8)
+    end
+
+    it '生徒以外に対して呼ぶと例外になる' do
+      teacher = create(:user, user_role: teacher_role, high_school:)
+
+      expect { teacher.generate_student_number }.to raise_error(/生徒以外/)
+    end
+
+    it '生成されるstudent_numberは既存と衝突しない' do
+      create(:user, user_role: student_role, high_school:, grade:,
+                    student_number: "#{high_school.school_code}AAAAAAAA")
+      allow(SecureRandom).to receive(:alphanumeric).with(8).and_return('aaaaaaaa', 'bbbbbbbb')
+
+      student.generate_student_number
+
+      expect(student.student_number).to eq("#{high_school.school_code}BBBBBBBB")
+    end
   end
 end


### PR DESCRIPTION
自己登録と学校CSV導入のどちらが先でも生徒アカウントが重複しないよう、
high_schools.school_code / users.student_number を追加。school_code は 高校作成時に自動採番し、student_number は school_code を内包する形で
生徒作成時に生成できるようにした。既存の全高校には一括backfillタスクで
school_code を採番済み。

## 概要

<!--
NotionのURLを書きましょう
背景があればそれも併せて書きましょう
-->

https://app.notion.com/p/Rails-1-3be2946467fd80d79056f9fc0bacd102

## 詳細
notionのコメントに高校に一括でschool_codeが入るコマンド貼ってます。

<!--
レビュアーに重点的に見て欲しい内容を書きましょう
レビュアーが疑問に思いそうな部分にコメントしておくと理解しやすいです
-->

## 動作確認
テストを追加して既存に影響しない事と、今回の追加に関係するテスト追加
<!--
修正内容について試したこと、スクリーンショット、インタラクションを伴う場合は GIF などを記載しましょう
-->

## その他

<!--
ライブラリを導入した場合は比較候補と選定理由を記載してください
-->

## 参考情報

<!--
参考記事の url などを記載しましょう
-->
