### PR TITLE
[Rails]インポート履歴一覧・詳細・CSVエクスポートAPI

### DIFF
--- a/rails/app/controllers/api/v1/admin/import_histories_controller.rb
+++ b/rails/app/controllers/api/v1/admin/import_histories_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Admin
+      class ImportHistoriesController < BaseController
+        def index
+          per_page = sanitized_per_page
+          histories = ::Admin::ImportHistoriesQuery.new
+                                                   .by_status(params[:status])
+                                                   .by_unit_id(params[:unit_id])
+                                                   .by_course_id(params[:course_id])
+                                                   .by_user_id(params[:user_id])
+                                                   .by_period(params[:from], params[:to])
+                                                   .order_by_created_at_desc
+                                                   .result
+                                                   .page(sanitized_page).per(per_page)
+
+          render json: {
+            import_histories: ActiveModelSerializers::SerializableResource.new(
+              histories,
+              each_serializer: ::Admin::ImportHistoryListSerializer
+            ),
+            meta: {
+              current_page: histories.current_page,
+              total_pages: histories.total_pages,
+              total_count: histories.total_count,
+              per_page: per_page
+            }
+          }
+        end
+      end
+    end
+  end
+end

--- a/rails/app/controllers/api/v1/admin/import_histories_controller.rb
+++ b/rails/app/controllers/api/v1/admin/import_histories_controller.rb
@@ -29,6 +29,12 @@ module Api
             }
           }
         end
+
+        def show
+          history = ImportHistory.includes(:user, :import_errors, unit: :course).find(params[:id])
+
+          render json: history, serializer: ::Admin::ImportHistoryDetailSerializer
+        end
       end
     end
   end

--- a/rails/app/controllers/api/v1/admin/import_histories_controller.rb
+++ b/rails/app/controllers/api/v1/admin/import_histories_controller.rb
@@ -42,7 +42,7 @@ module Api
 
         def import_histories_scope
           ::Admin::ImportHistoriesQuery.new.call(
-            params.slice(:status, :unit_id, :course_id, :user_id, :from, :to)
+            params.slice(:status, :unit_id, :course_id, :user_id, :from, :to, :sort, :order)
           )
         end
       end

--- a/rails/app/controllers/api/v1/admin/import_histories_controller.rb
+++ b/rails/app/controllers/api/v1/admin/import_histories_controller.rb
@@ -41,14 +41,9 @@ module Api
         private
 
         def import_histories_scope
-          ::Admin::ImportHistoriesQuery.new
-                                       .by_status(params[:status])
-                                       .by_unit_id(params[:unit_id])
-                                       .by_course_id(params[:course_id])
-                                       .by_user_id(params[:user_id])
-                                       .by_period(params[:from], params[:to])
-                                       .order_by_created_at_desc
-                                       .result
+          ::Admin::ImportHistoriesQuery.new.call(
+            params.slice(:status, :unit_id, :course_id, :user_id, :from, :to)
+          )
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/import_histories_controller.rb
+++ b/rails/app/controllers/api/v1/admin/import_histories_controller.rb
@@ -6,15 +6,7 @@ module Api
       class ImportHistoriesController < BaseController
         def index
           per_page = sanitized_per_page
-          histories = ::Admin::ImportHistoriesQuery.new
-                                                   .by_status(params[:status])
-                                                   .by_unit_id(params[:unit_id])
-                                                   .by_course_id(params[:course_id])
-                                                   .by_user_id(params[:user_id])
-                                                   .by_period(params[:from], params[:to])
-                                                   .order_by_created_at_desc
-                                                   .result
-                                                   .page(sanitized_page).per(per_page)
+          histories = import_histories_scope.page(sanitized_page).per(per_page)
 
           render json: {
             import_histories: ActiveModelSerializers::SerializableResource.new(
@@ -44,6 +36,19 @@ module Api
                     filename: "import_history_#{history.id}.csv",
                     type: 'text/csv; charset=UTF-8',
                     disposition: 'attachment'
+        end
+
+        private
+
+        def import_histories_scope
+          ::Admin::ImportHistoriesQuery.new
+                                       .by_status(params[:status])
+                                       .by_unit_id(params[:unit_id])
+                                       .by_course_id(params[:course_id])
+                                       .by_user_id(params[:user_id])
+                                       .by_period(params[:from], params[:to])
+                                       .order_by_created_at_desc
+                                       .result
         end
       end
     end

--- a/rails/app/controllers/api/v1/admin/import_histories_controller.rb
+++ b/rails/app/controllers/api/v1/admin/import_histories_controller.rb
@@ -35,6 +35,16 @@ module Api
 
           render json: history, serializer: ::Admin::ImportHistoryDetailSerializer
         end
+
+        def export
+          history = ImportHistory.includes(:import_errors).find(params[:id])
+          csv = ::Admin::ImportHistoryCsvExporterService.new(history).call
+
+          send_data csv,
+                    filename: "import_history_#{history.id}.csv",
+                    type: 'text/csv; charset=UTF-8',
+                    disposition: 'attachment'
+        end
       end
     end
   end

--- a/rails/app/models/import_history.rb
+++ b/rails/app/models/import_history.rb
@@ -24,7 +24,7 @@
 class ImportHistory < ApplicationRecord
   belongs_to :user
   belongs_to :unit
-  has_many :import_errors, dependent: :destroy
+  has_many :import_errors, -> { order(:row_number) }, dependent: :destroy, inverse_of: :import_history
 
   has_one_attached :file
 

--- a/rails/app/models/import_history.rb
+++ b/rails/app/models/import_history.rb
@@ -28,6 +28,8 @@ class ImportHistory < ApplicationRecord
 
   has_one_attached :file
 
+  scope :active, -> { where(deleted_at: nil) }
+
   enum status: {
     pending: 0,
     processing: 1,

--- a/rails/app/queries/admin/import_histories_query.rb
+++ b/rails/app/queries/admin/import_histories_query.rb
@@ -2,6 +2,11 @@
 
 module Admin
   class ImportHistoriesQuery
+    SORT_WHITELIST = %w[created_at total_count success_count error_count status].freeze
+    ORDER_WHITELIST = %w[asc desc].freeze
+    DEFAULT_SORT = 'created_at'
+    DEFAULT_ORDER = 'desc'
+
     def initialize(scope = ImportHistory.all)
       @scope = scope.includes(:user, unit: :course)
     end
@@ -12,7 +17,7 @@ module Admin
       by_course_id(filters[:course_id])
       by_user_id(filters[:user_id])
       by_period(filters[:from], filters[:to])
-      order_by_created_at_desc
+      order_by(filters[:sort], filters[:order])
       result
     end
 
@@ -58,8 +63,12 @@ module Admin
       self
     end
 
-    def order_by_created_at_desc
-      @scope = @scope.order(created_at: :desc).order(id: :desc)
+    def order_by(sort, order)
+      sort_key = SORT_WHITELIST.include?(sort.to_s) ? sort.to_s : DEFAULT_SORT
+      order_dir = ORDER_WHITELIST.include?(order.to_s) ? order.to_s : DEFAULT_ORDER
+      # タイブレークは id: :desc 固定。デフォルトの並び順（created_at desc = 新しい順）と
+      # 向きを揃えるため、Admin::CoursesQuery の id: :asc とは意図的に異なる。
+      @scope = @scope.order(import_histories: { sort_key => order_dir }).order(id: :desc)
       self
     end
 

--- a/rails/app/queries/admin/import_histories_query.rb
+++ b/rails/app/queries/admin/import_histories_query.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Admin
+  class ImportHistoriesQuery
+    def initialize(scope = ImportHistory.all)
+      @scope = scope.includes(:user, unit: :course)
+    end
+
+    def by_status(status)
+      return self unless status.is_a?(String) || status.is_a?(Symbol)
+      return self if status.to_s.blank?
+      return self unless ImportHistory.statuses.key?(status.to_s)
+
+      @scope = @scope.where(status: status)
+      self
+    end
+
+    def by_unit_id(id)
+      return self if id.blank?
+      return self unless id.is_a?(String) || id.is_a?(Integer)
+
+      @scope = @scope.where(unit_id: id)
+      self
+    end
+
+    def by_course_id(id)
+      return self if id.blank?
+      return self unless id.is_a?(String) || id.is_a?(Integer)
+
+      @scope = @scope.joins(:unit).where(units: { course_id: id })
+      self
+    end
+
+    def by_user_id(id)
+      return self if id.blank?
+      return self unless id.is_a?(String) || id.is_a?(Integer)
+
+      @scope = @scope.where(user_id: id)
+      self
+    end
+
+    def by_period(from, to)
+      from_date = parse_date(from)
+      to_date = parse_date(to)
+
+      @scope = @scope.where(import_histories: { created_at: from_date.beginning_of_day.. }) if from_date
+      @scope = @scope.where(import_histories: { created_at: ..to_date.end_of_day }) if to_date
+      self
+    end
+
+    def order_by_created_at_desc
+      @scope = @scope.order(created_at: :desc).order(id: :desc)
+      self
+    end
+
+    def result
+      @scope
+    end
+
+    private
+
+    def parse_date(value)
+      return nil unless value.is_a?(String)
+      return nil if value.blank?
+
+      Date.parse(value)
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/rails/app/queries/admin/import_histories_query.rb
+++ b/rails/app/queries/admin/import_histories_query.rb
@@ -6,6 +6,16 @@ module Admin
       @scope = scope.includes(:user, unit: :course)
     end
 
+    def call(filters = {})
+      by_status(filters[:status])
+      by_unit_id(filters[:unit_id])
+      by_course_id(filters[:course_id])
+      by_user_id(filters[:user_id])
+      by_period(filters[:from], filters[:to])
+      order_by_created_at_desc
+      result
+    end
+
     def by_status(status)
       return self unless status.is_a?(String) || status.is_a?(Symbol)
       return self if status.to_s.blank?

--- a/rails/app/queries/admin/import_histories_query.rb
+++ b/rails/app/queries/admin/import_histories_query.rb
@@ -12,6 +12,7 @@ module Admin
     end
 
     def call(filters = {})
+      active
       by_status(filters[:status])
       by_unit_id(filters[:unit_id])
       by_course_id(filters[:course_id])
@@ -19,6 +20,11 @@ module Admin
       by_period(filters[:from], filters[:to])
       order_by(filters[:sort], filters[:order])
       result
+    end
+
+    def active
+      @scope = @scope.active
+      self
     end
 
     def by_status(status)

--- a/rails/app/serializers/admin/import_history_detail_serializer.rb
+++ b/rails/app/serializers/admin/import_history_detail_serializer.rb
@@ -29,7 +29,7 @@ module Admin
     end
 
     def errors
-      object.import_errors.sort_by(&:row_number).map do |import_error|
+      object.import_errors.map do |import_error|
         { row_number: import_error.row_number, message: import_error.message }
       end
     end

--- a/rails/app/serializers/admin/import_history_detail_serializer.rb
+++ b/rails/app/serializers/admin/import_history_detail_serializer.rb
@@ -8,10 +8,10 @@ module Admin
                :errors, :warnings
 
     def course
-      unit = object.unit
-      return nil if unit&.course.nil?
+      course = object.unit&.course
+      return nil unless course
 
-      { id: unit.course.id, level_name: unit.course.level_name }
+      { id: course.id, level_name: course.level_name }
     end
 
     def unit

--- a/rails/app/serializers/admin/import_history_detail_serializer.rb
+++ b/rails/app/serializers/admin/import_history_detail_serializer.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Admin
+  class ImportHistoryDetailSerializer < ActiveModel::Serializer
+    attributes :id, :course, :unit, :user, :file_name, :status, :mode,
+               :total_count, :success_count, :error_count,
+               :started_at, :finished_at, :created_at,
+               :errors, :warnings
+
+    def course
+      unit = object.unit
+      return nil if unit&.course.nil?
+
+      { id: unit.course.id, level_name: unit.course.level_name }
+    end
+
+    def unit
+      return nil if object.unit.nil?
+
+      { id: object.unit.id, unit_name: object.unit.unit_name }
+    end
+
+    def user
+      return nil if object.user.nil?
+
+      { id: object.user.id, name: object.user.name }
+    end
+
+    def errors
+      object.import_errors.order(:row_number).map do |import_error|
+        { row_number: import_error.row_number, message: import_error.message }
+      end
+    end
+
+    def warnings
+      []
+    end
+  end
+end

--- a/rails/app/serializers/admin/import_history_detail_serializer.rb
+++ b/rails/app/serializers/admin/import_history_detail_serializer.rb
@@ -15,15 +15,17 @@ module Admin
     end
 
     def unit
-      return nil if object.unit.nil?
+      unit = object.unit
+      return nil unless unit
 
-      { id: object.unit.id, unit_name: object.unit.unit_name }
+      { id: unit.id, unit_name: unit.unit_name }
     end
 
     def user
-      return nil if object.user.nil?
+      user = object.user
+      return nil unless user
 
-      { id: object.user.id, name: object.user.name }
+      { id: user.id, name: user.name }
     end
 
     def errors

--- a/rails/app/serializers/admin/import_history_detail_serializer.rb
+++ b/rails/app/serializers/admin/import_history_detail_serializer.rb
@@ -27,7 +27,7 @@ module Admin
     end
 
     def errors
-      object.import_errors.order(:row_number).map do |import_error|
+      object.import_errors.sort_by(&:row_number).map do |import_error|
         { row_number: import_error.row_number, message: import_error.message }
       end
     end

--- a/rails/app/serializers/admin/import_history_list_serializer.rb
+++ b/rails/app/serializers/admin/import_history_list_serializer.rb
@@ -13,15 +13,17 @@ module Admin
     end
 
     def unit
-      return nil if object.unit.nil?
+      unit = object.unit
+      return nil unless unit
 
-      { id: object.unit.id, unit_name: object.unit.unit_name }
+      { id: unit.id, unit_name: unit.unit_name }
     end
 
     def user
-      return nil if object.user.nil?
+      user = object.user
+      return nil unless user
 
-      { id: object.user.id, name: object.user.name }
+      { id: user.id, name: user.name }
     end
   end
 end

--- a/rails/app/serializers/admin/import_history_list_serializer.rb
+++ b/rails/app/serializers/admin/import_history_list_serializer.rb
@@ -6,10 +6,10 @@ module Admin
                :total_count, :success_count, :error_count, :created_at
 
     def course
-      unit = object.unit
-      return nil if unit&.course.nil?
+      course = object.unit&.course
+      return nil unless course
 
-      { id: unit.course.id, level_name: unit.course.level_name }
+      { id: course.id, level_name: course.level_name }
     end
 
     def unit

--- a/rails/app/serializers/admin/import_history_list_serializer.rb
+++ b/rails/app/serializers/admin/import_history_list_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  class ImportHistoryListSerializer < ActiveModel::Serializer
+    attributes :id, :course, :unit, :user, :file_name, :status, :mode,
+               :total_count, :success_count, :error_count, :created_at
+
+    def course
+      unit = object.unit
+      return nil if unit&.course.nil?
+
+      { id: unit.course.id, level_name: unit.course.level_name }
+    end
+
+    def unit
+      return nil if object.unit.nil?
+
+      { id: object.unit.id, unit_name: object.unit.unit_name }
+    end
+
+    def user
+      return nil if object.user.nil?
+
+      { id: object.user.id, name: object.user.name }
+    end
+  end
+end

--- a/rails/app/services/admin/import_history_csv_exporter_service.rb
+++ b/rails/app/services/admin/import_history_csv_exporter_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Admin
+  class ImportHistoryCsvExporterService
+    require 'csv'
+
+    BOM = '﻿'
+
+    def initialize(import_history)
+      @import_history = import_history
+    end
+
+    def call
+      summary_line = "# total:#{@import_history.total_count}, " \
+                     "success:#{@import_history.success_count}, " \
+                     "error:#{@import_history.error_count}\n"
+
+      csv = CSV.generate do |c|
+        c << %w[row_number status message]
+
+        @import_history.import_errors.order(:row_number).each do |import_error|
+          c << [import_error.row_number, 'error', import_error.message]
+        end
+      end
+
+      "#{BOM}#{summary_line}#{csv}"
+    end
+  end
+end

--- a/rails/app/services/admin/import_history_csv_exporter_service.rb
+++ b/rails/app/services/admin/import_history_csv_exporter_service.rb
@@ -4,7 +4,7 @@ module Admin
   class ImportHistoryCsvExporterService
     require 'csv'
 
-    BOM = '﻿'
+    BOM = "\uFEFF"
 
     def initialize(import_history)
       @import_history = import_history

--- a/rails/app/services/admin/import_history_csv_exporter_service.rb
+++ b/rails/app/services/admin/import_history_csv_exporter_service.rb
@@ -5,6 +5,7 @@ module Admin
     require 'csv'
 
     BOM = "\uFEFF"
+    FORMULA_PREFIXES = ['=', '+', '-', '@'].freeze
 
     def initialize(import_history)
       @import_history = import_history
@@ -18,12 +19,21 @@ module Admin
       csv = CSV.generate do |c|
         c << %w[row_number status message]
 
-        @import_history.import_errors.order(:row_number).each do |import_error|
-          c << [import_error.row_number, 'error', import_error.message]
+        @import_history.import_errors.sort_by(&:row_number).each do |import_error|
+          c << [import_error.row_number, 'error', escape_formula(import_error.message)]
         end
       end
 
       "#{BOM}#{summary_line}#{csv}"
+    end
+
+    private
+
+    def escape_formula(value)
+      return value unless value.is_a?(String)
+      return value unless value.start_with?(*FORMULA_PREFIXES)
+
+      "'#{value}"
     end
   end
 end

--- a/rails/app/services/admin/import_history_csv_exporter_service.rb
+++ b/rails/app/services/admin/import_history_csv_exporter_service.rb
@@ -19,7 +19,7 @@ module Admin
       csv = CSV.generate do |c|
         c << %w[row_number status message]
 
-        @import_history.import_errors.sort_by(&:row_number).each do |import_error|
+        @import_history.import_errors.each do |import_error|
           c << [import_error.row_number, 'error', escape_formula(import_error.message)]
         end
       end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -70,6 +70,10 @@ Rails.application.routes.draw do
 
         get 'csv_template/questions', to: 'csv_templates#questions'
 
+        resources :import_histories, only: %i[index show] do
+          get :export, on: :member
+        end
+
         resources :courses do
           resources :units do
             resource :import_questions, only: :create do

--- a/rails/spec/factories/import_errors.rb
+++ b/rails/spec/factories/import_errors.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: import_errors
+#
+#  id                :bigint           not null, primary key
+#  import_history_id :bigint           not null
+#  row_number        :integer          not null
+#  message           :text(65535)      not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+FactoryBot.define do
+  factory :import_error do
+    association :import_history
+    sequence(:row_number) { |n| n }
+    message { 'エラーメッセージ' }
+  end
+end

--- a/rails/spec/models/import_history_spec.rb
+++ b/rails/spec/models/import_history_spec.rb
@@ -3,6 +3,15 @@
 require 'rails_helper'
 
 RSpec.describe ImportHistory, type: :model do
+  describe '.active' do
+    let!(:alive) { create(:import_history) }
+    let!(:dead) { create(:import_history, deleted_at: Time.current) }
+
+    it 'deleted_at が NULL のレコードのみ返す' do
+      expect(described_class.active).to contain_exactly(alive)
+    end
+  end
+
   describe 'mode enum' do
     it 'append / overwrite を持つ' do
       expect(described_class.modes.keys).to contain_exactly('append', 'overwrite')

--- a/rails/spec/models/import_history_spec.rb
+++ b/rails/spec/models/import_history_spec.rb
@@ -12,6 +12,32 @@ RSpec.describe ImportHistory, type: :model do
     end
   end
 
+  describe '#import_errors' do
+    let!(:history) { create(:import_history) }
+    let!(:later_row) { create(:import_error, import_history: history, row_number: 5) }
+    let!(:earlier_row) { create(:import_error, import_history: history, row_number: 2) }
+
+    it 'row_number 昇順で返る（作成順に依らない）' do
+      expect(history.import_errors).to eq([earlier_row, later_row])
+    end
+
+    it 'includes で preload しても追加クエリなしに row_number 昇順のまま返る' do
+      reloaded = described_class.includes(:import_errors).find(history.id)
+
+      queries = []
+      callback = lambda { |_n, _s, _f, _id, payload|
+        queries << payload[:sql] if payload[:name] != 'SCHEMA'
+      }
+      result = nil
+      ActiveSupport::Notifications.subscribed(callback, 'sql.active_record') do
+        result = reloaded.import_errors.to_a
+      end
+
+      expect(result).to eq([earlier_row, later_row])
+      expect(queries).to be_empty
+    end
+  end
+
   describe 'mode enum' do
     it 'append / overwrite を持つ' do
       expect(described_class.modes.keys).to contain_exactly('append', 'overwrite')

--- a/rails/spec/queries/admin/import_histories_query_spec.rb
+++ b/rails/spec/queries/admin/import_histories_query_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe Admin::ImportHistoriesQuery, type: :model do
       result = described_class.new.call
       expect(result).to contain_exactly(matched, unmatched_status, unmatched_unit)
     end
+
+    context 'sort/order を渡す場合' do
+      let!(:old) { create(:import_history, created_at: 3.days.ago) }
+      let!(:recent) { create(:import_history, created_at: 1.day.ago) }
+
+      it 'その並び順を反映する' do
+        result = described_class.new.call(sort: 'created_at', order: 'asc')
+        expect(result.to_a.index(old)).to be < result.to_a.index(recent)
+      end
+    end
   end
 
   describe '#result' do
@@ -144,12 +154,77 @@ RSpec.describe Admin::ImportHistoriesQuery, type: :model do
     end
   end
 
-  describe '#order_by_created_at_desc' do
-    let!(:old) { create(:import_history, created_at: 3.days.ago) }
-    let!(:recent) { create(:import_history, created_at: 1.day.ago) }
+  describe '#order_by' do
+    context 'sort/order を指定しない場合' do
+      let!(:old) { create(:import_history, created_at: 3.days.ago) }
+      let!(:recent) { create(:import_history, created_at: 1.day.ago) }
 
-    it '作成日時の降順で返す' do
-      expect(described_class.new.order_by_created_at_desc.result.to_a).to eq([recent, old])
+      it '作成日時の降順で返す（デフォルト）' do
+        expect(described_class.new.order_by(nil, nil).result.to_a).to eq([recent, old])
+      end
+    end
+
+    context 'sort=created_at, order=asc を指定した場合' do
+      let!(:old) { create(:import_history, created_at: 3.days.ago) }
+      let!(:recent) { create(:import_history, created_at: 1.day.ago) }
+
+      it '作成日時の昇順で返す' do
+        expect(described_class.new.order_by('created_at', 'asc').result.to_a).to eq([old, recent])
+      end
+    end
+
+    context 'sort=total_count を指定した場合' do
+      let!(:small) { create(:import_history, total_count: 1) }
+      let!(:large) { create(:import_history, total_count: 10) }
+
+      it '件数の降順で返す' do
+        expect(described_class.new.order_by('total_count', 'desc').result.to_a).to eq([large, small])
+      end
+    end
+
+    context 'sort=success_count を指定した場合' do
+      let!(:small) { create(:import_history, success_count: 1) }
+      let!(:large) { create(:import_history, success_count: 5) }
+
+      it '成功数の昇順で返す' do
+        expect(described_class.new.order_by('success_count', 'asc').result.to_a).to eq([small, large])
+      end
+    end
+
+    context 'sort=error_count を指定した場合' do
+      let!(:small) { create(:import_history, error_count: 0) }
+      let!(:large) { create(:import_history, error_count: 3) }
+
+      it 'エラー数の降順で返す' do
+        expect(described_class.new.order_by('error_count', 'desc').result.to_a).to eq([large, small])
+      end
+    end
+
+    context 'sort=status を指定した場合' do
+      let!(:completed) { create(:import_history, status: :completed) }
+      let!(:failed) { create(:import_history, status: :failed) }
+
+      it 'ステータス（enum内部値）の昇順で返す' do
+        expect(described_class.new.order_by('status', 'asc').result.to_a).to eq([completed, failed])
+      end
+    end
+
+    context '不正な sort 値を指定した場合' do
+      let!(:old) { create(:import_history, created_at: 3.days.ago) }
+      let!(:recent) { create(:import_history, created_at: 1.day.ago) }
+
+      it 'sort は作成日時にフォールバックしつつ、指定した order は反映される' do
+        expect(described_class.new.order_by('invalid_column', 'asc').result.to_a).to eq([old, recent])
+      end
+    end
+
+    context '不正な order 値を指定した場合' do
+      let!(:old) { create(:import_history, created_at: 3.days.ago) }
+      let!(:recent) { create(:import_history, created_at: 1.day.ago) }
+
+      it 'デフォルト（降順）にフォールバックする' do
+        expect(described_class.new.order_by('created_at', 'invalid_order').result.to_a).to eq([recent, old])
+      end
     end
   end
 end

--- a/rails/spec/queries/admin/import_histories_query_spec.rb
+++ b/rails/spec/queries/admin/import_histories_query_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe Admin::ImportHistoriesQuery, type: :model do
         expect(result.to_a.index(old)).to be < result.to_a.index(recent)
       end
     end
+
+    context 'ソフトデリート済みの履歴が存在する場合' do
+      let!(:deleted) { create(:import_history, deleted_at: Time.current) }
+
+      it '結果に含まれない' do
+        result = described_class.new.call
+        expect(result).not_to include(deleted)
+      end
+    end
   end
 
   describe '#result' do

--- a/rails/spec/queries/admin/import_histories_query_spec.rb
+++ b/rails/spec/queries/admin/import_histories_query_spec.rb
@@ -3,6 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe Admin::ImportHistoriesQuery, type: :model do
+  describe '#call' do
+    let!(:unit_a) { create(:unit) }
+    let!(:unit_b) { create(:unit) }
+    let!(:matched) { create(:import_history, unit: unit_a, status: :completed) }
+    let!(:unmatched_status) { create(:import_history, unit: unit_a, status: :failed) }
+    let!(:unmatched_unit) { create(:import_history, unit: unit_b, status: :completed) }
+
+    it 'キーワード引数のフィルタを組み合わせて絞り込む' do
+      result = described_class.new.call(status: 'completed', unit_id: unit_a.id)
+      expect(result).to contain_exactly(matched)
+    end
+
+    it '引数を渡さない場合は全件を作成日時降順で返す' do
+      result = described_class.new.call
+      expect(result).to contain_exactly(matched, unmatched_status, unmatched_unit)
+    end
+  end
+
   describe '#result' do
     it 'user / unit / unit.course を preload するように relation に includes を指定する' do
       relation = described_class.new.result

--- a/rails/spec/queries/admin/import_histories_query_spec.rb
+++ b/rails/spec/queries/admin/import_histories_query_spec.rb
@@ -116,6 +116,25 @@ RSpec.describe Admin::ImportHistoriesQuery, type: :model do
       expect(described_class.new.by_course_id([course_a.id, course_b.id]).result)
         .to contain_exactly(history_a, history_b)
     end
+
+    context '対象 course に紐づく履歴が複数件あり、ページネーションと組み合わせる場合' do
+      let!(:extra_histories) { create_list(:import_history, 2, unit: unit_a) }
+
+      it 'joins による重複行が発生せず、正しい件数を返す（unit は import_history に対して1件のため複製されない）' do
+        scope = described_class.new.by_course_id(course_a.id).result
+        expect(scope.count).to eq(3)
+      end
+
+      it 'ページを分けても合計件数と重複なく全件を取得できる' do
+        scope = described_class.new.by_course_id(course_a.id).result
+        page1 = scope.page(1).per(2).to_a
+        page2 = scope.page(2).per(2).to_a
+
+        expect(page1.size).to eq(2)
+        expect(page2.size).to eq(1)
+        expect(page1 + page2).to contain_exactly(history_a, *extra_histories)
+      end
+    end
   end
 
   describe '#by_user_id' do

--- a/rails/spec/queries/admin/import_histories_query_spec.rb
+++ b/rails/spec/queries/admin/import_histories_query_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::ImportHistoriesQuery, type: :model do
+  describe '#result' do
+    it 'user / unit / unit.course を preload するように relation に includes を指定する' do
+      relation = described_class.new.result
+      expect(relation.includes_values).to include(:user, unit: :course)
+    end
+  end
+
+  describe '#by_status' do
+    let!(:completed) { create(:import_history, status: :completed) }
+    let!(:failed) { create(:import_history, status: :failed) }
+
+    it '指定した status のみ返す' do
+      expect(described_class.new.by_status('failed').result).to contain_exactly(failed)
+    end
+
+    it 'nil の場合はフィルタしない' do
+      expect(described_class.new.by_status(nil).result).to contain_exactly(completed, failed)
+    end
+
+    it '空文字の場合はフィルタしない' do
+      expect(described_class.new.by_status('').result).to contain_exactly(completed, failed)
+    end
+
+    it '不正な status 値の場合はフィルタしない（500にならない）' do
+      expect(described_class.new.by_status('invalid').result).to contain_exactly(completed, failed)
+    end
+
+    it '配列を渡してもフィルタしない（パラメータ汚染防止）' do
+      expect(described_class.new.by_status(%w[failed]).result).to contain_exactly(completed, failed)
+    end
+  end
+
+  describe '#by_unit_id' do
+    let!(:unit_a) { create(:unit) }
+    let!(:unit_b) { create(:unit) }
+    let!(:history_a) { create(:import_history, unit: unit_a) }
+    let!(:history_b) { create(:import_history, unit: unit_b) }
+
+    it '指定 unit_id の履歴のみ返す' do
+      expect(described_class.new.by_unit_id(unit_a.id).result).to contain_exactly(history_a)
+    end
+
+    it 'nil の場合はフィルタしない' do
+      expect(described_class.new.by_unit_id(nil).result).to contain_exactly(history_a, history_b)
+    end
+
+    it '配列を渡してもフィルタしない（パラメータ汚染防止）' do
+      expect(described_class.new.by_unit_id([unit_a.id, unit_b.id]).result)
+        .to contain_exactly(history_a, history_b)
+    end
+
+    it 'ハッシュを渡してもフィルタしない（パラメータ汚染防止）' do
+      expect(described_class.new.by_unit_id({ gt: 0 }).result).to contain_exactly(history_a, history_b)
+    end
+  end
+
+  describe '#by_course_id' do
+    let!(:course_a) { create(:course) }
+    let!(:course_b) { create(:course) }
+    let!(:unit_a) { create(:unit, course: course_a) }
+    let!(:unit_b) { create(:unit, course: course_b) }
+    let!(:history_a) { create(:import_history, unit: unit_a) }
+    let!(:history_b) { create(:import_history, unit: unit_b) }
+
+    it '指定 course_id に属する unit の履歴のみ返す（unit 経由の join）' do
+      expect(described_class.new.by_course_id(course_a.id).result).to contain_exactly(history_a)
+    end
+
+    it 'nil の場合はフィルタしない' do
+      expect(described_class.new.by_course_id(nil).result).to contain_exactly(history_a, history_b)
+    end
+
+    it '配列を渡してもフィルタしない（パラメータ汚染防止）' do
+      expect(described_class.new.by_course_id([course_a.id, course_b.id]).result)
+        .to contain_exactly(history_a, history_b)
+    end
+  end
+
+  describe '#by_user_id' do
+    let!(:user_a) { create(:user, :admin, high_school: nil) }
+    let!(:user_b) { create(:user, :admin, high_school: nil) }
+    let!(:history_a) { create(:import_history, user: user_a) }
+    let!(:history_b) { create(:import_history, user: user_b) }
+
+    it '指定 user_id (実行者) の履歴のみ返す' do
+      expect(described_class.new.by_user_id(user_a.id).result).to contain_exactly(history_a)
+    end
+
+    it 'nil の場合はフィルタしない' do
+      expect(described_class.new.by_user_id(nil).result).to contain_exactly(history_a, history_b)
+    end
+  end
+
+  describe '#by_period' do
+    let!(:old) { create(:import_history, created_at: 10.days.ago) }
+    let!(:mid) { create(:import_history, created_at: 5.days.ago) }
+    let!(:recent) { create(:import_history, created_at: 1.day.ago) }
+
+    it 'from のみ指定した場合、from 以降の履歴を返す' do
+      expect(described_class.new.by_period(6.days.ago.to_date.to_s, nil).result)
+        .to contain_exactly(mid, recent)
+    end
+
+    it 'to のみ指定した場合、to 以前の履歴を返す' do
+      expect(described_class.new.by_period(nil, 6.days.ago.to_date.to_s).result)
+        .to contain_exactly(old)
+    end
+
+    it 'from と to を両方指定した場合、範囲内の履歴を返す' do
+      expect(described_class.new.by_period(6.days.ago.to_date.to_s, 2.days.ago.to_date.to_s).result)
+        .to contain_exactly(mid)
+    end
+
+    it '両方 nil の場合はフィルタしない' do
+      expect(described_class.new.by_period(nil, nil).result).to contain_exactly(old, mid, recent)
+    end
+
+    it '不正な日付文字列はフィルタしない（500にならない）' do
+      expect(described_class.new.by_period('invalid-date', nil).result)
+        .to contain_exactly(old, mid, recent)
+    end
+  end
+
+  describe '#order_by_created_at_desc' do
+    let!(:old) { create(:import_history, created_at: 3.days.ago) }
+    let!(:recent) { create(:import_history, created_at: 1.day.ago) }
+
+    it '作成日時の降順で返す' do
+      expect(described_class.new.order_by_created_at_desc.result.to_a).to eq([recent, old])
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/admin/import_histories_spec.rb
+++ b/rails/spec/requests/api/v1/admin/import_histories_spec.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Admin::ImportHistories', type: :request do
+  let(:headers) do
+    {
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json'
+    }
+  end
+
+  def login_and_get_cookie(user)
+    post '/api/v1/user/login',
+         params: { email: user.email, password: 'password' }.to_json,
+         headers: headers
+    response.headers['Set-Cookie']&.split(';')&.first
+  end
+
+  describe 'GET /api/v1/admin/import_histories' do
+    context '正常系' do
+      context 'インポート履歴が存在しない場合' do
+        subject { get '/api/v1/admin/import_histories', headers: headers.merge('Cookie' => cookie) }
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it 'ステータス200が返される' do
+          subject
+          expect(response).to have_http_status(:ok)
+        end
+
+        it 'import_histories は空配列、meta は0件の値を返す' do
+          subject
+          body = response.parsed_body
+          expect(body['import_histories']).to eq([])
+          expect(body['meta']).to include(
+            'current_page' => 1,
+            'total_pages' => 0,
+            'total_count' => 0,
+            'per_page' => 20
+          )
+        end
+      end
+
+      context '1件の履歴が存在する場合' do
+        subject { get '/api/v1/admin/import_histories', headers: headers.merge('Cookie' => cookie) }
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:executor) { create(:user, :admin, high_school: nil, name: '実行太郎') }
+        let!(:course) { create(:course, level_name: '基礎英語') }
+        let!(:unit) { create(:unit, course: course, unit_name: '単元1') }
+        let!(:history) do
+          create(:import_history, user: executor, unit: unit, status: :completed,
+                                  total_count: 10, success_count: 8, error_count: 2)
+        end
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '必要なフィールドが含まれる' do
+          subject
+          item = response.parsed_body['import_histories'].first
+          expect(item.keys).to include(
+            'id', 'course', 'unit', 'user', 'file_name', 'status', 'mode',
+            'total_count', 'success_count', 'error_count', 'created_at'
+          )
+        end
+
+        it 'course / unit / user がネストされたハッシュで返る' do
+          subject
+          item = response.parsed_body['import_histories'].first
+          expect(item['course']).to eq('id' => course.id, 'level_name' => '基礎英語')
+          expect(item['unit']).to eq('id' => unit.id, 'unit_name' => '単元1')
+          expect(item['user']).to eq('id' => executor.id, 'name' => '実行太郎')
+        end
+
+        it '件数系フィールドと status が正しい' do
+          subject
+          item = response.parsed_body['import_histories'].first
+          expect(item['id']).to eq(history.id)
+          expect(item['status']).to eq('completed')
+          expect(item['total_count']).to eq(10)
+          expect(item['success_count']).to eq(8)
+          expect(item['error_count']).to eq(2)
+        end
+
+        it 'meta.total_count が1になる' do
+          subject
+          expect(response.parsed_body['meta']['total_count']).to eq(1)
+        end
+      end
+
+      context 'ページネーション' do
+        subject do
+          get '/api/v1/admin/import_histories', params: query_params, headers: headers.merge('Cookie' => cookie)
+        end
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        before { create_list(:import_history, 25) }
+
+        context 'デフォルト per_page=20' do
+          let(:query_params) { {} }
+
+          it '20件返し、meta に current_page/per_page/total_count が入る' do
+            subject
+            body = response.parsed_body
+            expect(body['import_histories'].size).to eq(20)
+            expect(body['meta']).to include('current_page' => 1, 'per_page' => 20, 'total_count' => 25)
+          end
+        end
+
+        context 'page=2 を指定' do
+          let(:query_params) { { page: 2 } }
+
+          it '残り5件を返す' do
+            subject
+            expect(response.parsed_body['import_histories'].size).to eq(5)
+          end
+        end
+
+        context 'per_page=150 を指定（上限超過）' do
+          let(:query_params) { { per_page: 150 } }
+
+          it 'meta.per_page は100に丸められる' do
+            subject
+            expect(response.parsed_body['meta']['per_page']).to eq(100)
+          end
+        end
+      end
+
+      context 'status パラメータ指定時' do
+        subject do
+          get '/api/v1/admin/import_histories', params: { status: 'failed' }, headers: headers.merge('Cookie' => cookie)
+        end
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:completed) { create(:import_history, status: :completed) }
+        let!(:failed) { create(:import_history, status: :failed) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '指定した status のみ返す' do
+          subject
+          ids = response.parsed_body['import_histories'].pluck('id')
+          expect(ids).to contain_exactly(failed.id)
+        end
+      end
+
+      context 'course_id パラメータ指定時' do
+        subject do
+          get '/api/v1/admin/import_histories', params: { course_id: course_a.id },
+                                                headers: headers.merge('Cookie' => cookie)
+        end
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:course_a) { create(:course) }
+        let!(:course_b) { create(:course) }
+        let!(:unit_a) { create(:unit, course: course_a) }
+        let!(:unit_b) { create(:unit, course: course_b) }
+        let!(:history_a) { create(:import_history, unit: unit_a) }
+        let!(:history_b) { create(:import_history, unit: unit_b) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '指定 course に属する履歴のみ返す' do
+          subject
+          ids = response.parsed_body['import_histories'].pluck('id')
+          expect(ids).to contain_exactly(history_a.id)
+        end
+      end
+
+      context 'unit_id パラメータ指定時' do
+        subject do
+          get '/api/v1/admin/import_histories', params: { unit_id: unit_a.id },
+                                                headers: headers.merge('Cookie' => cookie)
+        end
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:unit_a) { create(:unit) }
+        let!(:unit_b) { create(:unit) }
+        let!(:history_a) { create(:import_history, unit: unit_a) }
+        let!(:history_b) { create(:import_history, unit: unit_b) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '指定 unit の履歴のみ返す' do
+          subject
+          ids = response.parsed_body['import_histories'].pluck('id')
+          expect(ids).to contain_exactly(history_a.id)
+        end
+      end
+
+      context 'user_id パラメータ指定時' do
+        subject do
+          get '/api/v1/admin/import_histories', params: { user_id: executor_a.id },
+                                                headers: headers.merge('Cookie' => cookie)
+        end
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:executor_a) { create(:user, :admin, high_school: nil) }
+        let!(:executor_b) { create(:user, :admin, high_school: nil) }
+        let!(:history_a) { create(:import_history, user: executor_a) }
+        let!(:history_b) { create(:import_history, user: executor_b) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '指定 user (実行者) の履歴のみ返す' do
+          subject
+          ids = response.parsed_body['import_histories'].pluck('id')
+          expect(ids).to contain_exactly(history_a.id)
+        end
+      end
+
+      context 'from/to パラメータ指定時' do
+        subject do
+          get '/api/v1/admin/import_histories', params: { from: 6.days.ago.to_date.to_s, to: 2.days.ago.to_date.to_s },
+                                                headers: headers.merge('Cookie' => cookie)
+        end
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:old) { create(:import_history, created_at: 10.days.ago) }
+        let!(:mid) { create(:import_history, created_at: 5.days.ago) }
+        let!(:recent) { create(:import_history, created_at: 1.day.ago) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '期間内の履歴のみ返す' do
+          subject
+          ids = response.parsed_body['import_histories'].pluck('id')
+          expect(ids).to contain_exactly(mid.id)
+        end
+      end
+    end
+
+    context '異常系' do
+      context '未認証アクセス' do
+        it '401が返される' do
+          get '/api/v1/admin/import_histories', headers: headers
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context '管理者以外のアクセス（生徒）' do
+        let!(:student_user) { create(:user) }
+
+        it '403が返される' do
+          cookie = login_and_get_cookie(student_user)
+          get '/api/v1/admin/import_histories', headers: headers.merge('Cookie' => cookie)
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context '管理者以外のアクセス（教員）' do
+        let!(:teacher_user) { create(:user, :teacher) }
+
+        it '403が返される' do
+          cookie = login_and_get_cookie(teacher_user)
+          get '/api/v1/admin/import_histories', headers: headers.merge('Cookie' => cookie)
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+  end
+end

--- a/rails/spec/requests/api/v1/admin/import_histories_spec.rb
+++ b/rails/spec/requests/api/v1/admin/import_histories_spec.rb
@@ -364,4 +364,81 @@ RSpec.describe 'Api::V1::Admin::ImportHistories', type: :request do
       end
     end
   end
+
+  describe 'GET /api/v1/admin/import_histories/:id/export' do
+    context '正常系' do
+      subject { get "/api/v1/admin/import_histories/#{history.id}/export", headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:history) do
+        create(:import_history, status: :completed, total_count: 2, success_count: 1, error_count: 1)
+      end
+      let!(:import_error) { create(:import_error, import_history: history, row_number: 4, message: '選択肢が不足しています') }
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'Content-Type が text/csv になる' do
+        subject
+        expect(response.headers['Content-Type']).to include('text/csv')
+      end
+
+      it 'Content-Disposition が attachment になる' do
+        subject
+        expect(response.headers['Content-Disposition']).to include('attachment')
+      end
+
+      it 'CSV本文にエラー内容が含まれる' do
+        subject
+        expect(response.body).to include('選択肢が不足しています')
+        expect(response.body).to include('total:2')
+      end
+    end
+
+    context '異常系' do
+      context '未認証アクセス' do
+        let!(:history) { create(:import_history) }
+
+        it '401が返される' do
+          get "/api/v1/admin/import_histories/#{history.id}/export", headers: headers
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context '管理者以外のアクセス（生徒）' do
+        let!(:student_user) { create(:user) }
+        let!(:history) { create(:import_history) }
+
+        it '403が返される' do
+          cookie = login_and_get_cookie(student_user)
+          get "/api/v1/admin/import_histories/#{history.id}/export", headers: headers.merge('Cookie' => cookie)
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context '管理者以外のアクセス（教員）' do
+        let!(:teacher_user) { create(:user, :teacher) }
+        let!(:history) { create(:import_history) }
+
+        it '403が返される' do
+          cookie = login_and_get_cookie(teacher_user)
+          get "/api/v1/admin/import_histories/#{history.id}/export", headers: headers.merge('Cookie' => cookie)
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context '存在しない id' do
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '404が返される' do
+          get '/api/v1/admin/import_histories/0/export', headers: headers.merge('Cookie' => cookie)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
 end

--- a/rails/spec/requests/api/v1/admin/import_histories_spec.rb
+++ b/rails/spec/requests/api/v1/admin/import_histories_spec.rb
@@ -257,4 +257,111 @@ RSpec.describe 'Api::V1::Admin::ImportHistories', type: :request do
       end
     end
   end
+
+  describe 'GET /api/v1/admin/import_histories/:id' do
+    context '正常系' do
+      subject { get "/api/v1/admin/import_histories/#{history.id}", headers: headers.merge('Cookie' => cookie) }
+
+      let!(:admin_user) { create(:user, :admin, high_school: nil) }
+      let!(:executor) { create(:user, :admin, high_school: nil, name: '実行太郎') }
+      let!(:course) { create(:course, level_name: '基礎英語') }
+      let!(:unit) { create(:unit, course: course, unit_name: '単元1') }
+      let!(:history) do
+        create(:import_history, user: executor, unit: unit, status: :completed,
+                                total_count: 3, success_count: 1, error_count: 2)
+      end
+      let(:cookie) { login_and_get_cookie(admin_user) }
+
+      it 'ステータス200が返される' do
+        subject
+        expect(response).to have_http_status(:ok)
+      end
+
+      it '基本フィールドが含まれる' do
+        subject
+        body = response.parsed_body
+        expect(body.keys).to include(
+          'id', 'course', 'unit', 'user', 'file_name', 'status', 'mode',
+          'total_count', 'success_count', 'error_count',
+          'started_at', 'finished_at', 'created_at', 'errors', 'warnings'
+        )
+      end
+
+      it 'course / unit / user がネストされたハッシュで返る' do
+        subject
+        body = response.parsed_body
+        expect(body['course']).to eq('id' => course.id, 'level_name' => '基礎英語')
+        expect(body['unit']).to eq('id' => unit.id, 'unit_name' => '単元1')
+        expect(body['user']).to eq('id' => executor.id, 'name' => '実行太郎')
+      end
+
+      it 'warnings は常に空配列' do
+        subject
+        expect(response.parsed_body['warnings']).to eq([])
+      end
+
+      context 'エラー行が存在する場合' do
+        let!(:earlier_error) { create(:import_error, import_history: history, row_number: 3, message: '問題文は必須です') }
+        let!(:later_error) { create(:import_error, import_history: history, row_number: 5, message: '正解の形式が不正') }
+
+        it 'errors に全件、row_number 昇順で含まれる' do
+          subject
+          errors = response.parsed_body['errors']
+          expect(errors.size).to eq(2)
+          expect(errors.pluck('row_number')).to eq([3, 5])
+          expect(errors.first['message']).to eq('問題文は必須です')
+        end
+      end
+
+      context 'エラー行が存在しない場合' do
+        it 'errors は空配列' do
+          subject
+          expect(response.parsed_body['errors']).to eq([])
+        end
+      end
+    end
+
+    context '異常系' do
+      context '未認証アクセス' do
+        let!(:history) { create(:import_history) }
+
+        it '401が返される' do
+          get "/api/v1/admin/import_histories/#{history.id}", headers: headers
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      context '管理者以外のアクセス（生徒）' do
+        let!(:student_user) { create(:user) }
+        let!(:history) { create(:import_history) }
+
+        it '403が返される' do
+          cookie = login_and_get_cookie(student_user)
+          get "/api/v1/admin/import_histories/#{history.id}", headers: headers.merge('Cookie' => cookie)
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context '管理者以外のアクセス（教員）' do
+        let!(:teacher_user) { create(:user, :teacher) }
+        let!(:history) { create(:import_history) }
+
+        it '403が返される' do
+          cookie = login_and_get_cookie(teacher_user)
+          get "/api/v1/admin/import_histories/#{history.id}", headers: headers.merge('Cookie' => cookie)
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+
+      context '存在しない id' do
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '404が返される' do
+          get '/api/v1/admin/import_histories/0', headers: headers.merge('Cookie' => cookie)
+          expect(response).to have_http_status(:not_found)
+        end
+      end
+    end
+  end
 end

--- a/rails/spec/services/admin/import_history_csv_exporter_service_spec.rb
+++ b/rails/spec/services/admin/import_history_csv_exporter_service_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Admin::ImportHistoryCsvExporterService, type: :model do
+  describe '#call' do
+    subject(:csv) { described_class.new(history).call }
+
+    let(:history) do
+      create(:import_history, status: :completed, total_count: 3, success_count: 1, error_count: 2)
+    end
+
+    context 'エラー行が存在する場合' do
+      before do
+        create(:import_error, import_history: history, row_number: 3, message: '問題文は必須です')
+        create(:import_error, import_history: history, row_number: 5, message: '正解の形式が不正')
+      end
+
+      it 'BOM付きで始まる' do
+        expect(csv).to start_with('﻿')
+      end
+
+      it 'サマリーコメント行に total/success/error 件数を含む' do
+        summary_line = csv.delete_prefix('﻿').lines.first
+        expect(summary_line).to include('total:3', 'success:1', 'error:2')
+      end
+
+      it 'ヘッダー行に row_number, status, message を含む' do
+        rows = CSV.parse(csv.delete_prefix('﻿'), skip_lines: /\A#/)
+        expect(rows.first).to eq(%w[row_number status message])
+      end
+
+      it 'row_number 昇順でエラー行が出力される' do
+        rows = CSV.parse(csv.delete_prefix('﻿'), headers: true, skip_lines: /\A#/)
+        expect(rows.pluck('row_number')).to eq(%w[3 5])
+      end
+
+      it '各行の status は error、message はエラー内容' do
+        rows = CSV.parse(csv.delete_prefix('﻿'), headers: true, skip_lines: /\A#/)
+        expect(rows.pluck('status')).to all(eq('error'))
+        expect(rows.first['message']).to eq('問題文は必須です')
+      end
+    end
+
+    context 'エラー行が存在しない場合' do
+      it 'ヘッダー行のみでエラー行は出力されない' do
+        rows = CSV.parse(csv.delete_prefix('﻿'), headers: true, skip_lines: /\A#/)
+        expect(rows.size).to eq(0)
+      end
+
+      it 'サマリーコメント行は出力される' do
+        summary_line = csv.delete_prefix('﻿').lines.first
+        expect(summary_line).to include('total:3', 'success:1', 'error:2')
+      end
+    end
+  end
+end

--- a/rails/spec/services/admin/import_history_csv_exporter_service_spec.rb
+++ b/rails/spec/services/admin/import_history_csv_exporter_service_spec.rb
@@ -42,6 +42,38 @@ RSpec.describe Admin::ImportHistoryCsvExporterService, type: :model do
       end
     end
 
+    context 'message が数式インジェクションを狙った値で始まる場合' do
+      before do
+        create(:import_error, import_history: history, row_number: 1, message: '=HYPERLINK("http://evil.example")')
+        create(:import_error, import_history: history, row_number: 2, message: '+1+1')
+        create(:import_error, import_history: history, row_number: 3, message: '-1+1')
+        create(:import_error, import_history: history, row_number: 4, message: '@SUM(1+1)')
+      end
+
+      it '先頭にシングルクォートを付与してエスケープする' do
+        rows = CSV.parse(csv.delete_prefix('﻿'), headers: true, skip_lines: /\A#/)
+        expect(rows.pluck('message')).to eq(
+          [
+            "'=HYPERLINK(\"http://evil.example\")",
+            "'+1+1",
+            "'-1+1",
+            "'@SUM(1+1)"
+          ]
+        )
+      end
+    end
+
+    context 'message が数式でない通常の文字列の場合' do
+      before do
+        create(:import_error, import_history: history, row_number: 1, message: '問題文は必須です')
+      end
+
+      it 'エスケープされない' do
+        rows = CSV.parse(csv.delete_prefix('﻿'), headers: true, skip_lines: /\A#/)
+        expect(rows.first['message']).to eq('問題文は必須です')
+      end
+    end
+
     context 'エラー行が存在しない場合' do
       it 'ヘッダー行のみでエラー行は出力されない' do
         rows = CSV.parse(csv.delete_prefix('﻿'), headers: true, skip_lines: /\A#/)


### PR DESCRIPTION
## 概要

インポート履歴ページ用のAPIを実装（issue #57）。

CSVインポート機能自体（`Api::V1::Admin::ImportQuestionsController`等）は実装済みで、`ImportHistory`/`ImportError`モデルも既存。今回は、その実行履歴を閲覧するための3エンドポイント（一覧・詳細・CSVエクスポート）を追加した。

- `GET /api/v1/admin/import_histories` — 一覧（page/per_page/course_id/unit_id/status/user_id/from/toでフィルタ可能）
- `GET /api/v1/admin/import_histories/:id` — 詳細（実行結果サマリー＋errors全件＋warnings＋user/unit/course情報）
- `GET /api/v1/admin/import_histories/:id/export` — エラー明細CSVエクスポート（BOM付き、`Content-Disposition: attachment`）

## 詳細

- `Admin::ImportHistoriesQuery`は既存の`Admin::CoursesQuery`と同じmethod chainビルダーパターンで実装。フィルタ値はホワイトリスト検証・型チェックを行い、不正値でも500にならずデフォルト挙動にフォールバックする
- シリアライザーも既存の`Admin::CourseListSerializer`/`CourseDetailSerializer`の命名・実装パターンを踏襲
- 既存スキーマの範囲内で実装しているため、以下は仕様として割り切っている点としてレビューで見て欲しい
  - `import_errors`テーブルにはエラー行（row_number, message）のみが保存されており、warning区分や成功行の元データを保持するカラムは存在しない
  - そのため詳細APIの`warnings[]`は常に空配列、CSVエクスポートも成功行の元データではなく「エラー明細（row_number/status/message）＋ファイル冒頭のtotal/success/errorサマリーコメント行」という構成にした
- 既存の（namespaceなしの）軽量`ImportHistorySerializer`（dashboards/unit_detailで使用中）はそのまま残し、今回は新規シリアライザーを追加するのみで既存箇所には手を入れていない
- ルーティングは`units`配下のネストではなく、ダッシュボードや単元詳細からも横断的に参照される一覧という性質を踏まえて`admin`直下のトップレベルリソースにした

## 動作確認

Docker Compose (development環境) を起動し、実際にAPIを叩いて確認した。

1. 管理者ユーザーと、エラー2件・成功1件を含む`ImportHistory`をdevelopment DBに作成
2. ログインしてCookieを取得後、以下を実行

```
GET /api/v1/admin/import_histories
→ 200、作成した履歴が course/unit/user のネスト情報付きで一覧に含まれることを確認

GET /api/v1/admin/import_histories?status=failed
→ 200、該当なしで空配列・meta.total_count=0

GET /api/v1/admin/import_histories?unit_id=57
→ 200、指定unitの履歴のみ1件返ることを確認

GET /api/v1/admin/import_histories/12
→ 200、errorsに2件（row_number昇順）、warningsが空配列であることを確認

GET /api/v1/admin/import_histories/12/export
→ 200、Content-Type: text/csv; charset=utf-8
→ Content-Disposition: attachment; filename="import_history_12.csv"
→ 本文:
  # total:3, success:1, error:2
  row_number,status,message
  2,error,問題文は必須です
  3,error,正解の形式が不正です

GET /api/v1/admin/import_histories/0
→ 404（存在しないID）
```

未認証アクセス時、development環境では500（`ActionDispatch::Request::Session::DisabledSessionError`）になったが、これは既存の`/api/v1/admin/courses`や`/api/v1/admin/dashboard`など無関係な既存エンドポイントでも同様に再現するdevelopment環境固有の既知の挙動で、今回の実装によるものではないことを確認した。test環境（RSpec）では未認証時に正しく401が返ることをrequest specで担保している。

作成した確認用データ（admin/course/unit/import_history）はテスト後に削除済み。

RSpecも合わせて実行:
- `bundle exec rspec spec/queries/admin/import_histories_query_spec.rb spec/services/admin/import_history_csv_exporter_service_spec.rb spec/requests/api/v1/admin/import_histories_spec.rb` — 63 examples, 0 failures
- `bundle exec rspec`（フルスイート）— 936 examples, 3 failures（並行実行によるDB競合が原因、対象specを個別再実行して0 failuresを確認済み。本PRの変更とは無関係）
- `bundle exec rubocop`（変更ファイル）— オフェンスなし（`config/routes.rb`の既存オフェンス36件はmainブランチに元から存在するもので本PRでは増加なし）

## その他

新規ライブラリの導入なし。既存の`active_model_serializers`・`kaminari`・`csv`のみ使用。

## 参考情報

🤖 Generated with [Claude Code](https://claude.com/claude-code)