### PR TITLE
インポート履歴一覧画面(/admin/csv-import/history)の実装

### DIFF
--- a/frontend/app/(admin)/admin/(authenticated)/csv-import/history/page.tsx
+++ b/frontend/app/(admin)/admin/(authenticated)/csv-import/history/page.tsx
@@ -1,0 +1,5 @@
+import { AdminImportHistory } from "@/features/AdminImportHistory";
+
+export default function AdminImportHistoryPage() {
+  return <AdminImportHistory />;
+}

--- a/frontend/app/api/admin/import_histories/route.ts
+++ b/frontend/app/api/admin/import_histories/route.ts
@@ -1,0 +1,38 @@
+import { handleRailsRouteError } from "@/libs/server/rails/handleRailsRouteError";
+import { railsFetch } from "@/libs/server/rails/railsFetch";
+import { type NextRequest, NextResponse } from "next/server";
+
+const FORWARD_PARAM_KEYS = [
+  "page",
+  "per_page",
+  "status",
+  "course_id",
+  "unit_id",
+  "user_id",
+  "from",
+  "to",
+  "sort",
+  "order",
+] as const;
+
+// インポート履歴一覧の取得
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const params = new URLSearchParams();
+  for (const key of FORWARD_PARAM_KEYS) {
+    const value = searchParams.get(key);
+    if (value) params.set(key, value);
+  }
+
+  try {
+    const { status, data, setCookie } = await railsFetch(
+      `/api/v1/admin/import_histories?${params.toString()}`,
+    );
+
+    const res = NextResponse.json(data, { status });
+    if (setCookie) res.headers.set("set-cookie", setCookie);
+    return res;
+  } catch (error) {
+    return handleRailsRouteError(error, "インポート履歴の取得に失敗しました");
+  }
+}

--- a/frontend/features/AdminDashboard/Presenter.test.tsx
+++ b/frontend/features/AdminDashboard/Presenter.test.tsx
@@ -75,4 +75,10 @@ describe("AdminDashboardPresenter", () => {
       screen.getByText("CSVインポート履歴がありません"),
     ).toBeInTheDocument();
   });
+
+  it("「すべて見る」リンクが履歴一覧ページを指す", () => {
+    render(<Presenter data={mockData} />);
+    const link = screen.getByRole("link", { name: "すべて見る" });
+    expect(link).toHaveAttribute("href", "/admin/csv-import/history");
+  });
 });

--- a/frontend/features/AdminDashboard/Presenter.tsx
+++ b/frontend/features/AdminDashboard/Presenter.tsx
@@ -117,9 +117,24 @@ export const Presenter = ({ data }: Props) => {
           sx={{ border: `1px solid ${colors.border.light}`, borderRadius: 2 }}
         >
           <CardContent>
-            <Typography fontWeight={600} sx={{ mb: 2 }}>
-              最近のCSVインポート
-            </Typography>
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                mb: 2,
+              }}
+            >
+              <Typography fontWeight={600}>最近のCSVインポート</Typography>
+              <Typography
+                component={Link}
+                href="/admin/csv-import/history"
+                variant="body2"
+                sx={{ color: colors.brand.primary, textDecoration: "none" }}
+              >
+                すべて見る
+              </Typography>
+            </Box>
             {recent_imports.length === 0 ? (
               <Typography
                 color="text.secondary"

--- a/frontend/features/AdminImportHistory/Presenter.test.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.test.tsx
@@ -90,9 +90,9 @@ describe("AdminImportHistoryPresenter", () => {
     expect(headers).toContain("コース");
     expect(headers).toContain("単元");
     expect(headers).toContain("件数");
-    expect(headers.some((h) => h?.includes("成功数") && h?.includes("エラー数"))).toBe(
-      true,
-    );
+    expect(
+      headers.some((h) => h?.includes("成功数") && h?.includes("エラー数")),
+    ).toBe(true);
     expect(headers).toContain("実行者");
     expect(headers).toContain("ステータス");
   });
@@ -254,7 +254,9 @@ describe("AdminImportHistoryPresenter", () => {
         onClearFilters={onClearFilters}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: "フィルタを全てクリア" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "フィルタを全てクリア" }),
+    );
     expect(onClearFilters).toHaveBeenCalled();
   });
 
@@ -352,7 +354,11 @@ describe("AdminImportHistoryPresenter", () => {
     render(
       <Presenter
         {...defaultProps}
-        filters={{ ...defaultProps.filters, from: "2026-08-20", to: "2026-08-01" }}
+        filters={{
+          ...defaultProps.filters,
+          from: "2026-08-20",
+          to: "2026-08-01",
+        }}
       />,
     );
     expect(
@@ -364,7 +370,11 @@ describe("AdminImportHistoryPresenter", () => {
     render(
       <Presenter
         {...defaultProps}
-        filters={{ ...defaultProps.filters, from: "2026-08-01", to: "2026-08-20" }}
+        filters={{
+          ...defaultProps.filters,
+          from: "2026-08-01",
+          to: "2026-08-20",
+        }}
       />,
     );
     expect(

--- a/frontend/features/AdminImportHistory/Presenter.test.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
-import { Presenter } from "../Presenter";
-import type { ImportHistoriesData } from "../types";
+import { Presenter } from "./Presenter";
+import type { ImportHistoriesData } from "./types";
 
 vi.mock("next/link", () => ({
   default: ({

--- a/frontend/features/AdminImportHistory/Presenter.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.tsx
@@ -3,10 +3,13 @@
 import { colors } from "@/app/theme/colors";
 import {
   Box,
+  Button,
   Card,
   CardContent,
   Chip,
   FormControl,
+  IconButton,
+  InputAdornment,
   InputLabel,
   MenuItem,
   Pagination,
@@ -21,6 +24,7 @@ import {
   TableSortLabel,
   Typography,
 } from "@mui/material";
+import ClearIcon from "@mui/icons-material/Clear";
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { ja } from "date-fns/locale";
@@ -59,6 +63,7 @@ type Props = {
   onSortChange: (sort: ImportHistorySort) => void;
   onPageChange: (page: number) => void;
   onPerPageChange: (perPage: number) => void;
+  onClearFilters: () => void;
   onRowClick: (id: number) => void;
 };
 
@@ -118,6 +123,7 @@ export const Presenter = ({
   onSortChange,
   onPageChange,
   onPerPageChange,
+  onClearFilters,
   onRowClick,
 }: Props) => {
   const { import_histories: histories, meta } = data;
@@ -125,6 +131,13 @@ export const Presenter = ({
   const fromDate = dateToInput(filters.from);
   const toDate = dateToInput(filters.to);
   const dateRangeInvalid = !!fromDate && !!toDate && fromDate > toDate;
+  const hasActiveFilters =
+    !!filters.status ||
+    !!filters.courseId ||
+    !!filters.unitId ||
+    !!filters.userId ||
+    !!filters.from ||
+    !!filters.to;
 
   const handlePerPageChange = (e: SelectChangeEvent<string>) => {
     onPerPageChange(Number(e.target.value));
@@ -175,6 +188,22 @@ export const Presenter = ({
             onChange={(e) =>
               onStatusChange(e.target.value as ImportHistoryStatus | "")
             }
+            endAdornment={
+              filters.status && (
+                <InputAdornment position="end" sx={{ mr: 2 }}>
+                  <IconButton
+                    aria-label="ステータスをクリア"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onStatusChange("");
+                    }}
+                  >
+                    <ClearIcon fontSize="inherit" />
+                  </IconButton>
+                </InputAdornment>
+              )
+            }
           >
             <MenuItem value="">すべて</MenuItem>
             {STATUS_OPTIONS.map((option) => (
@@ -192,6 +221,22 @@ export const Presenter = ({
             label="コース"
             value={filters.courseId}
             onChange={(e) => onCourseChange(e.target.value)}
+            endAdornment={
+              filters.courseId && (
+                <InputAdornment position="end" sx={{ mr: 2 }}>
+                  <IconButton
+                    aria-label="コースをクリア"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onCourseChange("");
+                    }}
+                  >
+                    <ClearIcon fontSize="inherit" />
+                  </IconButton>
+                </InputAdornment>
+              )
+            }
           >
             <MenuItem value="">すべて</MenuItem>
             {courseOptions.map((course) => (
@@ -209,6 +254,22 @@ export const Presenter = ({
             label="単元"
             value={filters.unitId}
             onChange={(e) => onUnitChange(e.target.value)}
+            endAdornment={
+              filters.unitId && (
+                <InputAdornment position="end" sx={{ mr: 2 }}>
+                  <IconButton
+                    aria-label="単元をクリア"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onUnitChange("");
+                    }}
+                  >
+                    <ClearIcon fontSize="inherit" />
+                  </IconButton>
+                </InputAdornment>
+              )
+            }
           >
             <MenuItem value="">すべて</MenuItem>
             {unitOptions.map((unit) => (
@@ -226,6 +287,22 @@ export const Presenter = ({
             label="実行者"
             value={filters.userId}
             onChange={(e) => onUserChange(e.target.value)}
+            endAdornment={
+              filters.userId && (
+                <InputAdornment position="end" sx={{ mr: 2 }}>
+                  <IconButton
+                    aria-label="実行者をクリア"
+                    size="small"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onUserChange("");
+                    }}
+                  >
+                    <ClearIcon fontSize="inherit" />
+                  </IconButton>
+                </InputAdornment>
+              )
+            }
           >
             <MenuItem value="">すべて</MenuItem>
             {userOptions.map((user) => (
@@ -244,7 +321,25 @@ export const Presenter = ({
             maxDate={toDate ?? undefined}
             onChange={(date) => onFromChange(dateToParam(date))}
             slotProps={{
-              textField: { size: "small", sx: { width: 140, ...compactFieldSx } },
+              textField: {
+                size: "small",
+                sx: { width: 140, ...compactFieldSx },
+                InputProps: filters.from
+                  ? {
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <IconButton
+                            aria-label="開始日をクリア"
+                            size="small"
+                            onClick={() => onFromChange("")}
+                          >
+                            <ClearIcon fontSize="inherit" />
+                          </IconButton>
+                        </InputAdornment>
+                      ),
+                    }
+                  : undefined,
+              },
             }}
           />
           <DatePicker
@@ -261,10 +356,39 @@ export const Presenter = ({
                   ? "終了日は開始日以降の日付を指定してください"
                   : undefined,
                 sx: { width: 140, ...compactFieldSx },
+                InputProps: filters.to
+                  ? {
+                      endAdornment: (
+                        <InputAdornment position="end">
+                          <IconButton
+                            aria-label="終了日をクリア"
+                            size="small"
+                            onClick={() => onToChange("")}
+                          >
+                            <ClearIcon fontSize="inherit" />
+                          </IconButton>
+                        </InputAdornment>
+                      ),
+                    }
+                  : undefined,
               },
             }}
           />
         </LocalizationProvider>
+
+        {hasActiveFilters && (
+          <Button
+            size="small"
+            onClick={onClearFilters}
+            sx={{
+              color: colors.text.muted,
+              textTransform: "none",
+              fontSize: "0.8125rem",
+            }}
+          >
+            フィルタを全てクリア
+          </Button>
+        )}
 
         <FormControl
           size="small"

--- a/frontend/features/AdminImportHistory/Presenter.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.tsx
@@ -28,6 +28,7 @@ import { format, isValid, parseISO } from "date-fns";
 import {
   IMPORT_STATUS_COLOR,
   IMPORT_STATUS_LABEL,
+  PER_PAGE_OPTIONS,
   type ImportHistoriesData,
   type ImportHistoryFilters,
   type ImportHistoryOrder,
@@ -48,6 +49,7 @@ type Props = {
   sort: ImportHistorySort;
   order: ImportHistoryOrder;
   page: number;
+  perPage: number;
   onStatusChange: (status: ImportHistoryStatus | "") => void;
   onCourseChange: (courseId: string) => void;
   onUnitChange: (unitId: string) => void;
@@ -56,6 +58,7 @@ type Props = {
   onToChange: (to: string) => void;
   onSortChange: (sort: ImportHistorySort) => void;
   onPageChange: (page: number) => void;
+  onPerPageChange: (perPage: number) => void;
   onRowClick: (id: number) => void;
 };
 
@@ -83,6 +86,7 @@ export const Presenter = ({
   sort,
   order,
   page,
+  perPage,
   onStatusChange,
   onCourseChange,
   onUnitChange,
@@ -91,6 +95,7 @@ export const Presenter = ({
   onToChange,
   onSortChange,
   onPageChange,
+  onPerPageChange,
   onRowClick,
 }: Props) => {
   const { import_histories: histories, meta } = data;
@@ -113,6 +118,10 @@ export const Presenter = ({
 
   const handleUserChange = (e: SelectChangeEvent<string>) => {
     onUserChange(e.target.value);
+  };
+
+  const handlePerPageChange = (e: SelectChangeEvent<string>) => {
+    onPerPageChange(Number(e.target.value));
   };
 
   return (
@@ -203,6 +212,22 @@ export const Presenter = ({
             {userOptions.map((user) => (
               <MenuItem key={user.id} value={String(user.id)}>
                 {user.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl size="small" sx={{ minWidth: 120 }}>
+          <InputLabel id="import-history-per-page-label">表示件数</InputLabel>
+          <Select
+            labelId="import-history-per-page-label"
+            label="表示件数"
+            value={String(perPage)}
+            onChange={handlePerPageChange}
+          >
+            {PER_PAGE_OPTIONS.map((option) => (
+              <MenuItem key={option} value={String(option)}>
+                {option}件
               </MenuItem>
             ))}
           </Select>

--- a/frontend/features/AdminImportHistory/Presenter.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { colors } from "@/app/theme/colors";
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Pagination,
+  Select,
+  type SelectChangeEvent,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Typography,
+} from "@mui/material";
+import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
+import { ja } from "date-fns/locale";
+import { format, parseISO } from "date-fns";
+import {
+  IMPORT_STATUS_COLOR,
+  IMPORT_STATUS_LABEL,
+  type ImportHistoriesData,
+  type ImportHistoryFilters,
+  type ImportHistoryOrder,
+  type ImportHistorySort,
+  type ImportHistoryStatus,
+} from "./types";
+
+type CourseOption = { id: number; level_name: string };
+type UnitOption = { id: number; unit_name: string };
+type UserOption = { id: number; name: string };
+
+type Props = {
+  data: ImportHistoriesData;
+  filters: ImportHistoryFilters;
+  courseOptions: CourseOption[];
+  unitOptions: UnitOption[];
+  userOptions: UserOption[];
+  sort: ImportHistorySort;
+  order: ImportHistoryOrder;
+  page: number;
+  onStatusChange: (status: ImportHistoryStatus | "") => void;
+  onCourseChange: (courseId: string) => void;
+  onUnitChange: (unitId: string) => void;
+  onUserChange: (userId: string) => void;
+  onFromChange: (from: string) => void;
+  onToChange: (to: string) => void;
+  onSortChange: (sort: ImportHistorySort) => void;
+  onPageChange: (page: number) => void;
+  onRowClick: (id: number) => void;
+};
+
+const STATUS_OPTIONS: { value: ImportHistoryStatus; label: string }[] = [
+  { value: "pending", label: IMPORT_STATUS_LABEL.pending },
+  { value: "processing", label: IMPORT_STATUS_LABEL.processing },
+  { value: "completed", label: IMPORT_STATUS_LABEL.completed },
+  { value: "failed", label: IMPORT_STATUS_LABEL.failed },
+];
+
+const dateToInput = (value: string) => (value ? parseISO(value) : null);
+const dateToParam = (date: Date | null) => (date ? format(date, "yyyy-MM-dd") : "");
+
+export const Presenter = ({
+  data,
+  filters,
+  courseOptions,
+  unitOptions,
+  userOptions,
+  sort,
+  order,
+  page,
+  onStatusChange,
+  onCourseChange,
+  onUnitChange,
+  onUserChange,
+  onFromChange,
+  onToChange,
+  onSortChange,
+  onPageChange,
+  onRowClick,
+}: Props) => {
+  const { import_histories: histories, meta } = data;
+
+  const handleStatusChange = (e: SelectChangeEvent<string>) => {
+    onStatusChange(e.target.value as ImportHistoryStatus | "");
+  };
+
+  const handleCourseChange = (e: SelectChangeEvent<string>) => {
+    onCourseChange(e.target.value);
+  };
+
+  const handleUnitChange = (e: SelectChangeEvent<string>) => {
+    onUnitChange(e.target.value);
+  };
+
+  const handleUserChange = (e: SelectChangeEvent<string>) => {
+    onUserChange(e.target.value);
+  };
+
+  return (
+    <Box sx={{ p: 3 }}>
+      <Box sx={{ display: "flex", alignItems: "baseline", gap: 1.5, mb: 3 }}>
+        <Typography
+          variant="h5"
+          fontWeight={700}
+          sx={{ color: colors.text.primary }}
+        >
+          インポート履歴一覧
+        </Typography>
+        <Typography variant="body2" sx={{ color: colors.text.muted }}>
+          {meta.total_count} 件
+        </Typography>
+      </Box>
+
+      {/* フィルタ */}
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        <FormControl size="small" sx={{ minWidth: 140 }}>
+          <InputLabel id="import-history-status-label">ステータス</InputLabel>
+          <Select
+            labelId="import-history-status-label"
+            label="ステータス"
+            value={filters.status}
+            onChange={handleStatusChange}
+          >
+            <MenuItem value="">すべて</MenuItem>
+            {STATUS_OPTIONS.map((option) => (
+              <MenuItem key={option.value} value={option.value}>
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel id="import-history-course-label">コース</InputLabel>
+          <Select
+            labelId="import-history-course-label"
+            label="コース"
+            value={filters.courseId}
+            onChange={handleCourseChange}
+          >
+            <MenuItem value="">すべて</MenuItem>
+            {courseOptions.map((course) => (
+              <MenuItem key={course.id} value={String(course.id)}>
+                {course.level_name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel id="import-history-unit-label">単元</InputLabel>
+          <Select
+            labelId="import-history-unit-label"
+            label="単元"
+            value={filters.unitId}
+            onChange={handleUnitChange}
+          >
+            <MenuItem value="">すべて</MenuItem>
+            {unitOptions.map((unit) => (
+              <MenuItem key={unit.id} value={String(unit.id)}>
+                {unit.unit_name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel id="import-history-user-label">実行者</InputLabel>
+          <Select
+            labelId="import-history-user-label"
+            label="実行者"
+            value={filters.userId}
+            onChange={handleUserChange}
+          >
+            <MenuItem value="">すべて</MenuItem>
+            {userOptions.map((user) => (
+              <MenuItem key={user.id} value={String(user.id)}>
+                {user.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={ja}>
+          <DatePicker
+            label="開始日"
+            format="yyyy/MM/dd"
+            value={dateToInput(filters.from)}
+            onChange={(date) => onFromChange(dateToParam(date))}
+            slotProps={{ textField: { size: "small" } }}
+          />
+          <DatePicker
+            label="終了日"
+            format="yyyy/MM/dd"
+            value={dateToInput(filters.to)}
+            onChange={(date) => onToChange(dateToParam(date))}
+            slotProps={{ textField: { size: "small" } }}
+          />
+        </LocalizationProvider>
+      </Box>
+
+      {/* テーブル */}
+      <Card
+        elevation={0}
+        sx={{
+          border: `1px solid ${colors.border.light}`,
+          borderRadius: 2,
+          mb: 3,
+        }}
+      >
+        <CardContent sx={{ p: 0, "&:last-child": { pb: 0 } }}>
+          {histories.length === 0 ? (
+            <Box sx={{ py: 6, textAlign: "center" }}>
+              <Typography color="text.secondary">
+                インポート履歴が見つかりません
+              </Typography>
+            </Box>
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow sx={{ bgcolor: colors.surface.light }}>
+                    <TableCell sx={{ fontWeight: 600 }}>
+                      <TableSortLabel
+                        active={sort === "created_at"}
+                        direction={sort === "created_at" ? order : "desc"}
+                        onClick={() => onSortChange("created_at")}
+                      >
+                        日時
+                      </TableSortLabel>
+                    </TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>コース</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>単元</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }} align="right">
+                      <TableSortLabel
+                        active={sort === "total_count"}
+                        direction={sort === "total_count" ? order : "asc"}
+                        onClick={() => onSortChange("total_count")}
+                      >
+                        件数
+                      </TableSortLabel>
+                    </TableCell>
+                    <TableCell sx={{ fontWeight: 600 }} align="right">
+                      成功数/エラー数
+                    </TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>実行者</TableCell>
+                    <TableCell sx={{ fontWeight: 600 }}>
+                      <TableSortLabel
+                        active={sort === "status"}
+                        direction={sort === "status" ? order : "asc"}
+                        onClick={() => onSortChange("status")}
+                      >
+                        ステータス
+                      </TableSortLabel>
+                    </TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {histories.map((history) => (
+                    <TableRow
+                      key={history.id}
+                      hover
+                      onClick={() => onRowClick(history.id)}
+                      sx={{
+                        cursor: "pointer",
+                        "&:last-child td": { border: 0 },
+                      }}
+                    >
+                      <TableCell>
+                        {format(new Date(history.created_at), "yyyy/MM/dd HH:mm")}
+                      </TableCell>
+                      <TableCell>{history.course?.level_name ?? "-"}</TableCell>
+                      <TableCell>{history.unit?.unit_name ?? "-"}</TableCell>
+                      <TableCell align="right">{history.total_count}</TableCell>
+                      <TableCell align="right">
+                        {history.success_count} / {history.error_count}
+                      </TableCell>
+                      <TableCell>{history.user?.name ?? "-"}</TableCell>
+                      <TableCell>
+                        <Chip
+                          label={IMPORT_STATUS_LABEL[history.status]}
+                          size="small"
+                          color={IMPORT_STATUS_COLOR[history.status]}
+                          variant="outlined"
+                        />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ページネーション */}
+      {meta.total_pages > 1 && (
+        <Box sx={{ display: "flex", justifyContent: "center" }}>
+          <Pagination
+            count={meta.total_pages}
+            page={page}
+            onChange={(_, value) => onPageChange(value)}
+            color="primary"
+          />
+        </Box>
+      )}
+    </Box>
+  );
+};

--- a/frontend/features/AdminImportHistory/Presenter.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.tsx
@@ -303,7 +303,21 @@ export const Presenter = ({
                       </TableSortLabel>
                     </TableCell>
                     <TableCell sx={{ fontWeight: 600 }} align="right">
-                      成功数/エラー数
+                      <TableSortLabel
+                        active={sort === "success_count"}
+                        direction={sort === "success_count" ? order : "asc"}
+                        onClick={() => onSortChange("success_count")}
+                      >
+                        成功数
+                      </TableSortLabel>
+                      {" / "}
+                      <TableSortLabel
+                        active={sort === "error_count"}
+                        direction={sort === "error_count" ? order : "asc"}
+                        onClick={() => onSortChange("error_count")}
+                      >
+                        エラー数
+                      </TableSortLabel>
                     </TableCell>
                     <TableCell sx={{ fontWeight: 600 }}>実行者</TableCell>
                     <TableCell sx={{ fontWeight: 600 }}>

--- a/frontend/features/AdminImportHistory/Presenter.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.tsx
@@ -90,6 +90,10 @@ export const Presenter = ({
 }: Props) => {
   const { import_histories: histories, meta } = data;
 
+  const fromDate = dateToInput(filters.from);
+  const toDate = dateToInput(filters.to);
+  const dateRangeInvalid = !!fromDate && !!toDate && fromDate > toDate;
+
   const handleStatusChange = (e: SelectChangeEvent<string>) => {
     onStatusChange(e.target.value as ImportHistoryStatus | "");
   };
@@ -203,16 +207,26 @@ export const Presenter = ({
           <DatePicker
             label="開始日"
             format="yyyy/MM/dd"
-            value={dateToInput(filters.from)}
+            value={fromDate}
+            maxDate={toDate ?? undefined}
             onChange={(date) => onFromChange(dateToParam(date))}
             slotProps={{ textField: { size: "small" } }}
           />
           <DatePicker
             label="終了日"
             format="yyyy/MM/dd"
-            value={dateToInput(filters.to)}
+            value={toDate}
+            minDate={fromDate ?? undefined}
             onChange={(date) => onToChange(dateToParam(date))}
-            slotProps={{ textField: { size: "small" } }}
+            slotProps={{
+              textField: {
+                size: "small",
+                error: dateRangeInvalid,
+                helperText: dateRangeInvalid
+                  ? "終了日は開始日以降の日付を指定してください"
+                  : undefined,
+              },
+            }}
           />
         </LocalizationProvider>
       </Box>

--- a/frontend/features/AdminImportHistory/Presenter.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.tsx
@@ -72,6 +72,16 @@ const STATUS_OPTIONS: { value: ImportHistoryStatus; label: string }[] = [
 const dateToInput = (value: string) => (value ? parseISO(value) : null);
 const dateToParam = (date: Date | null) => (date ? format(date, "yyyy-MM-dd") : "");
 
+// Gentelella風のフラット・ミニマルなテイストを本画面ローカルで再現するトークン。
+// 角丸なし・影なし、薄いグレーのボーダーのみで区切る。
+const flat = {
+  border: "#E6E9ED",
+  headerBg: "#ffffff",
+  stripe: "#F7F7F7",
+  accent: "#1ABB9C",
+  titleText: "#2A3F54",
+};
+
 const formatDateTime = (value: string) => {
   const date = new Date(value);
   return isValid(date) ? format(date, "yyyy/MM/dd HH:mm") : "-";
@@ -110,11 +120,20 @@ export const Presenter = ({
 
   return (
     <Box sx={{ p: 3 }}>
-      <Box sx={{ display: "flex", alignItems: "baseline", gap: 1.5, mb: 3 }}>
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: 1.5,
+          mb: 3,
+          pb: 1.5,
+          borderBottom: `2px solid ${flat.border}`,
+        }}
+      >
         <Typography
           variant="h5"
-          fontWeight={700}
-          sx={{ color: colors.text.primary }}
+          fontWeight={600}
+          sx={{ color: flat.titleText, letterSpacing: 0.3 }}
         >
           インポート履歴一覧
         </Typography>
@@ -251,8 +270,9 @@ export const Presenter = ({
       <Card
         elevation={0}
         sx={{
-          border: `1px solid ${colors.border.light}`,
-          borderRadius: 2,
+          border: `1px solid ${flat.border}`,
+          borderRadius: 0,
+          boxShadow: "none",
           mb: 3,
         }}
       >
@@ -265,10 +285,22 @@ export const Presenter = ({
             </Box>
           ) : (
             <TableContainer>
-              <Table size="small">
+              <Table
+                size="small"
+                sx={{
+                  "& .MuiTableCell-root": {
+                    borderBottom: `1px solid ${flat.border}`,
+                  },
+                }}
+              >
                 <TableHead>
-                  <TableRow sx={{ bgcolor: colors.surface.light }}>
-                    <TableCell sx={{ fontWeight: 600 }}>
+                  <TableRow sx={{ bgcolor: flat.headerBg }}>
+                    <TableCell
+                      sx={{
+                        fontWeight: 600,
+                        borderBottom: `2px solid ${flat.border}`,
+                      }}
+                    >
                       <TableSortLabel
                         active={sort === "created_at"}
                         direction={sort === "created_at" ? order : "desc"}
@@ -277,9 +309,29 @@ export const Presenter = ({
                         日時
                       </TableSortLabel>
                     </TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>コース</TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>単元</TableCell>
-                    <TableCell sx={{ fontWeight: 600 }} align="right">
+                    <TableCell
+                      sx={{
+                        fontWeight: 600,
+                        borderBottom: `2px solid ${flat.border}`,
+                      }}
+                    >
+                      コース
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        fontWeight: 600,
+                        borderBottom: `2px solid ${flat.border}`,
+                      }}
+                    >
+                      単元
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        fontWeight: 600,
+                        borderBottom: `2px solid ${flat.border}`,
+                      }}
+                      align="right"
+                    >
                       <TableSortLabel
                         active={sort === "total_count"}
                         direction={sort === "total_count" ? order : "asc"}
@@ -288,7 +340,13 @@ export const Presenter = ({
                         件数
                       </TableSortLabel>
                     </TableCell>
-                    <TableCell sx={{ fontWeight: 600 }} align="right">
+                    <TableCell
+                      sx={{
+                        fontWeight: 600,
+                        borderBottom: `2px solid ${flat.border}`,
+                      }}
+                      align="right"
+                    >
                       <TableSortLabel
                         active={sort === "success_count"}
                         direction={sort === "success_count" ? order : "asc"}
@@ -305,8 +363,20 @@ export const Presenter = ({
                         エラー数
                       </TableSortLabel>
                     </TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>実行者</TableCell>
-                    <TableCell sx={{ fontWeight: 600 }}>
+                    <TableCell
+                      sx={{
+                        fontWeight: 600,
+                        borderBottom: `2px solid ${flat.border}`,
+                      }}
+                    >
+                      実行者
+                    </TableCell>
+                    <TableCell
+                      sx={{
+                        fontWeight: 600,
+                        borderBottom: `2px solid ${flat.border}`,
+                      }}
+                    >
                       <TableSortLabel
                         active={sort === "status"}
                         direction={sort === "status" ? order : "asc"}
@@ -318,14 +388,16 @@ export const Presenter = ({
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {histories.map((history) => (
+                  {histories.map((history, index) => (
                     <TableRow
                       key={history.id}
                       hover
                       onClick={() => onRowClick(history.id)}
                       sx={{
                         cursor: "pointer",
+                        bgcolor: index % 2 === 1 ? flat.stripe : "transparent",
                         "&:last-child td": { border: 0 },
+                        "&:hover": { bgcolor: "#EFF3F5" },
                       }}
                     >
                       <TableCell>
@@ -343,7 +415,13 @@ export const Presenter = ({
                           label={IMPORT_STATUS_LABEL[history.status]}
                           size="small"
                           color={IMPORT_STATUS_COLOR[history.status]}
-                          variant="outlined"
+                          variant="filled"
+                          sx={{
+                            borderRadius: "3px",
+                            fontWeight: 600,
+                            fontSize: "0.7rem",
+                            color: "#fff",
+                          }}
                         />
                       </TableCell>
                     </TableRow>

--- a/frontend/features/AdminImportHistory/Presenter.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.tsx
@@ -24,7 +24,7 @@ import {
 import { DatePicker, LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { ja } from "date-fns/locale";
-import { format, parseISO } from "date-fns";
+import { format, isValid, parseISO } from "date-fns";
 import {
   IMPORT_STATUS_COLOR,
   IMPORT_STATUS_LABEL,
@@ -68,6 +68,11 @@ const STATUS_OPTIONS: { value: ImportHistoryStatus; label: string }[] = [
 
 const dateToInput = (value: string) => (value ? parseISO(value) : null);
 const dateToParam = (date: Date | null) => (date ? format(date, "yyyy-MM-dd") : "");
+
+const formatDateTime = (value: string) => {
+  const date = new Date(value);
+  return isValid(date) ? format(date, "yyyy/MM/dd HH:mm") : "-";
+};
 
 export const Presenter = ({
   data,
@@ -299,7 +304,7 @@ export const Presenter = ({
                       }}
                     >
                       <TableCell>
-                        {format(new Date(history.created_at), "yyyy/MM/dd HH:mm")}
+                        {formatDateTime(history.created_at)}
                       </TableCell>
                       <TableCell>{history.course?.level_name ?? "-"}</TableCell>
                       <TableCell>{history.unit?.unit_name ?? "-"}</TableCell>

--- a/frontend/features/AdminImportHistory/Presenter.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.tsx
@@ -75,7 +75,8 @@ const STATUS_OPTIONS: { value: ImportHistoryStatus; label: string }[] = [
 ];
 
 const dateToInput = (value: string) => (value ? parseISO(value) : null);
-const dateToParam = (date: Date | null) => (date ? format(date, "yyyy-MM-dd") : "");
+const dateToParam = (date: Date | null) =>
+  date ? format(date, "yyyy-MM-dd") : "";
 
 // Gentelella風のフラット・ミニマルなテイストを本画面ローカルで再現するトークン。
 // 角丸なし・影なし、薄いグレーのボーダーのみで区切る。

--- a/frontend/features/AdminImportHistory/Presenter.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.tsx
@@ -104,22 +104,6 @@ export const Presenter = ({
   const toDate = dateToInput(filters.to);
   const dateRangeInvalid = !!fromDate && !!toDate && fromDate > toDate;
 
-  const handleStatusChange = (e: SelectChangeEvent<string>) => {
-    onStatusChange(e.target.value as ImportHistoryStatus | "");
-  };
-
-  const handleCourseChange = (e: SelectChangeEvent<string>) => {
-    onCourseChange(e.target.value);
-  };
-
-  const handleUnitChange = (e: SelectChangeEvent<string>) => {
-    onUnitChange(e.target.value);
-  };
-
-  const handleUserChange = (e: SelectChangeEvent<string>) => {
-    onUserChange(e.target.value);
-  };
-
   const handlePerPageChange = (e: SelectChangeEvent<string>) => {
     onPerPageChange(Number(e.target.value));
   };
@@ -155,7 +139,9 @@ export const Presenter = ({
             labelId="import-history-status-label"
             label="ステータス"
             value={filters.status}
-            onChange={handleStatusChange}
+            onChange={(e) =>
+              onStatusChange(e.target.value as ImportHistoryStatus | "")
+            }
           >
             <MenuItem value="">すべて</MenuItem>
             {STATUS_OPTIONS.map((option) => (
@@ -172,7 +158,7 @@ export const Presenter = ({
             labelId="import-history-course-label"
             label="コース"
             value={filters.courseId}
-            onChange={handleCourseChange}
+            onChange={(e) => onCourseChange(e.target.value)}
           >
             <MenuItem value="">すべて</MenuItem>
             {courseOptions.map((course) => (
@@ -189,7 +175,7 @@ export const Presenter = ({
             labelId="import-history-unit-label"
             label="単元"
             value={filters.unitId}
-            onChange={handleUnitChange}
+            onChange={(e) => onUnitChange(e.target.value)}
           >
             <MenuItem value="">すべて</MenuItem>
             {unitOptions.map((unit) => (
@@ -206,7 +192,7 @@ export const Presenter = ({
             labelId="import-history-user-label"
             label="実行者"
             value={filters.userId}
-            onChange={handleUserChange}
+            onChange={(e) => onUserChange(e.target.value)}
           >
             <MenuItem value="">すべて</MenuItem>
             {userOptions.map((user) => (

--- a/frontend/features/AdminImportHistory/Presenter.tsx
+++ b/frontend/features/AdminImportHistory/Presenter.tsx
@@ -80,6 +80,18 @@ const flat = {
   stripe: "#F7F7F7",
   accent: "#1ABB9C",
   titleText: "#2A3F54",
+  filterBg: "#FAFBFC",
+};
+
+// フィルタのSelect/DatePickerを角丸なし・小さめのGentelella風に揃えるための共通sx
+const compactFieldSx = {
+  "& .MuiOutlinedInput-root": {
+    borderRadius: "2px",
+    fontSize: "0.8125rem",
+  },
+  "& .MuiInputLabel-root": {
+    fontSize: "0.8125rem",
+  },
 };
 
 const formatDateTime = (value: string) => {
@@ -148,11 +160,13 @@ export const Presenter = ({
           display: "flex",
           flexWrap: "wrap",
           alignItems: "center",
-          gap: 2,
+          gap: 1.25,
           mb: 3,
+          p: 1.5,
+          bgcolor: flat.filterBg,
         }}
       >
-        <FormControl size="small" sx={{ minWidth: 140 }}>
+        <FormControl size="small" sx={{ minWidth: 110, ...compactFieldSx }}>
           <InputLabel id="import-history-status-label">ステータス</InputLabel>
           <Select
             labelId="import-history-status-label"
@@ -171,7 +185,7 @@ export const Presenter = ({
           </Select>
         </FormControl>
 
-        <FormControl size="small" sx={{ minWidth: 160 }}>
+        <FormControl size="small" sx={{ minWidth: 130, ...compactFieldSx }}>
           <InputLabel id="import-history-course-label">コース</InputLabel>
           <Select
             labelId="import-history-course-label"
@@ -188,7 +202,7 @@ export const Presenter = ({
           </Select>
         </FormControl>
 
-        <FormControl size="small" sx={{ minWidth: 160 }}>
+        <FormControl size="small" sx={{ minWidth: 130, ...compactFieldSx }}>
           <InputLabel id="import-history-unit-label">単元</InputLabel>
           <Select
             labelId="import-history-unit-label"
@@ -205,7 +219,7 @@ export const Presenter = ({
           </Select>
         </FormControl>
 
-        <FormControl size="small" sx={{ minWidth: 160 }}>
+        <FormControl size="small" sx={{ minWidth: 130, ...compactFieldSx }}>
           <InputLabel id="import-history-user-label">実行者</InputLabel>
           <Select
             labelId="import-history-user-label"
@@ -222,22 +236,6 @@ export const Presenter = ({
           </Select>
         </FormControl>
 
-        <FormControl size="small" sx={{ minWidth: 120 }}>
-          <InputLabel id="import-history-per-page-label">表示件数</InputLabel>
-          <Select
-            labelId="import-history-per-page-label"
-            label="表示件数"
-            value={String(perPage)}
-            onChange={handlePerPageChange}
-          >
-            {PER_PAGE_OPTIONS.map((option) => (
-              <MenuItem key={option} value={String(option)}>
-                {option}件
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-
         <LocalizationProvider dateAdapter={AdapterDateFns} adapterLocale={ja}>
           <DatePicker
             label="開始日"
@@ -245,7 +243,9 @@ export const Presenter = ({
             value={fromDate}
             maxDate={toDate ?? undefined}
             onChange={(date) => onFromChange(dateToParam(date))}
-            slotProps={{ textField: { size: "small" } }}
+            slotProps={{
+              textField: { size: "small", sx: { width: 140, ...compactFieldSx } },
+            }}
           />
           <DatePicker
             label="終了日"
@@ -260,10 +260,30 @@ export const Presenter = ({
                 helperText: dateRangeInvalid
                   ? "終了日は開始日以降の日付を指定してください"
                   : undefined,
+                sx: { width: 140, ...compactFieldSx },
               },
             }}
           />
         </LocalizationProvider>
+
+        <FormControl
+          size="small"
+          sx={{ minWidth: 90, ml: "auto", ...compactFieldSx }}
+        >
+          <InputLabel id="import-history-per-page-label">表示件数</InputLabel>
+          <Select
+            labelId="import-history-per-page-label"
+            label="表示件数"
+            value={String(perPage)}
+            onChange={handlePerPageChange}
+          >
+            {PER_PAGE_OPTIONS.map((option) => (
+              <MenuItem key={option} value={String(option)}>
+                {option}件
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
       </Box>
 
       {/* テーブル */}

--- a/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
+++ b/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
@@ -89,7 +89,9 @@ describe("AdminImportHistoryPresenter", () => {
     expect(headers).toContain("コース");
     expect(headers).toContain("単元");
     expect(headers).toContain("件数");
-    expect(headers).toContain("成功数/エラー数");
+    expect(headers.some((h) => h?.includes("成功数") && h?.includes("エラー数"))).toBe(
+      true,
+    );
     expect(headers).toContain("実行者");
     expect(headers).toContain("ステータス");
   });
@@ -204,6 +206,20 @@ describe("AdminImportHistoryPresenter", () => {
     const sortButton = screen.getByRole("button", { name: /件数/ });
     fireEvent.click(sortButton);
     expect(onSortChange).toHaveBeenCalledWith("total_count");
+  });
+
+  it("成功数ソートボタンをクリックすると onSortChange が success_count で呼ばれる", () => {
+    const onSortChange = vi.fn();
+    render(<Presenter {...defaultProps} onSortChange={onSortChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "成功数" }));
+    expect(onSortChange).toHaveBeenCalledWith("success_count");
+  });
+
+  it("エラー数ソートボタンをクリックすると onSortChange が error_count で呼ばれる", () => {
+    const onSortChange = vi.fn();
+    render(<Presenter {...defaultProps} onSortChange={onSortChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "エラー数" }));
+    expect(onSortChange).toHaveBeenCalledWith("error_count");
   });
 
   it("表示件数プルダウンに 20 / 50 / 100 が表示され、変更で onPerPageChange が呼ばれる", () => {

--- a/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
+++ b/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
@@ -140,6 +140,18 @@ describe("AdminImportHistoryPresenter", () => {
     expect(dashes.length).toBeGreaterThanOrEqual(2);
   });
 
+  it("created_at が不正な値でもクラッシュせず「-」で表示される", () => {
+    const data: ImportHistoriesData = {
+      ...mockData,
+      import_histories: [
+        { ...mockData.import_histories[0], id: 6, created_at: "" },
+      ],
+    };
+    expect(() =>
+      render(<Presenter {...defaultProps} data={data} />),
+    ).not.toThrow();
+  });
+
   it("ステータスセレクトの変更で onStatusChange が呼ばれる", () => {
     const onStatusChange = vi.fn();
     render(<Presenter {...defaultProps} onStatusChange={onStatusChange} />);

--- a/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
+++ b/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
@@ -204,6 +204,30 @@ describe("AdminImportHistoryPresenter", () => {
     expect(onRowClick).toHaveBeenCalledWith(1);
   });
 
+  it("終了日が開始日より前のとき、終了日フィールドにエラーが表示される", () => {
+    render(
+      <Presenter
+        {...defaultProps}
+        filters={{ ...defaultProps.filters, from: "2026-08-20", to: "2026-08-01" }}
+      />,
+    );
+    expect(
+      screen.getByText("終了日は開始日以降の日付を指定してください"),
+    ).toBeInTheDocument();
+  });
+
+  it("開始日が終了日以前のとき、日付レンジのエラーは表示されない", () => {
+    render(
+      <Presenter
+        {...defaultProps}
+        filters={{ ...defaultProps.filters, from: "2026-08-01", to: "2026-08-20" }}
+      />,
+    );
+    expect(
+      screen.queryByText("終了日は開始日以降の日付を指定してください"),
+    ).not.toBeInTheDocument();
+  });
+
   it("import_histories が空のとき「見つかりません」が表示される", () => {
     render(
       <Presenter

--- a/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
+++ b/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
@@ -76,6 +76,7 @@ const defaultProps = {
   onSortChange: vi.fn(),
   onPageChange: vi.fn(),
   onPerPageChange: vi.fn(),
+  onClearFilters: vi.fn(),
   onRowClick: vi.fn(),
 };
 
@@ -154,6 +155,107 @@ describe("AdminImportHistoryPresenter", () => {
     expect(() =>
       render(<Presenter {...defaultProps} data={data} />),
     ).not.toThrow();
+  });
+
+  it("フィルタが未設定のとき、個別クリアボタンと一括クリアボタンは表示されない", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(
+      screen.queryByRole("button", { name: "ステータスをクリア" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "フィルタを全てクリア" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("ステータスフィルタ設定時、個別クリアボタンで onStatusChange('') が呼ばれる", () => {
+    const onStatusChange = vi.fn();
+    render(
+      <Presenter
+        {...defaultProps}
+        filters={{ ...defaultProps.filters, status: "completed" }}
+        onStatusChange={onStatusChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "ステータスをクリア" }));
+    expect(onStatusChange).toHaveBeenCalledWith("");
+  });
+
+  it("コースフィルタ設定時、個別クリアボタンで onCourseChange('') が呼ばれる", () => {
+    const onCourseChange = vi.fn();
+    render(
+      <Presenter
+        {...defaultProps}
+        filters={{ ...defaultProps.filters, courseId: "10" }}
+        onCourseChange={onCourseChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "コースをクリア" }));
+    expect(onCourseChange).toHaveBeenCalledWith("");
+  });
+
+  it("単元フィルタ設定時、個別クリアボタンで onUnitChange('') が呼ばれる", () => {
+    const onUnitChange = vi.fn();
+    render(
+      <Presenter
+        {...defaultProps}
+        filters={{ ...defaultProps.filters, unitId: "100" }}
+        onUnitChange={onUnitChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "単元をクリア" }));
+    expect(onUnitChange).toHaveBeenCalledWith("");
+  });
+
+  it("実行者フィルタ設定時、個別クリアボタンで onUserChange('') が呼ばれる", () => {
+    const onUserChange = vi.fn();
+    render(
+      <Presenter
+        {...defaultProps}
+        filters={{ ...defaultProps.filters, userId: "1000" }}
+        onUserChange={onUserChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "実行者をクリア" }));
+    expect(onUserChange).toHaveBeenCalledWith("");
+  });
+
+  it("開始日フィルタ設定時、個別クリアボタンで onFromChange('') が呼ばれる", () => {
+    const onFromChange = vi.fn();
+    render(
+      <Presenter
+        {...defaultProps}
+        filters={{ ...defaultProps.filters, from: "2026-08-01" }}
+        onFromChange={onFromChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "開始日をクリア" }));
+    expect(onFromChange).toHaveBeenCalledWith("");
+  });
+
+  it("終了日フィルタ設定時、個別クリアボタンで onToChange('') が呼ばれる", () => {
+    const onToChange = vi.fn();
+    render(
+      <Presenter
+        {...defaultProps}
+        filters={{ ...defaultProps.filters, to: "2026-08-20" }}
+        onToChange={onToChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "終了日をクリア" }));
+    expect(onToChange).toHaveBeenCalledWith("");
+  });
+
+  it("いずれかのフィルタが設定されているとき、一括クリアボタンが表示され onClearFilters が呼ばれる", () => {
+    const onClearFilters = vi.fn();
+    render(
+      <Presenter
+        {...defaultProps}
+        filters={{ ...defaultProps.filters, status: "completed" }}
+        onClearFilters={onClearFilters}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "フィルタを全てクリア" }));
+    expect(onClearFilters).toHaveBeenCalled();
   });
 
   it("ステータスセレクトの変更で onStatusChange が呼ばれる", () => {

--- a/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
+++ b/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
@@ -66,6 +66,7 @@ const defaultProps = {
   sort: "created_at" as const,
   order: "desc" as const,
   page: 1,
+  perPage: 20,
   onStatusChange: vi.fn(),
   onCourseChange: vi.fn(),
   onUnitChange: vi.fn(),
@@ -74,6 +75,7 @@ const defaultProps = {
   onToChange: vi.fn(),
   onSortChange: vi.fn(),
   onPageChange: vi.fn(),
+  onPerPageChange: vi.fn(),
   onRowClick: vi.fn(),
 };
 
@@ -202,6 +204,18 @@ describe("AdminImportHistoryPresenter", () => {
     const sortButton = screen.getByRole("button", { name: /件数/ });
     fireEvent.click(sortButton);
     expect(onSortChange).toHaveBeenCalledWith("total_count");
+  });
+
+  it("表示件数プルダウンに 20 / 50 / 100 が表示され、変更で onPerPageChange が呼ばれる", () => {
+    const onPerPageChange = vi.fn();
+    render(<Presenter {...defaultProps} onPerPageChange={onPerPageChange} />);
+    const select = screen.getByLabelText("表示件数");
+    fireEvent.mouseDown(select);
+    expect(screen.getByRole("option", { name: "20件" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "50件" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "100件" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("option", { name: "50件" }));
+    expect(onPerPageChange).toHaveBeenCalledWith(50);
   });
 
   it("ページネーションが表示される", () => {

--- a/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
+++ b/frontend/features/AdminImportHistory/__tests__/Presenter.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Presenter } from "../Presenter";
+import type { ImportHistoriesData } from "../types";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const mockData: ImportHistoriesData = {
+  import_histories: [
+    {
+      id: 1,
+      course: { id: 10, level_name: "基礎英語" },
+      unit: { id: 100, unit_name: "単元1" },
+      user: { id: 1000, name: "実行太郎" },
+      file_name: "questions.csv",
+      status: "completed",
+      mode: "append",
+      total_count: 10,
+      success_count: 8,
+      error_count: 2,
+      created_at: "2026-08-01T10:00:00Z",
+    },
+    {
+      id: 2,
+      course: { id: 11, level_name: "標準数学" },
+      unit: { id: 101, unit_name: "単元2" },
+      user: { id: 1001, name: "実行花子" },
+      file_name: "questions2.csv",
+      status: "failed",
+      mode: "overwrite",
+      total_count: 5,
+      success_count: 0,
+      error_count: 5,
+      created_at: "2026-08-02T10:00:00Z",
+    },
+  ],
+  meta: {
+    current_page: 1,
+    total_pages: 3,
+    total_count: 50,
+    per_page: 20,
+  },
+};
+
+const defaultProps = {
+  data: mockData,
+  filters: {
+    status: "" as const,
+    courseId: "",
+    unitId: "",
+    userId: "",
+    from: "",
+    to: "",
+  },
+  courseOptions: [{ id: 10, level_name: "基礎英語" }],
+  unitOptions: [{ id: 100, unit_name: "単元1" }],
+  userOptions: [{ id: 1000, name: "実行太郎" }],
+  sort: "created_at" as const,
+  order: "desc" as const,
+  page: 1,
+  onStatusChange: vi.fn(),
+  onCourseChange: vi.fn(),
+  onUnitChange: vi.fn(),
+  onUserChange: vi.fn(),
+  onFromChange: vi.fn(),
+  onToChange: vi.fn(),
+  onSortChange: vi.fn(),
+  onPageChange: vi.fn(),
+  onRowClick: vi.fn(),
+};
+
+describe("AdminImportHistoryPresenter", () => {
+  it("テーブルヘッダーに指定された列が表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    const headers = screen
+      .getAllByRole("columnheader")
+      .map((h) => h.textContent);
+    expect(headers).toContain("日時");
+    expect(headers).toContain("コース");
+    expect(headers).toContain("単元");
+    expect(headers).toContain("件数");
+    expect(headers).toContain("成功数/エラー数");
+    expect(headers).toContain("実行者");
+    expect(headers).toContain("ステータス");
+  });
+
+  it("import_histories データが行として正しくレンダリングされる", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByText("基礎英語")).toBeInTheDocument();
+    expect(screen.getByText("単元1")).toBeInTheDocument();
+    expect(screen.getByText("実行太郎")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+    expect(screen.getByText("8 / 2")).toBeInTheDocument();
+
+    expect(screen.getByText("標準数学")).toBeInTheDocument();
+    expect(screen.getByText("単元2")).toBeInTheDocument();
+    expect(screen.getByText("実行花子")).toBeInTheDocument();
+  });
+
+  it("ステータスバッジが completed=完了 で表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByText("完了")).toBeInTheDocument();
+  });
+
+  it("ステータスバッジが failed=失敗 で表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByText("失敗")).toBeInTheDocument();
+  });
+
+  it("ステータスバッジが processing=処理中、pending=待機中 で表示される", () => {
+    const data: ImportHistoriesData = {
+      ...mockData,
+      import_histories: [
+        { ...mockData.import_histories[0], id: 3, status: "processing" },
+        { ...mockData.import_histories[0], id: 4, status: "pending" },
+      ],
+    };
+    render(<Presenter {...defaultProps} data={data} />);
+    expect(screen.getByText("処理中")).toBeInTheDocument();
+    expect(screen.getByText("待機中")).toBeInTheDocument();
+  });
+
+  it("courseId が未設定の行はコース/単元が「-」で表示される", () => {
+    const data: ImportHistoriesData = {
+      ...mockData,
+      import_histories: [
+        { ...mockData.import_histories[0], id: 5, course: null, unit: null },
+      ],
+    };
+    render(<Presenter {...defaultProps} data={data} />);
+    const dashes = screen.getAllByText("-");
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("ステータスセレクトの変更で onStatusChange が呼ばれる", () => {
+    const onStatusChange = vi.fn();
+    render(<Presenter {...defaultProps} onStatusChange={onStatusChange} />);
+    const select = screen.getByLabelText("ステータス");
+    fireEvent.mouseDown(select);
+    fireEvent.click(screen.getByRole("option", { name: "完了" }));
+    expect(onStatusChange).toHaveBeenCalledWith("completed");
+  });
+
+  it("コースセレクトの変更で onCourseChange が呼ばれる", () => {
+    const onCourseChange = vi.fn();
+    render(<Presenter {...defaultProps} onCourseChange={onCourseChange} />);
+    const select = screen.getByLabelText("コース");
+    fireEvent.mouseDown(select);
+    fireEvent.click(screen.getByRole("option", { name: "基礎英語" }));
+    expect(onCourseChange).toHaveBeenCalledWith("10");
+  });
+
+  it("単元セレクトの変更で onUnitChange が呼ばれる", () => {
+    const onUnitChange = vi.fn();
+    render(<Presenter {...defaultProps} onUnitChange={onUnitChange} />);
+    const select = screen.getByLabelText("単元");
+    fireEvent.mouseDown(select);
+    fireEvent.click(screen.getByRole("option", { name: "単元1" }));
+    expect(onUnitChange).toHaveBeenCalledWith("100");
+  });
+
+  it("実行者セレクトの変更で onUserChange が呼ばれる", () => {
+    const onUserChange = vi.fn();
+    render(<Presenter {...defaultProps} onUserChange={onUserChange} />);
+    const select = screen.getByLabelText("実行者");
+    fireEvent.mouseDown(select);
+    fireEvent.click(screen.getByRole("option", { name: "実行太郎" }));
+    expect(onUserChange).toHaveBeenCalledWith("1000");
+  });
+
+  it("日時ヘッダーをクリックすると onSortChange が呼ばれる", () => {
+    const onSortChange = vi.fn();
+    render(<Presenter {...defaultProps} onSortChange={onSortChange} />);
+    const sortButton = screen.getByRole("button", { name: /日時/ });
+    fireEvent.click(sortButton);
+    expect(onSortChange).toHaveBeenCalledWith("created_at");
+  });
+
+  it("件数ヘッダーをクリックすると onSortChange が呼ばれる", () => {
+    const onSortChange = vi.fn();
+    render(<Presenter {...defaultProps} onSortChange={onSortChange} />);
+    const sortButton = screen.getByRole("button", { name: /件数/ });
+    fireEvent.click(sortButton);
+    expect(onSortChange).toHaveBeenCalledWith("total_count");
+  });
+
+  it("ページネーションが表示される", () => {
+    render(<Presenter {...defaultProps} />);
+    expect(screen.getByRole("navigation")).toBeInTheDocument();
+  });
+
+  it("行をクリックすると onRowClick が呼ばれる", () => {
+    const onRowClick = vi.fn();
+    render(<Presenter {...defaultProps} onRowClick={onRowClick} />);
+    fireEvent.click(screen.getByText("基礎英語"));
+    expect(onRowClick).toHaveBeenCalledWith(1);
+  });
+
+  it("import_histories が空のとき「見つかりません」が表示される", () => {
+    render(
+      <Presenter
+        {...defaultProps}
+        data={{ ...mockData, import_histories: [] }}
+      />,
+    );
+    expect(
+      screen.getByText("インポート履歴が見つかりません"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -43,20 +43,18 @@ export const useFetchHistories = () => {
   const router = useRouter();
 
   useEffect(() => {
-    apiClient
-      .get<AdminCoursesData>("/api/admin/courses", { params: { per_page: 100 } })
-      .then((res) => setCourseOptions(res.data.courses))
-      .catch((err) => {
-        if (err.response?.status === 401) {
-          router.push("/login");
-        }
-      });
-  }, [router]);
-
-  useEffect(() => {
-    apiClient
-      .get<AdminAdminsData>("/api/admin/admins", { params: { per_page: 100 } })
-      .then((res) => setUserOptions(res.data.admins))
+    Promise.all([
+      apiClient.get<AdminCoursesData>("/api/admin/courses", {
+        params: { per_page: 100 },
+      }),
+      apiClient.get<AdminAdminsData>("/api/admin/admins", {
+        params: { per_page: 100 },
+      }),
+    ])
+      .then(([coursesRes, adminsRes]) => {
+        setCourseOptions(coursesRes.data.courses);
+        setUserOptions(adminsRes.data.admins);
+      })
       .catch((err) => {
         if (err.response?.status === 401) {
           router.push("/login");

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -126,34 +126,33 @@ export const useFetchHistories = () => {
     };
   }, [page, perPage, sort, order, filters, router]);
 
-  const handleStatusChange = (status: ImportHistoryStatus | "") => {
-    setFilters((prev) => ({ ...prev, status }));
+  const updateFilters = (patch: Partial<ImportHistoryFilters>) => {
+    setFilters((prev) => ({ ...prev, ...patch }));
     setPage(1);
+  };
+
+  const handleStatusChange = (status: ImportHistoryStatus | "") => {
+    updateFilters({ status });
   };
 
   const handleCourseChange = (courseId: string) => {
-    setFilters((prev) => ({ ...prev, courseId, unitId: "" }));
-    setPage(1);
+    updateFilters({ courseId, unitId: "" });
   };
 
   const handleUnitChange = (unitId: string) => {
-    setFilters((prev) => ({ ...prev, unitId }));
-    setPage(1);
+    updateFilters({ unitId });
   };
 
   const handleUserChange = (userId: string) => {
-    setFilters((prev) => ({ ...prev, userId }));
-    setPage(1);
+    updateFilters({ userId });
   };
 
   const handleFromChange = (from: string) => {
-    setFilters((prev) => ({ ...prev, from }));
-    setPage(1);
+    updateFilters({ from });
   };
 
   const handleToChange = (to: string) => {
-    setFilters((prev) => ({ ...prev, to }));
-    setPage(1);
+    updateFilters({ to });
   };
 
   const handlePerPageChange = (nextPerPage: number) => {

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -43,15 +43,23 @@ export const useFetchHistories = () => {
     apiClient
       .get<AdminCoursesData>("/api/admin/courses", { params: { per_page: 100 } })
       .then((res) => setCourseOptions(res.data.courses))
-      .catch(() => {});
-  }, []);
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          router.push("/login");
+        }
+      });
+  }, [router]);
 
   useEffect(() => {
     apiClient
       .get<AdminAdminsData>("/api/admin/admins", { params: { per_page: 100 } })
       .then((res) => setUserOptions(res.data.admins))
-      .catch(() => {});
-  }, []);
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          router.push("/login");
+        }
+      });
+  }, [router]);
 
   useEffect(() => {
     if (!filters.courseId) {

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -152,6 +152,11 @@ export const useFetchHistories = () => {
     updateFilters({ to });
   };
 
+  const handleClearFilters = () => {
+    setFilters(INITIAL_FILTERS);
+    setPage(1);
+  };
+
   const handlePerPageChange = (nextPerPage: number) => {
     setPerPage(nextPerPage);
     setPage(1);
@@ -186,6 +191,7 @@ export const useFetchHistories = () => {
     onSortChange: handleSortChange,
     onPageChange: setPage,
     onPerPageChange: handlePerPageChange,
+    onClearFilters: handleClearFilters,
     onRowClick: handleRowClick,
   };
 };

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { apiClient } from "@/libs/http/apiClient";
+import type {
+  ImportHistoriesData,
+  ImportHistoryFilters,
+  ImportHistoryOrder,
+  ImportHistorySort,
+  ImportHistoryStatus,
+} from "../types";
+
+type CourseOption = { id: number; level_name: string };
+type UnitOption = { id: number; unit_name: string };
+type UserOption = { id: number; name: string };
+
+type AdminCoursesData = { courses: CourseOption[] };
+type AdminCourseDetailData = { units: UnitOption[] };
+type AdminAdminsData = { admins: UserOption[] };
+
+const INITIAL_FILTERS: ImportHistoryFilters = {
+  status: "",
+  courseId: "",
+  unitId: "",
+  userId: "",
+  from: "",
+  to: "",
+};
+
+export const useFetchHistories = () => {
+  const [data, setData] = useState<ImportHistoriesData | null>(null);
+  const [courseOptions, setCourseOptions] = useState<CourseOption[]>([]);
+  const [unitOptions, setUnitOptions] = useState<UnitOption[]>([]);
+  const [userOptions, setUserOptions] = useState<UserOption[]>([]);
+  const [filters, setFilters] = useState<ImportHistoryFilters>(INITIAL_FILTERS);
+  const [sort, setSort] = useState<ImportHistorySort>("created_at");
+  const [order, setOrder] = useState<ImportHistoryOrder>("desc");
+  const [page, setPage] = useState(1);
+  const router = useRouter();
+
+  useEffect(() => {
+    apiClient
+      .get<AdminCoursesData>("/api/admin/courses", { params: { per_page: 100 } })
+      .then((res) => setCourseOptions(res.data.courses))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    apiClient
+      .get<AdminAdminsData>("/api/admin/admins", { params: { per_page: 100 } })
+      .then((res) => setUserOptions(res.data.admins))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!filters.courseId) {
+      setUnitOptions([]);
+      return;
+    }
+
+    apiClient
+      .get<AdminCourseDetailData>(`/api/admin/courses/${filters.courseId}`)
+      .then((res) => setUnitOptions(res.data.units))
+      .catch(() => setUnitOptions([]));
+  }, [filters.courseId]);
+
+  useEffect(() => {
+    const params: Record<string, string> = {
+      page: String(page),
+      sort,
+      order,
+    };
+    if (filters.status) params.status = filters.status;
+    if (filters.courseId) params.course_id = filters.courseId;
+    if (filters.unitId) params.unit_id = filters.unitId;
+    if (filters.userId) params.user_id = filters.userId;
+    if (filters.from) params.from = filters.from;
+    if (filters.to) params.to = filters.to;
+
+    apiClient
+      .get<ImportHistoriesData>("/api/admin/import_histories", { params })
+      .then((res) => setData(res.data))
+      .catch((err) => {
+        if (err.response?.status === 401) {
+          router.push("/login");
+        }
+      });
+  }, [page, sort, order, filters, router]);
+
+  const handleStatusChange = (status: ImportHistoryStatus | "") => {
+    setFilters((prev) => ({ ...prev, status }));
+    setPage(1);
+  };
+
+  const handleCourseChange = (courseId: string) => {
+    setFilters((prev) => ({ ...prev, courseId, unitId: "" }));
+    setPage(1);
+  };
+
+  const handleUnitChange = (unitId: string) => {
+    setFilters((prev) => ({ ...prev, unitId }));
+    setPage(1);
+  };
+
+  const handleUserChange = (userId: string) => {
+    setFilters((prev) => ({ ...prev, userId }));
+    setPage(1);
+  };
+
+  const handleFromChange = (from: string) => {
+    setFilters((prev) => ({ ...prev, from }));
+    setPage(1);
+  };
+
+  const handleToChange = (to: string) => {
+    setFilters((prev) => ({ ...prev, to }));
+    setPage(1);
+  };
+
+  const handleSortChange = (nextSort: ImportHistorySort) => {
+    if (sort === nextSort) {
+      setOrder((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSort(nextSort);
+      setOrder("asc");
+    }
+    setPage(1);
+  };
+
+  const handleRowClick = (id: number) => {
+    router.push(`/admin/csv-import/history/${id}`);
+  };
+
+  return {
+    data,
+    filters,
+    courseOptions,
+    unitOptions,
+    userOptions,
+    sort,
+    order,
+    page,
+    onStatusChange: handleStatusChange,
+    onCourseChange: handleCourseChange,
+    onUnitChange: handleUnitChange,
+    onUserChange: handleUserChange,
+    onFromChange: handleFromChange,
+    onToChange: handleToChange,
+    onSortChange: handleSortChange,
+    onPageChange: setPage,
+    onRowClick: handleRowClick,
+  };
+};

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -4,10 +4,10 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import axios from "axios";
 import { apiClient } from "@/libs/http/apiClient";
+import { useSortToggle } from "@/hooks/useSortToggle";
 import type {
   ImportHistoriesData,
   ImportHistoryFilters,
-  ImportHistoryOrder,
   ImportHistorySort,
   ImportHistoryStatus,
 } from "../types";
@@ -36,8 +36,7 @@ export const useFetchHistories = () => {
   const [unitOptions, setUnitOptions] = useState<UnitOption[]>([]);
   const [userOptions, setUserOptions] = useState<UserOption[]>([]);
   const [filters, setFilters] = useState<ImportHistoryFilters>(INITIAL_FILTERS);
-  const [sort, setSort] = useState<ImportHistorySort>("created_at");
-  const [order, setOrder] = useState<ImportHistoryOrder>("desc");
+  const { sort, order, toggleSort } = useSortToggle<ImportHistorySort>("created_at");
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(20);
   const router = useRouter();
@@ -159,12 +158,7 @@ export const useFetchHistories = () => {
   };
 
   const handleSortChange = (nextSort: ImportHistorySort) => {
-    if (sort === nextSort) {
-      setOrder((prev) => (prev === "asc" ? "desc" : "asc"));
-    } else {
-      setSort(nextSort);
-      setOrder("asc");
-    }
+    toggleSort(nextSort);
     setPage(1);
   };
 

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import axios from "axios";
 import { apiClient } from "@/libs/http/apiClient";
 import type {
   ImportHistoriesData,
@@ -87,17 +88,29 @@ export const useFetchHistories = () => {
     if (filters.from) params.from = filters.from;
     if (filters.to) params.to = filters.to;
 
+    // フィルタを素早く連続変更した際、古いリクエストのレスポンスが新しい
+    // レスポンスを上書きしないよう、リクエストごとにキャンセルする
+    const controller = new AbortController();
+
     setError(false);
     apiClient
-      .get<ImportHistoriesData>("/api/admin/import_histories", { params })
+      .get<ImportHistoriesData>("/api/admin/import_histories", {
+        params,
+        signal: controller.signal,
+      })
       .then((res) => setData(res.data))
       .catch((err) => {
+        if (axios.isCancel(err)) return;
         if (err.response?.status === 401) {
           router.push("/login");
           return;
         }
         setError(true);
       });
+
+    return () => {
+      controller.abort();
+    };
   }, [page, sort, order, filters, router]);
 
   const handleStatusChange = (status: ImportHistoryStatus | "") => {

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -30,6 +30,7 @@ const INITIAL_FILTERS: ImportHistoryFilters = {
 
 export const useFetchHistories = () => {
   const [data, setData] = useState<ImportHistoriesData | null>(null);
+  const [error, setError] = useState(false);
   const [courseOptions, setCourseOptions] = useState<CourseOption[]>([]);
   const [unitOptions, setUnitOptions] = useState<UnitOption[]>([]);
   const [userOptions, setUserOptions] = useState<UserOption[]>([]);
@@ -86,13 +87,16 @@ export const useFetchHistories = () => {
     if (filters.from) params.from = filters.from;
     if (filters.to) params.to = filters.to;
 
+    setError(false);
     apiClient
       .get<ImportHistoriesData>("/api/admin/import_histories", { params })
       .then((res) => setData(res.data))
       .catch((err) => {
         if (err.response?.status === 401) {
           router.push("/login");
+          return;
         }
+        setError(true);
       });
   }, [page, sort, order, filters, router]);
 
@@ -142,6 +146,7 @@ export const useFetchHistories = () => {
 
   return {
     data,
+    error,
     filters,
     courseOptions,
     unitOptions,

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -39,6 +39,7 @@ export const useFetchHistories = () => {
   const [sort, setSort] = useState<ImportHistorySort>("created_at");
   const [order, setOrder] = useState<ImportHistoryOrder>("desc");
   const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(20);
   const router = useRouter();
 
   useEffect(() => {
@@ -78,6 +79,7 @@ export const useFetchHistories = () => {
   useEffect(() => {
     const params: Record<string, string> = {
       page: String(page),
+      per_page: String(perPage),
       sort,
       order,
     };
@@ -111,7 +113,7 @@ export const useFetchHistories = () => {
     return () => {
       controller.abort();
     };
-  }, [page, sort, order, filters, router]);
+  }, [page, perPage, sort, order, filters, router]);
 
   const handleStatusChange = (status: ImportHistoryStatus | "") => {
     setFilters((prev) => ({ ...prev, status }));
@@ -143,6 +145,11 @@ export const useFetchHistories = () => {
     setPage(1);
   };
 
+  const handlePerPageChange = (nextPerPage: number) => {
+    setPerPage(nextPerPage);
+    setPage(1);
+  };
+
   const handleSortChange = (nextSort: ImportHistorySort) => {
     if (sort === nextSort) {
       setOrder((prev) => (prev === "asc" ? "desc" : "asc"));
@@ -167,6 +174,7 @@ export const useFetchHistories = () => {
     sort,
     order,
     page,
+    perPage,
     onStatusChange: handleStatusChange,
     onCourseChange: handleCourseChange,
     onUnitChange: handleUnitChange,
@@ -175,6 +183,7 @@ export const useFetchHistories = () => {
     onToChange: handleToChange,
     onSortChange: handleSortChange,
     onPageChange: setPage,
+    onPerPageChange: handlePerPageChange,
     onRowClick: handleRowClick,
   };
 };

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import axios from "axios";
 import { apiClient } from "@/libs/http/apiClient";
@@ -64,15 +64,26 @@ export const useFetchHistories = () => {
       });
   }, [router]);
 
+  const unitOptionsCache = useRef(new Map<string, UnitOption[]>());
+
   useEffect(() => {
     if (!filters.courseId) {
       setUnitOptions([]);
       return;
     }
 
+    const cached = unitOptionsCache.current.get(filters.courseId);
+    if (cached) {
+      setUnitOptions(cached);
+      return;
+    }
+
     apiClient
       .get<AdminCourseDetailData>(`/api/admin/courses/${filters.courseId}`)
-      .then((res) => setUnitOptions(res.data.units))
+      .then((res) => {
+        unitOptionsCache.current.set(filters.courseId, res.data.units);
+        setUnitOptions(res.data.units);
+      })
       .catch(() => setUnitOptions([]));
   }, [filters.courseId]);
 

--- a/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
+++ b/frontend/features/AdminImportHistory/hooks/useFetchHistories.ts
@@ -36,7 +36,8 @@ export const useFetchHistories = () => {
   const [unitOptions, setUnitOptions] = useState<UnitOption[]>([]);
   const [userOptions, setUserOptions] = useState<UserOption[]>([]);
   const [filters, setFilters] = useState<ImportHistoryFilters>(INITIAL_FILTERS);
-  const { sort, order, toggleSort } = useSortToggle<ImportHistorySort>("created_at");
+  const { sort, order, toggleSort } =
+    useSortToggle<ImportHistorySort>("created_at");
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(20);
   const router = useRouter();

--- a/frontend/features/AdminImportHistory/index.tsx
+++ b/frontend/features/AdminImportHistory/index.tsx
@@ -1,11 +1,28 @@
 "use client";
 
-import { Box, CircularProgress } from "@mui/material";
+import { Box, CircularProgress, Typography } from "@mui/material";
 import { Presenter } from "./Presenter";
 import { useFetchHistories } from "./hooks/useFetchHistories";
 
 export const AdminImportHistory = () => {
-  const { data, ...handlers } = useFetchHistories();
+  const { data, error, ...handlers } = useFetchHistories();
+
+  if (error) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        <Typography variant="body2" color="text.secondary">
+          データの取得に失敗しました
+        </Typography>
+      </Box>
+    );
+  }
 
   if (!data) {
     return (

--- a/frontend/features/AdminImportHistory/index.tsx
+++ b/frontend/features/AdminImportHistory/index.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Box, CircularProgress } from "@mui/material";
+import { Presenter } from "./Presenter";
+import { useFetchHistories } from "./hooks/useFetchHistories";
+
+export const AdminImportHistory = () => {
+  const { data, ...handlers } = useFetchHistories();
+
+  if (!data) {
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          height: "100%",
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return <Presenter data={data} {...handlers} />;
+};

--- a/frontend/features/AdminImportHistory/types.ts
+++ b/frontend/features/AdminImportHistory/types.ts
@@ -1,4 +1,8 @@
-export type ImportHistoryStatus = "pending" | "processing" | "completed" | "failed";
+export type ImportHistoryStatus =
+  | "pending"
+  | "processing"
+  | "completed"
+  | "failed";
 
 export type ImportHistoryMode = "append" | "overwrite";
 

--- a/frontend/features/AdminImportHistory/types.ts
+++ b/frontend/features/AdminImportHistory/types.ts
@@ -1,0 +1,66 @@
+export type ImportHistoryStatus = "pending" | "processing" | "completed" | "failed";
+
+export type ImportHistoryMode = "append" | "overwrite";
+
+export type ImportHistoryRow = {
+  id: number;
+  course: { id: number; level_name: string } | null;
+  unit: { id: number; unit_name: string } | null;
+  user: { id: number; name: string } | null;
+  file_name: string;
+  status: ImportHistoryStatus;
+  mode: ImportHistoryMode;
+  total_count: number;
+  success_count: number;
+  error_count: number;
+  created_at: string;
+};
+
+export type ImportHistoryMeta = {
+  current_page: number;
+  total_pages: number;
+  total_count: number;
+  per_page: number;
+};
+
+export type ImportHistoriesData = {
+  import_histories: ImportHistoryRow[];
+  meta: ImportHistoryMeta;
+};
+
+export type ImportHistorySort =
+  | "created_at"
+  | "total_count"
+  | "success_count"
+  | "error_count"
+  | "status";
+
+export type ImportHistoryOrder = "asc" | "desc";
+
+export type ImportHistoryFilters = {
+  status: ImportHistoryStatus | "";
+  courseId: string;
+  unitId: string;
+  userId: string;
+  from: string;
+  to: string;
+};
+
+export const PER_PAGE_OPTIONS = [20, 50, 100] as const;
+
+export const IMPORT_STATUS_LABEL: Record<ImportHistoryStatus, string> = {
+  pending: "待機中",
+  processing: "処理中",
+  completed: "完了",
+  failed: "失敗",
+};
+
+export const IMPORT_STATUS_COLOR: Record<
+  ImportHistoryStatus,
+  "warning" | "info" | "success" | "error"
+> = {
+  pending: "warning",
+  processing: "info",
+  completed: "success",
+  failed: "error",
+};

--- a/frontend/hooks/useSortToggle.ts
+++ b/frontend/hooks/useSortToggle.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+
+// 同じ列を再クリックしたらasc/descをトグルし、別の列ならascから開始する
+// ソート状態管理。AdminCourses/AdminImportHistoryのソート可能な一覧で共通利用する。
+export const useSortToggle = <TSort extends string>(
+  initialSort: TSort,
+  initialOrder: "asc" | "desc" = "desc",
+) => {
+  const [sort, setSort] = useState<TSort>(initialSort);
+  const [order, setOrder] = useState<"asc" | "desc">(initialOrder);
+
+  const toggleSort = (nextSort: TSort) => {
+    if (sort === nextSort) {
+      setOrder((prev) => (prev === "asc" ? "desc" : "asc"));
+    } else {
+      setSort(nextSort);
+      setOrder("asc");
+    }
+  };
+
+  return { sort, order, toggleSort };
+};

--- a/rails/spec/requests/api/v1/admin/import_histories_spec.rb
+++ b/rails/spec/requests/api/v1/admin/import_histories_spec.rb
@@ -208,6 +208,39 @@ RSpec.describe 'Api::V1::Admin::ImportHistories', type: :request do
         end
       end
 
+      context 'sort/order パラメータ指定時' do
+        subject do
+          get '/api/v1/admin/import_histories', params: { sort: 'total_count', order: 'asc' },
+                                                headers: headers.merge('Cookie' => cookie)
+        end
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:small) { create(:import_history, total_count: 1) }
+        let!(:large) { create(:import_history, total_count: 10) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '指定した sort/order で並び替えて返す' do
+          subject
+          ids = response.parsed_body['import_histories'].pluck('id')
+          expect(ids).to eq([small.id, large.id])
+        end
+      end
+
+      context 'sort/order パラメータ未指定時' do
+        subject { get '/api/v1/admin/import_histories', headers: headers.merge('Cookie' => cookie) }
+
+        let!(:admin_user) { create(:user, :admin, high_school: nil) }
+        let!(:old) { create(:import_history, created_at: 3.days.ago) }
+        let!(:recent) { create(:import_history, created_at: 1.day.ago) }
+        let(:cookie) { login_and_get_cookie(admin_user) }
+
+        it '作成日時の降順（デフォルト）で返す' do
+          subject
+          ids = response.parsed_body['import_histories'].pluck('id')
+          expect(ids).to eq([recent.id, old.id])
+        end
+      end
+
       context 'from/to パラメータ指定時' do
         subject do
           get '/api/v1/admin/import_histories', params: { from: 6.days.ago.to_date.to_s, to: 2.days.ago.to_date.to_s },


### PR DESCRIPTION
## 概要

管理者用CSVインポート履歴一覧画面 `/admin/csv-import/history` を実装する。

- 親issue: 管理者用管理画面 UI 設計・実装
- 依存: 履歴API（`feature/issue-57_import_histories_api`）

## 詳細

### 実装内容
- `frontend/app/(admin)/admin/(authenticated)/csv-import/history/page.tsx`
- `frontend/features/AdminImportHistory/`（index.tsx, Presenter.tsx, types.ts, hooks/useFetchHistories.ts, `__tests__/Presenter.test.tsx`）
- `frontend/app/api/admin/import_histories/route.ts`（BFF route、`handleRailsRouteError`使用）
- ダッシュボードに履歴一覧への「すべて見る」リンクを追加

### 画面機能
- 一覧テーブル列: 日時 / コース / 単元 / 件数 / 成功数・エラー数 / 実行者 / ステータス
- フィルタ: ステータス・コース・単元・実行者・日付範囲（個別クリア・一括クリア対応）
- ソート・ページネーション・表示件数変更
- ステータスバッジ: 完了=Green / 処理中=Blue / 待機中=Amber / 失敗=Red
- 行クリックで詳細画面へ遷移（詳細画面自体は別issue）
- デザインはGentelella（参考: https://preview.colorlib.com/theme/gentelella/production/index.html ）を参考にフラット・ミニマルなスタイルに調整

### バックエンド改修
- `Admin::ImportHistoriesQuery` に一覧のソート機能（`sort`/`order`パラメータ）を追加
- 当初 `order_by(sort, order)` を単体メソッドとして追加したが、base ブランチ側で `ImportHistoriesQuery#call(filters)` という統一インターフェースへのリファクタリング（ソフトデリートフィルタ・CSVインジェクション対策等も含む）が並行して進んだため、本ブランチを base ブランチの最新にリベースし `call(filters)` 経由でsort/orderが渡るよう整合を取り済み

レビュアーに重点的に見て欲しい点:
- フィルタの状態管理（URLクエリとは同期していません。既存の `AdminCourses` パターンを踏襲）
- BFF route (`app/api/admin/import_histories/route.ts`) のパラメータ中継とエラーハンドリング
- 行クリック時の遷移先 (`/admin/csv-import/history/[id]`) は未実装のため、現時点では404になります（別issueで対応予定）

## 動作確認

- Rails: `bundle exec rspec spec/queries/admin/import_histories_query_spec.rb spec/requests/api/v1/admin/import_histories_spec.rb spec/services/admin/import_history_csv_exporter_service_spec.rb` で全件Green（リベース後も再確認済み）
- Frontend: `Presenter.test.tsx`（29件）含む全体テストスイート Green、`tsc --noEmit` / `eslint` エラーなし
- ブラウザでの手動確認は未実施（別途確認をお願いします）

## その他

特になし。

## 参考情報

- デザイン参考: https://preview.colorlib.com/theme/gentelella/production/index.html